### PR TITLE
added docs for git, versions, and changelog

### DIFF
--- a/docs/legate/core/source/changelog.rst
+++ b/docs/legate/core/source/changelog.rst
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+2021.06.0
+---------
+
+Release on June X, 2021
+
+- Brief description of change (:pr:`1`) `Author Name`

--- a/docs/legate/core/source/git.rst
+++ b/docs/legate/core/source/git.rst
@@ -1,0 +1,69 @@
+How to Release
+==============
+
+Approach
+--------
+
+Our development approach involves protecting the `main` branch so that it
+becomes the official release record for any Legate project. Development PRs will
+be merged into a release branch, which will be merged into main and tagged only
+when the release is ready. The only other merges to `main` are hotfixes.
+
+Development Workflow
+--------------------
+
+All PRs are merged into a release branch named `branch-M.B` where `M` is the
+major version and `B` is the minor version number. Release branches are created
+from the previous release branch when the decision has been made to **freeze**
+the release. 
+
+To **freeze** a release branch is to stop new development for the release, and
+focus on completing outstanding features and any bugs discovered from testing.
+Once this **freeze** happens a new branch `branch-M.C` (where `C=B+1`) is
+created so development can continue. Updates to `branch-M.B` can be merged as
+needed to `branch-M.C`, but generally will wait until the release is finished.
+This means that `branch-M.X` (where `X` is the highest minor version) the latest
+and greatest code.
+
+Hotfixes (patch releases) related to the current release `M.A` are directly
+merged to `main` from a PR and then those changes are also merged to the current
+release branches in progress through an automated process. All merges to `main`
+trigger an automated CI job that will produce a new release and tag incrementing
+the patch version off of the previous highest tag in the repo. Once the tag is
+set, the automated CI build for conda packages creates and pushes new packages
+for users. This includes the version change enabling known good builds and the
+ability to rollback.
+
+Minor (and eventually, Major) release development takes place on the current
+release branch. PRs can be edited on GitHub to set the target base branch for
+merging the PR. It is the reviewer’s responsibility to ensure the PR is targeted
+for the correct and planned release branch. Once PRs have passed all tests, they
+are merged to their release branch, which triggers an automated CI build for
+conda packages that will be marked as development, such as M.N-dev1. These can
+be inspected by the team to ensure the build works as intended and perform
+larger testing.
+
+Once a release has been reviewed and signoff has been given, a PR is created to
+merge the release branch to main. After the merge, the automated tagging process
+tags and releases a minor version and kicks off the conda builds for the public
+release.
+
+Summary
+-------
+
+- The `main` branch is the official release history (including hotfixes).
+  - The tip of `main` is intended to be always working given the testing and
+  reviews of merged PRs. - Hotfixes (patch releases) are automatically tagged
+  for every push to `main`.
+- Release branches are used for development of the next releases and **all PRs
+except for hotfixes** are merged to the current release branch.
+  - A new release branch is created from the previous release branch after the
+  release **freeze** (see above). - After the **freeze** and before the release
+  branch is merged, there are two release branches; however, active development
+  should take place in the next release branch, while cleanup and finalization
+  happens in the frozen branch. - This gives the highest numbered `branch-M.X`
+  (modulo hot fixes and unmerged frozen release fixes) the latest and greatest
+  code.
+- Minor releases are done by creating a PR for the minor release from the
+associated release branch.
+  - After review and sign off by the team, the PR is merged into main.

--- a/docs/legate/core/source/git.rst
+++ b/docs/legate/core/source/git.rst
@@ -12,18 +12,20 @@ when the release is ready. The only other merges to `main` are hotfixes.
 Development Workflow
 --------------------
 
-All PRs are merged into a release branch named `branch-M.B` where `M` is the
-major version and `B` is the minor version number. Release branches are created
-from the previous release branch when the decision has been made to **freeze**
-the release. 
+All new development happens on a release branch named `branch-M.B` where `M` is
+the major version and `B` is the minor version number. Minor, single-commit
+changes can be pushed directly to this branch. For more significant development
+use branches on your personal fork of the main repos, and upstream those changes
+through PRs.
 
-To **freeze** a release branch is to stop new development for the release, and
-focus on completing outstanding features and any bugs discovered from testing.
-Once this **freeze** happens a new branch `branch-M.C` (where `C=B+1`) is
-created so development can continue. Updates to `branch-M.B` can be merged as
-needed to `branch-M.C`, but generally will wait until the release is finished.
-This means that `branch-M.X` (where `X` is the highest minor version) the latest
-and greatest code.
+Release branches are created from the previous release branch when the decision
+has been made to **freeze** the release. To **freeze** a release branch is to
+stop new development for the release, and focus on completing outstanding
+features and any bugs discovered from testing. Once this **freeze** happens a
+new branch `branch-M.C` (where `C=B+1`) is created so development can continue.
+Updates to `branch-M.B` can be merged as needed to `branch-M.C`, but generally
+will wait until the release is finished. This means that `branch-M.X` (where `X`
+is the highest minor version) the latest and greatest code.
 
 Hotfixes (patch releases) related to the current release `M.A` are directly
 merged to `main` from a PR and then those changes are also merged to the current

--- a/docs/legate/core/source/git.rst
+++ b/docs/legate/core/source/git.rst
@@ -52,18 +52,18 @@ Summary
 -------
 
 - The `main` branch is the official release history (including hotfixes).
-  - The tip of `main` is intended to be always working given the testing and
-  reviews of merged PRs. - Hotfixes (patch releases) are automatically tagged
-  for every push to `main`.
+- The tip of `main` is intended to be always working given the testing and
+  reviews of merged PRs.
+- Hotfixes (patch releases) are automatically tagged for every push to `main`.
 - Release branches are used for development of the next releases and **all PRs
-except for hotfixes** are merged to the current release branch.
-  - A new release branch is created from the previous release branch after the
-  release **freeze** (see above). - After the **freeze** and before the release
-  branch is merged, there are two release branches; however, active development
-  should take place in the next release branch, while cleanup and finalization
-  happens in the frozen branch. - This gives the highest numbered `branch-M.X`
-  (modulo hot fixes and unmerged frozen release fixes) the latest and greatest
-  code.
+  except for hotfixes** are merged to the current release branch.
+- A new release branch is created from the previous release branch after the
+  release **freeze** (see above).
+- After the **freeze** and before the release branch is merged, there are two
+  release branches; however, active development should take place in the next
+  release branch, while cleanup and finalization happens in the frozen branch.
+- This gives the highest numbered `branch-M.X` (modulo hotfixes and unmerged
+  frozen release fixes) the latest and greatest code.
 - Minor releases are done by creating a PR for the minor release from the
-associated release branch.
-  - After review and sign off by the team, the PR is merged into main.
+  associated release branch.
+- After review and sign off by the team, the PR is merged into main.

--- a/docs/legate/core/source/index.rst
+++ b/docs/legate/core/source/index.rst
@@ -4,6 +4,9 @@ Welcome to Legate Core's documentation!
 .. toctree::
 
   Overview <README.md>
+  versions.rst
+  git.rst
+  changelog.rst
   API Reference <api.rst>
 
 

--- a/docs/legate/core/source/versions.rst
+++ b/docs/legate/core/source/versions.rst
@@ -1,0 +1,36 @@
+Versions and Tags
+=================
+
+Overview
+--------
+
+Summary of the versioning and release methodology used by Legate projects.
+
+Versioning method
+-----------------
+
+All Legate projects use the [CalVer](https://calver.org/) versioning method for
+all releases starting with June 2021 release.
+
+The Legate team is aware of the impacts that public API changes cause to users,
+so API & ABI compatibility is guaranteed within each `YY.MM` version.
+
+Release types and tagging
+-------------------------
+
+Using CalVer for versioning, Legate projects use the notation `YY.MM.PP` for
+releases/tags where `YY` indicates the zero padded year, `MM` indicates the zero
+padded month, and `PP` indicates the zero padded hotfix/patch version. Each
+release is accompanied by a tag in the git repo with the same formatting and
+leading `v`.
+
+Hotfix/Patch
+____________
+
+A hotfix/patch release occurs for the current release, incrementing the
+hotfix/patch version number by 1.
+
+There is no limit or time constraint of these releases as they are governed by
+the need to fix critical issues in the current release. Generally, hotfix/patch
+releases contain only one change and are typically bug fixes; new features
+should not be introduced in this way.


### PR DESCRIPTION
This describes a slightly more conservative approach than what we discussed, but this is taken from the RAPIDS team. I thought perhaps folks on the @nv-legate/core-team  would find it more comfortable.
