### PR TITLE
Force left alignment for pointers and references

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -54,7 +54,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/src/data/scalar.cc
+++ b/src/data/scalar.cc
@@ -20,7 +20,7 @@
 
 namespace legate {
 
-Scalar::Scalar(bool tuple, LegateTypeCode code, const void *data)
+Scalar::Scalar(bool tuple, LegateTypeCode code, const void* data)
   : tuple_(tuple), code_(code), data_(data)
 {
 }
@@ -37,7 +37,7 @@ size_t Scalar::size() const
 {
   auto elem_size = type_dispatch(code_, elem_size_fn{});
   if (tuple_) {
-    auto num_elements = *static_cast<const int32_t *>(data_);
+    auto num_elements = *static_cast<const int32_t*>(data_);
     return sizeof(int32_t) + num_elements * elem_size;
   } else
     return elem_size;

--- a/src/data/scalar.h
+++ b/src/data/scalar.h
@@ -23,12 +23,12 @@ namespace legate {
 
 class Scalar {
  public:
-  Scalar()               = default;
-  Scalar(const Scalar &) = default;
-  Scalar(bool tuple, LegateTypeCode code, const void *data);
+  Scalar()              = default;
+  Scalar(const Scalar&) = default;
+  Scalar(bool tuple, LegateTypeCode code, const void* data);
 
  public:
-  Scalar &operator=(const Scalar &) = default;
+  Scalar& operator=(const Scalar&) = default;
 
  public:
   bool is_tuple() const { return tuple_; }
@@ -43,7 +43,7 @@ class Scalar {
  private:
   bool tuple_{false};
   LegateTypeCode code_{MAX_TYPE_NUMBER};
-  const void *data_;
+  const void* data_;
 };
 
 }  // namespace legate

--- a/src/data/store.cc
+++ b/src/data/store.cc
@@ -21,7 +21,7 @@ namespace legate {
 
 using namespace Legion;
 
-RegionField::RegionField(int32_t dim, const PhysicalRegion &pr, FieldID fid)
+RegionField::RegionField(int32_t dim, const PhysicalRegion& pr, FieldID fid)
   : dim_(dim), pr_(pr), fid_(fid)
 {
   auto priv  = pr.get_privilege();
@@ -30,7 +30,7 @@ RegionField::RegionField(int32_t dim, const PhysicalRegion &pr, FieldID fid)
   reducible_ = static_cast<bool>(priv & LEGION_REDUCE) || (readable_ && writable_);
 }
 
-RegionField::RegionField(RegionField &&other) noexcept
+RegionField::RegionField(RegionField&& other) noexcept
   : dim_(other.dim_),
     pr_(other.pr_),
     fid_(other.fid_),
@@ -40,7 +40,7 @@ RegionField::RegionField(RegionField &&other) noexcept
 {
 }
 
-RegionField &RegionField::operator=(RegionField &&other) noexcept
+RegionField& RegionField::operator=(RegionField&& other) noexcept
 {
   dim_       = other.dim_;
   pr_        = other.pr_;
@@ -53,9 +53,9 @@ RegionField &RegionField::operator=(RegionField &&other) noexcept
 
 Domain RegionField::domain() const { return dim_dispatch(dim_, get_domain_fn{}, pr_); }
 
-OutputRegionField::OutputRegionField(const OutputRegion &out, FieldID fid) : out_(out), fid_(fid) {}
+OutputRegionField::OutputRegionField(const OutputRegion& out, FieldID fid) : out_(out), fid_(fid) {}
 
-OutputRegionField::OutputRegionField(OutputRegionField &&other) noexcept
+OutputRegionField::OutputRegionField(OutputRegionField&& other) noexcept
   : bound_(other.bound_), out_(other.out_), fid_(other.fid_)
 {
   other.bound_ = false;
@@ -63,7 +63,7 @@ OutputRegionField::OutputRegionField(OutputRegionField &&other) noexcept
   other.fid_   = -1;
 }
 
-OutputRegionField &OutputRegionField::operator=(OutputRegionField &&other) noexcept
+OutputRegionField& OutputRegionField::operator=(OutputRegionField&& other) noexcept
 {
   bound_ = other.bound_;
   out_   = other.out_;
@@ -78,12 +78,12 @@ OutputRegionField &OutputRegionField::operator=(OutputRegionField &&other) noexc
 
 FutureWrapper::FutureWrapper(Domain domain, Future future) : domain_(domain), future_(future) {}
 
-FutureWrapper::FutureWrapper(const FutureWrapper &other) noexcept
+FutureWrapper::FutureWrapper(const FutureWrapper& other) noexcept
   : domain_(other.domain_), future_(other.future_)
 {
 }
 
-FutureWrapper &FutureWrapper::operator=(const FutureWrapper &other) noexcept
+FutureWrapper& FutureWrapper::operator=(const FutureWrapper& other) noexcept
 {
   domain_ = other.domain_;
   future_ = other.future_;
@@ -110,7 +110,7 @@ Store::Store(int32_t dim,
 Store::Store(int32_t dim,
              LegateTypeCode code,
              int32_t redop_id,
-             RegionField &&region_field,
+             RegionField&& region_field,
              std::unique_ptr<StoreTransform> transform)
   : is_future_(false),
     is_output_store_(false),
@@ -126,7 +126,7 @@ Store::Store(int32_t dim,
 }
 
 Store::Store(LegateTypeCode code,
-             OutputRegionField &&output,
+             OutputRegionField&& output,
              std::unique_ptr<StoreTransform> transform)
   : is_future_(false),
     is_output_store_(true),
@@ -138,7 +138,7 @@ Store::Store(LegateTypeCode code,
 {
 }
 
-Store::Store(Store &&other) noexcept
+Store::Store(Store&& other) noexcept
   : is_future_(other.is_future_),
     is_output_store_(other.is_output_store_),
     dim_(other.dim_),
@@ -154,7 +154,7 @@ Store::Store(Store &&other) noexcept
 {
 }
 
-Store &Store::operator=(Store &&other) noexcept
+Store& Store::operator=(Store&& other) noexcept
 {
   is_future_       = other.is_future_;
   is_output_store_ = other.is_output_store_;

--- a/src/data/store.h
+++ b/src/data/store.h
@@ -26,15 +26,15 @@ namespace legate {
 class RegionField {
  public:
   RegionField() {}
-  RegionField(int32_t dim, const Legion::PhysicalRegion &pr, Legion::FieldID fid);
+  RegionField(int32_t dim, const Legion::PhysicalRegion& pr, Legion::FieldID fid);
 
  public:
-  RegionField(RegionField &&other) noexcept;
-  RegionField &operator=(RegionField &&other) noexcept;
+  RegionField(RegionField&& other) noexcept;
+  RegionField& operator=(RegionField&& other) noexcept;
 
  private:
-  RegionField(const RegionField &other) = delete;
-  RegionField &operator=(const RegionField &other) = delete;
+  RegionField(const RegionField& other) = delete;
+  RegionField& operator=(const RegionField& other) = delete;
 
  public:
   int32_t dim() const { return dim_; }
@@ -43,34 +43,34 @@ class RegionField {
   template <typename ACC, int32_t N>
   struct trans_accesor_fn {
     template <int32_t M>
-    ACC operator()(const Legion::PhysicalRegion &pr,
+    ACC operator()(const Legion::PhysicalRegion& pr,
                    Legion::FieldID fid,
-                   const Legion::AffineTransform<M, N> &transform)
+                   const Legion::AffineTransform<M, N>& transform)
     {
       return ACC(pr, fid, transform);
     }
     template <int32_t M>
-    ACC operator()(const Legion::PhysicalRegion &pr,
+    ACC operator()(const Legion::PhysicalRegion& pr,
                    Legion::FieldID fid,
-                   const Legion::AffineTransform<M, N> &transform,
-                   const Legion::Rect<N> &bounds)
+                   const Legion::AffineTransform<M, N>& transform,
+                   const Legion::Rect<N>& bounds)
     {
       return ACC(pr, fid, transform, bounds);
     }
     template <int32_t M>
-    ACC operator()(const Legion::PhysicalRegion &pr,
+    ACC operator()(const Legion::PhysicalRegion& pr,
                    Legion::FieldID fid,
                    int32_t redop_id,
-                   const Legion::AffineTransform<M, N> &transform)
+                   const Legion::AffineTransform<M, N>& transform)
     {
       return ACC(pr, fid, redop_id, transform);
     }
     template <int32_t M>
-    ACC operator()(const Legion::PhysicalRegion &pr,
+    ACC operator()(const Legion::PhysicalRegion& pr,
                    Legion::FieldID fid,
                    int32_t redop_id,
-                   const Legion::AffineTransform<M, N> &transform,
-                   const Legion::Rect<N> &bounds)
+                   const Legion::AffineTransform<M, N>& transform,
+                   const Legion::Rect<N>& bounds)
     {
       return ACC(pr, fid, redop_id, transform, bounds);
     }
@@ -78,7 +78,7 @@ class RegionField {
 
   struct get_domain_fn {
     template <int32_t DIM>
-    Legion::Domain operator()(const Legion::PhysicalRegion &pr)
+    Legion::Domain operator()(const Legion::PhysicalRegion& pr)
     {
       return Legion::Domain(pr.get_bounds<DIM, Legion::coord_t>());
     }
@@ -96,41 +96,41 @@ class RegionField {
 
  public:
   template <typename T, int32_t DIM>
-  AccessorRO<T, DIM> read_accessor(const Legion::DomainAffineTransform &transform) const;
+  AccessorRO<T, DIM> read_accessor(const Legion::DomainAffineTransform& transform) const;
   template <typename T, int32_t DIM>
-  AccessorWO<T, DIM> write_accessor(const Legion::DomainAffineTransform &transform) const;
+  AccessorWO<T, DIM> write_accessor(const Legion::DomainAffineTransform& transform) const;
   template <typename T, int32_t DIM>
-  AccessorRW<T, DIM> read_write_accessor(const Legion::DomainAffineTransform &transform) const;
+  AccessorRW<T, DIM> read_write_accessor(const Legion::DomainAffineTransform& transform) const;
   template <typename OP, bool EXCLUSIVE, int32_t DIM>
   AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(
-    int32_t redop_id, const Legion::DomainAffineTransform &transform) const;
+    int32_t redop_id, const Legion::DomainAffineTransform& transform) const;
 
  public:
   template <typename T, int32_t DIM>
-  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename T, int32_t DIM>
-  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename T, int32_t DIM>
-  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename OP, bool EXCLUSIVE, int32_t DIM>
   AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(int32_t redop_id,
-                                                 const Legion::Rect<DIM> &bounds) const;
+                                                 const Legion::Rect<DIM>& bounds) const;
 
  public:
   template <typename T, int32_t DIM>
-  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM> &bounds,
-                                   const Legion::DomainAffineTransform &transform) const;
+  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM>& bounds,
+                                   const Legion::DomainAffineTransform& transform) const;
   template <typename T, int32_t DIM>
-  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM> &bounds,
-                                    const Legion::DomainAffineTransform &transform) const;
+  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM>& bounds,
+                                    const Legion::DomainAffineTransform& transform) const;
   template <typename T, int32_t DIM>
-  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM> &bounds,
-                                         const Legion::DomainAffineTransform &transform) const;
+  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM>& bounds,
+                                         const Legion::DomainAffineTransform& transform) const;
   template <typename OP, bool EXCLUSIVE, int32_t DIM>
   AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(
     int32_t redop_id,
-    const Legion::Rect<DIM> &bounds,
-    const Legion::DomainAffineTransform &transform) const;
+    const Legion::Rect<DIM>& bounds,
+    const Legion::DomainAffineTransform& transform) const;
 
  public:
   template <int32_t DIM>
@@ -156,19 +156,19 @@ class RegionField {
 class OutputRegionField {
  public:
   OutputRegionField() {}
-  OutputRegionField(const Legion::OutputRegion &out, Legion::FieldID fid);
+  OutputRegionField(const Legion::OutputRegion& out, Legion::FieldID fid);
 
  public:
-  OutputRegionField(OutputRegionField &&other) noexcept;
-  OutputRegionField &operator=(OutputRegionField &&other) noexcept;
+  OutputRegionField(OutputRegionField&& other) noexcept;
+  OutputRegionField& operator=(OutputRegionField&& other) noexcept;
 
  private:
-  OutputRegionField(const OutputRegionField &other) = delete;
-  OutputRegionField &operator=(const OutputRegionField &other) = delete;
+  OutputRegionField(const OutputRegionField& other) = delete;
+  OutputRegionField& operator=(const OutputRegionField& other) = delete;
 
  public:
   template <typename VAL>
-  void return_data(Legion::DeferredBuffer<VAL, 1> &buffer, size_t num_elements);
+  void return_data(Legion::DeferredBuffer<VAL, 1>& buffer, size_t num_elements);
 
  private:
   bool bound_{false};
@@ -182,8 +182,8 @@ class FutureWrapper {
   FutureWrapper(Legion::Domain domain, Legion::Future future);
 
  public:
-  FutureWrapper(const FutureWrapper &other) noexcept;
-  FutureWrapper &operator=(const FutureWrapper &other) noexcept;
+  FutureWrapper(const FutureWrapper& other) noexcept;
+  FutureWrapper& operator=(const FutureWrapper& other) noexcept;
 
  public:
   int32_t dim() const { return domain_.dim; }
@@ -194,7 +194,7 @@ class FutureWrapper {
 
  public:
   template <typename T, int32_t DIM>
-  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM>& bounds) const;
 
  public:
   template <typename VAL>
@@ -220,19 +220,19 @@ class Store {
   Store(int32_t dim,
         LegateTypeCode code,
         int32_t redop_id,
-        RegionField &&region_field,
+        RegionField&& region_field,
         std::unique_ptr<StoreTransform> transform = nullptr);
   Store(LegateTypeCode code,
-        OutputRegionField &&output,
+        OutputRegionField&& output,
         std::unique_ptr<StoreTransform> transform = nullptr);
 
  public:
-  Store(Store &&other) noexcept;
-  Store &operator=(Store &&other) noexcept;
+  Store(Store&& other) noexcept;
+  Store& operator=(Store&& other) noexcept;
 
  private:
-  Store(const Store &other) = delete;
-  Store &operator=(const Store &other) = delete;
+  Store(const Store& other) = delete;
+  Store& operator=(const Store& other) = delete;
 
  public:
   int32_t dim() const { return dim_; }
@@ -250,13 +250,13 @@ class Store {
 
  public:
   template <typename T, int32_t DIM>
-  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename T, int32_t DIM>
-  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename T, int32_t DIM>
-  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename OP, bool EXCLUSIVE, int32_t DIM>
-  AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(const Legion::Rect<DIM> &bounds) const;
+  AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(const Legion::Rect<DIM>& bounds) const;
 
  public:
   template <int32_t DIM>
@@ -274,7 +274,7 @@ class Store {
 
  public:
   template <typename VAL>
-  void return_data(Legion::DeferredBuffer<VAL, 1> &buffer, size_t num_elements);
+  void return_data(Legion::DeferredBuffer<VAL, 1>& buffer, size_t num_elements);
 
  private:
   bool is_future_{false};

--- a/src/data/store.inl
+++ b/src/data/store.inl
@@ -41,14 +41,14 @@ AccessorRD<OP, EXCLUSIVE, DIM> RegionField::reduce_accessor(int32_t redop_id) co
 }
 
 template <typename T, int DIM>
-AccessorRO<T, DIM> RegionField::read_accessor(const Legion::DomainAffineTransform &transform) const
+AccessorRO<T, DIM> RegionField::read_accessor(const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRO<T, DIM>;
   return dim_dispatch(transform.transform.m, trans_accesor_fn<ACC, DIM>{}, pr_, fid_, transform);
 }
 
 template <typename T, int DIM>
-AccessorWO<T, DIM> RegionField::write_accessor(const Legion::DomainAffineTransform &transform) const
+AccessorWO<T, DIM> RegionField::write_accessor(const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorWO<T, DIM>;
   return dim_dispatch(transform.transform.m, trans_accesor_fn<ACC, DIM>{}, pr_, fid_, transform);
@@ -56,7 +56,7 @@ AccessorWO<T, DIM> RegionField::write_accessor(const Legion::DomainAffineTransfo
 
 template <typename T, int DIM>
 AccessorRW<T, DIM> RegionField::read_write_accessor(
-  const Legion::DomainAffineTransform &transform) const
+  const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRW<T, DIM>;
   return dim_dispatch(transform.transform.m, trans_accesor_fn<ACC, DIM>{}, pr_, fid_, transform);
@@ -64,7 +64,7 @@ AccessorRW<T, DIM> RegionField::read_write_accessor(
 
 template <typename OP, bool EXCLUSIVE, int DIM>
 AccessorRD<OP, EXCLUSIVE, DIM> RegionField::reduce_accessor(
-  int32_t redop_id, const Legion::DomainAffineTransform &transform) const
+  int32_t redop_id, const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRD<OP, EXCLUSIVE, DIM>;
   return dim_dispatch(
@@ -72,33 +72,33 @@ AccessorRD<OP, EXCLUSIVE, DIM> RegionField::reduce_accessor(
 }
 
 template <typename T, int DIM>
-AccessorRO<T, DIM> RegionField::read_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRO<T, DIM> RegionField::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
   return AccessorRO<T, DIM>(pr_, fid_, bounds);
 }
 
 template <typename T, int DIM>
-AccessorWO<T, DIM> RegionField::write_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorWO<T, DIM> RegionField::write_accessor(const Legion::Rect<DIM>& bounds) const
 {
   return AccessorWO<T, DIM>(pr_, fid_, bounds);
 }
 
 template <typename T, int DIM>
-AccessorRW<T, DIM> RegionField::read_write_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRW<T, DIM> RegionField::read_write_accessor(const Legion::Rect<DIM>& bounds) const
 {
   return AccessorRW<T, DIM>(pr_, fid_, bounds);
 }
 
 template <typename OP, bool EXCLUSIVE, int DIM>
 AccessorRD<OP, EXCLUSIVE, DIM> RegionField::reduce_accessor(int32_t redop_id,
-                                                            const Legion::Rect<DIM> &bounds) const
+                                                            const Legion::Rect<DIM>& bounds) const
 {
   return AccessorRD<OP, EXCLUSIVE, DIM>(pr_, fid_, redop_id, bounds);
 }
 
 template <typename T, int32_t DIM>
-AccessorRO<T, DIM> RegionField::read_accessor(const Legion::Rect<DIM> &bounds,
-                                              const Legion::DomainAffineTransform &transform) const
+AccessorRO<T, DIM> RegionField::read_accessor(const Legion::Rect<DIM>& bounds,
+                                              const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRO<T, DIM>;
   return dim_dispatch(
@@ -106,8 +106,8 @@ AccessorRO<T, DIM> RegionField::read_accessor(const Legion::Rect<DIM> &bounds,
 }
 
 template <typename T, int32_t DIM>
-AccessorWO<T, DIM> RegionField::write_accessor(const Legion::Rect<DIM> &bounds,
-                                               const Legion::DomainAffineTransform &transform) const
+AccessorWO<T, DIM> RegionField::write_accessor(const Legion::Rect<DIM>& bounds,
+                                               const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorWO<T, DIM>;
   return dim_dispatch(
@@ -116,7 +116,7 @@ AccessorWO<T, DIM> RegionField::write_accessor(const Legion::Rect<DIM> &bounds,
 
 template <typename T, int32_t DIM>
 AccessorRW<T, DIM> RegionField::read_write_accessor(
-  const Legion::Rect<DIM> &bounds, const Legion::DomainAffineTransform &transform) const
+  const Legion::Rect<DIM>& bounds, const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRW<T, DIM>;
   return dim_dispatch(
@@ -126,8 +126,8 @@ AccessorRW<T, DIM> RegionField::read_write_accessor(
 template <typename OP, bool EXCLUSIVE, int DIM>
 AccessorRD<OP, EXCLUSIVE, DIM> RegionField::reduce_accessor(
   int32_t redop_id,
-  const Legion::Rect<DIM> &bounds,
-  const Legion::DomainAffineTransform &transform) const
+  const Legion::Rect<DIM>& bounds,
+  const Legion::DomainAffineTransform& transform) const
 {
   using ACC = AccessorRD<OP, EXCLUSIVE, DIM>;
   return dim_dispatch(
@@ -148,7 +148,7 @@ AccessorRO<T, DIM> FutureWrapper::read_accessor() const
 }
 
 template <typename T, int DIM>
-AccessorRO<T, DIM> FutureWrapper::read_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRO<T, DIM> FutureWrapper::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
   auto memkind = Legion::Memory::Kind::NO_MEMKIND;
   return AccessorRO<T, DIM>(
@@ -168,7 +168,7 @@ VAL FutureWrapper::scalar() const
 }
 
 template <typename VAL>
-void OutputRegionField::return_data(Legion::DeferredBuffer<VAL, 1> &buffer, size_t num_elements)
+void OutputRegionField::return_data(Legion::DeferredBuffer<VAL, 1>& buffer, size_t num_elements)
 {
   assert(!bound_);
   out_.return_data(fid_, buffer, &num_elements);
@@ -225,7 +225,7 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor() const
 }
 
 template <typename T, int DIM>
-AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
   assert(DIM == dim_);
   if (is_future_) return future_.read_accessor<T, DIM>(bounds);
@@ -238,7 +238,7 @@ AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM> &bounds) const
 }
 
 template <typename T, int DIM>
-AccessorWO<T, DIM> Store::write_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorWO<T, DIM> Store::write_accessor(const Legion::Rect<DIM>& bounds) const
 {
   assert(!is_future_);
   assert(DIM == dim_);
@@ -250,7 +250,7 @@ AccessorWO<T, DIM> Store::write_accessor(const Legion::Rect<DIM> &bounds) const
 }
 
 template <typename T, int DIM>
-AccessorRW<T, DIM> Store::read_write_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRW<T, DIM> Store::read_write_accessor(const Legion::Rect<DIM>& bounds) const
 {
   assert(!is_future_);
   assert(DIM == dim_);
@@ -262,7 +262,7 @@ AccessorRW<T, DIM> Store::read_write_accessor(const Legion::Rect<DIM> &bounds) c
 }
 
 template <typename OP, bool EXCLUSIVE, int DIM>
-AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Legion::Rect<DIM> &bounds) const
+AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Legion::Rect<DIM>& bounds) const
 {
   assert(!is_future_);
   assert(DIM == dim_);
@@ -287,7 +287,7 @@ VAL Store::scalar() const
 }
 
 template <typename VAL>
-void Store::return_data(Legion::DeferredBuffer<VAL, 1> &buffer, size_t num_elements)
+void Store::return_data(Legion::DeferredBuffer<VAL, 1>& buffer, size_t num_elements)
 {
   assert(is_output_store_);
   output_field_.return_data(buffer, num_elements);

--- a/src/data/transform.cc
+++ b/src/data/transform.cc
@@ -22,7 +22,7 @@ using namespace Legion;
 
 using StoreTransformP = std::unique_ptr<StoreTransform>;
 
-DomainTransform operator*(const DomainTransform &lhs, const DomainTransform &rhs)
+DomainTransform operator*(const DomainTransform& lhs, const DomainTransform& rhs)
 {
   assert(lhs.n == rhs.m);
   DomainTransform result;
@@ -37,7 +37,7 @@ DomainTransform operator*(const DomainTransform &lhs, const DomainTransform &rhs
   return result;
 }
 
-DomainPoint operator+(const DomainPoint &lhs, const DomainPoint &rhs)
+DomainPoint operator+(const DomainPoint& lhs, const DomainPoint& rhs)
 {
   assert(lhs.dim == rhs.dim);
   DomainPoint result(lhs);
@@ -45,7 +45,7 @@ DomainPoint operator+(const DomainPoint &lhs, const DomainPoint &rhs)
   return result;
 }
 
-DomainAffineTransform combine(const DomainAffineTransform &lhs, const DomainAffineTransform &rhs)
+DomainAffineTransform combine(const DomainAffineTransform& lhs, const DomainAffineTransform& rhs)
 {
   DomainAffineTransform result;
   auto transform   = lhs.transform * rhs.transform;
@@ -55,14 +55,14 @@ DomainAffineTransform combine(const DomainAffineTransform &lhs, const DomainAffi
   return result;
 }
 
-StoreTransform::StoreTransform(StoreTransformP &&parent) : parent_(std::move(parent)) {}
+StoreTransform::StoreTransform(StoreTransformP&& parent) : parent_(std::move(parent)) {}
 
-Shift::Shift(int32_t dim, int64_t offset, StoreTransformP &&parent)
+Shift::Shift(int32_t dim, int64_t offset, StoreTransformP&& parent)
   : StoreTransform(std::forward<StoreTransformP>(parent)), dim_(dim), offset_(offset)
 {
 }
 
-Domain Shift::transform(const Domain &input) const
+Domain Shift::transform(const Domain& input) const
 {
   auto result = nullptr != parent_ ? parent_->transform(input) : input;
   result.rect_data[dim_] += offset_;
@@ -97,16 +97,16 @@ DomainAffineTransform Shift::inverse_transform(int32_t in_dim) const
     return result;
 }
 
-Promote::Promote(int32_t extra_dim, int64_t dim_size, StoreTransformP &&parent)
+Promote::Promote(int32_t extra_dim, int64_t dim_size, StoreTransformP&& parent)
   : StoreTransform(std::forward<StoreTransformP>(parent)),
     extra_dim_(extra_dim),
     dim_size_(dim_size)
 {
 }
 
-Domain Promote::transform(const Domain &input) const
+Domain Promote::transform(const Domain& input) const
 {
-  auto promote = [](int32_t extra_dim, int64_t dim_size, const Domain &input) {
+  auto promote = [](int32_t extra_dim, int64_t dim_size, const Domain& input) {
     Domain output;
     output.dim = input.dim + 1;
 
@@ -154,14 +154,14 @@ DomainAffineTransform Promote::inverse_transform(int32_t in_dim) const
     return result;
 }
 
-Project::Project(int32_t dim, int64_t coord, StoreTransformP &&parent)
+Project::Project(int32_t dim, int64_t coord, StoreTransformP&& parent)
   : StoreTransform(std::forward<StoreTransformP>(parent)), dim_(dim), coord_(coord)
 {
 }
 
-Domain Project::transform(const Domain &input) const
+Domain Project::transform(const Domain& input) const
 {
-  auto project = [](int32_t collapsed_dim, const Domain &input) {
+  auto project = [](int32_t collapsed_dim, const Domain& input) {
     Domain output;
     output.dim = input.dim - 1;
 
@@ -211,14 +211,14 @@ DomainAffineTransform Project::inverse_transform(int32_t in_dim) const
     return result;
 }
 
-Transpose::Transpose(std::vector<int32_t> &&axes, StoreTransformP &&parent)
+Transpose::Transpose(std::vector<int32_t>&& axes, StoreTransformP&& parent)
   : StoreTransform(std::forward<StoreTransformP>(parent)), axes_(std::move(axes))
 {
 }
 
-Domain Transpose::transform(const Domain &input) const
+Domain Transpose::transform(const Domain& input) const
 {
-  auto transpose = [](const auto &axes, const Domain &input) {
+  auto transpose = [](const auto& axes, const Domain& input) {
     Domain output;
     output.dim = input.dim;
     for (int32_t in_dim = 0; in_dim < input.dim; ++in_dim) {
@@ -257,7 +257,7 @@ DomainAffineTransform Transpose::inverse_transform(int32_t in_dim) const
     return result;
 }
 
-Delinearize::Delinearize(int32_t dim, std::vector<int64_t> &&sizes, StoreTransformP &&parent)
+Delinearize::Delinearize(int32_t dim, std::vector<int64_t>&& sizes, StoreTransformP&& parent)
   : StoreTransform(std::forward<StoreTransformP>(parent)),
     dim_(dim),
     sizes_(std::move(sizes)),
@@ -269,7 +269,7 @@ Delinearize::Delinearize(int32_t dim, std::vector<int64_t> &&sizes, StoreTransfo
   for (auto size : sizes_) volume_ *= size;
 }
 
-Domain Delinearize::transform(const Domain &input) const
+Domain Delinearize::transform(const Domain& input) const
 {
   Domain output;
   output.dim     = input.dim - 1 + sizes_.size();

--- a/src/data/transform.h
+++ b/src/data/transform.h
@@ -25,11 +25,11 @@ namespace legate {
 class StoreTransform {
  public:
   StoreTransform() {}
-  StoreTransform(std::unique_ptr<StoreTransform> &&parent);
+  StoreTransform(std::unique_ptr<StoreTransform>&& parent);
   ~StoreTransform() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &input) const           = 0;
+  virtual Legion::Domain transform(const Legion::Domain& input) const           = 0;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const = 0;
 
  protected:
@@ -38,11 +38,11 @@ class StoreTransform {
 
 class Shift : public StoreTransform {
  public:
-  Shift(int32_t dim, int64_t offset, std::unique_ptr<StoreTransform> &&parent = nullptr);
+  Shift(int32_t dim, int64_t offset, std::unique_ptr<StoreTransform>&& parent = nullptr);
   virtual ~Shift() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &input) const override;
+  virtual Legion::Domain transform(const Legion::Domain& input) const override;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const override;
 
  private:
@@ -52,11 +52,11 @@ class Shift : public StoreTransform {
 
 class Promote : public StoreTransform {
  public:
-  Promote(int32_t extra_dim, int64_t dim_size, std::unique_ptr<StoreTransform> &&parent = nullptr);
+  Promote(int32_t extra_dim, int64_t dim_size, std::unique_ptr<StoreTransform>&& parent = nullptr);
   virtual ~Promote() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &input) const override;
+  virtual Legion::Domain transform(const Legion::Domain& input) const override;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const override;
 
  private:
@@ -66,11 +66,11 @@ class Promote : public StoreTransform {
 
 class Project : public StoreTransform {
  public:
-  Project(int32_t dim, int64_t coord, std::unique_ptr<StoreTransform> &&parent = nullptr);
+  Project(int32_t dim, int64_t coord, std::unique_ptr<StoreTransform>&& parent = nullptr);
   virtual ~Project() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &domain) const override;
+  virtual Legion::Domain transform(const Legion::Domain& domain) const override;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const override;
 
  private:
@@ -80,11 +80,11 @@ class Project : public StoreTransform {
 
 class Transpose : public StoreTransform {
  public:
-  Transpose(std::vector<int32_t> &&axes, std::unique_ptr<StoreTransform> &&parent = nullptr);
+  Transpose(std::vector<int32_t>&& axes, std::unique_ptr<StoreTransform>&& parent = nullptr);
   virtual ~Transpose() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &domain) const override;
+  virtual Legion::Domain transform(const Legion::Domain& domain) const override;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const override;
 
  private:
@@ -94,12 +94,12 @@ class Transpose : public StoreTransform {
 class Delinearize : public StoreTransform {
  public:
   Delinearize(int32_t dim,
-              std::vector<int64_t> &&sizes,
-              std::unique_ptr<StoreTransform> &&parent = nullptr);
+              std::vector<int64_t>&& sizes,
+              std::unique_ptr<StoreTransform>&& parent = nullptr);
   virtual ~Delinearize() {}
 
  public:
-  virtual Legion::Domain transform(const Legion::Domain &domain) const override;
+  virtual Legion::Domain transform(const Legion::Domain& domain) const override;
   virtual Legion::DomainAffineTransform inverse_transform(int32_t in_dim) const override;
 
  private:

--- a/src/gpu/cudalibs.h
+++ b/src/gpu/cudalibs.h
@@ -31,15 +31,15 @@ struct CUDALibraries {
 
  private:
   // Prevent copying and overwriting
-  CUDALibraries(const CUDALibraries &rhs);
-  CUDALibraries &operator=(const CUDALibraries &rhs);
+  CUDALibraries(const CUDALibraries& rhs);
+  CUDALibraries& operator=(const CUDALibraries& rhs);
 
  public:
   void finalize(void);
-  cublasContext *get_cublas(void);
+  cublasContext* get_cublas(void);
 
  protected:
-  cublasContext *cublas;  // this is synonymous with cublasHandle_t
+  cublasContext* cublas;  // this is synonymous with cublasHandle_t
 };
 
 }  // namespace legate

--- a/src/runtime/context.cc
+++ b/src/runtime/context.cc
@@ -23,9 +23,9 @@
 
 namespace legate {
 
-LibraryContext::LibraryContext(Legion::Runtime *runtime,
-                               const std::string &library_name,
-                               const ResourceConfig &config)
+LibraryContext::LibraryContext(Legion::Runtime* runtime,
+                               const std::string& library_name,
+                               const ResourceConfig& config)
 {
   task_scope_ = ResourceScope(
     runtime->generate_library_task_ids(library_name.c_str(), config.max_tasks), config.max_tasks);
@@ -136,10 +136,10 @@ bool LibraryContext::valid_sharding_id(Legion::ShardingID shard_id) const
   return shard_scope_.in_scope(shard_id);
 }
 
-TaskContext::TaskContext(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+TaskContext::TaskContext(const Legion::Task* task,
+                         const std::vector<Legion::PhysicalRegion>& regions,
                          Legion::Context context,
-                         Legion::Runtime *runtime)
+                         Legion::Runtime* runtime)
   : task_(task), regions_(regions), context_(context), runtime_(runtime)
 {
   Deserializer dez(task, regions);

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -37,7 +37,7 @@ class ResourceScope {
   ResourceScope(int64_t base, int64_t max) : base_(base), max_(max) {}
 
  public:
-  ResourceScope(const ResourceScope &) = default;
+  ResourceScope(const ResourceScope&) = default;
 
  public:
   int64_t translate(int64_t local_resource_id) const { return base_ + local_resource_id; }
@@ -58,12 +58,12 @@ class ResourceScope {
 
 class LibraryContext {
  public:
-  LibraryContext(Legion::Runtime *runtime,
-                 const std::string &library_name,
-                 const ResourceConfig &config);
+  LibraryContext(Legion::Runtime* runtime,
+                 const std::string& library_name,
+                 const ResourceConfig& config);
 
  public:
-  LibraryContext(const LibraryContext &) = default;
+  LibraryContext(const LibraryContext&) = default;
 
  public:
   Legion::TaskID get_task_id(int64_t local_task_id) const;
@@ -98,22 +98,22 @@ class LibraryContext {
 // of the Legion API.
 class TaskContext {
  public:
-  TaskContext(const Legion::Task *task,
-              const std::vector<Legion::PhysicalRegion> &regions,
+  TaskContext(const Legion::Task* task,
+              const std::vector<Legion::PhysicalRegion>& regions,
               Legion::Context context,
-              Legion::Runtime *runtime);
+              Legion::Runtime* runtime);
 
  public:
-  std::vector<Store> &inputs() { return inputs_; }
-  std::vector<Store> &outputs() { return outputs_; }
-  std::vector<Store> &reductions() { return reductions_; }
-  std::vector<Scalar> &scalars() { return scalars_; }
+  std::vector<Store>& inputs() { return inputs_; }
+  std::vector<Store>& outputs() { return outputs_; }
+  std::vector<Store>& reductions() { return reductions_; }
+  std::vector<Scalar>& scalars() { return scalars_; }
 
  private:
-  const Legion::Task *task_;
-  const std::vector<Legion::PhysicalRegion> &regions_;
+  const Legion::Task* task_;
+  const std::vector<Legion::PhysicalRegion>& regions_;
   Legion::Context context_;
-  Legion::Runtime *runtime_;
+  Legion::Runtime* runtime_;
 
  private:
   std::vector<Store> inputs_, outputs_, reductions_;

--- a/src/task/task.h
+++ b/src/task/task.h
@@ -39,7 +39,7 @@ struct ReturnSize<void> {
 };
 
 template <typename RET_T = void>
-using LegateVariantImpl = RET_T (*)(TaskContext &);
+using LegateVariantImpl = RET_T (*)(TaskContext&);
 
 template <typename T>
 class LegateTask {
@@ -49,23 +49,23 @@ class LegateTask {
   using __yes = int8_t[2];
   struct HasCPUVariant {
     template <typename U>
-    static __yes &test(decltype(&U::cpu_variant));
+    static __yes& test(decltype(&U::cpu_variant));
     template <typename U>
-    static __no &test(...);
+    static __no& test(...);
     static const bool value = (sizeof(test<T>(0)) == sizeof(__yes));
   };
   struct HasOMPVariant {
     template <typename U>
-    static __yes &test(decltype(&U::omp_variant));
+    static __yes& test(decltype(&U::omp_variant));
     template <typename U>
-    static __no &test(...);
+    static __no& test(...);
     static const bool value = (sizeof(test<T>(0)) == sizeof(__yes));
   };
   struct HasGPUVariant {
     template <typename U>
-    static __yes &test(decltype(&U::gpu_variant));
+    static __yes& test(decltype(&U::gpu_variant));
     template <typename U>
-    static __no &test(...);
+    static __no& test(...);
     static const bool value = (sizeof(test<T>(0)) == sizeof(__yes));
   };
 
@@ -75,19 +75,19 @@ class LegateTask {
   static void register_variants_with_return();
 
  public:
-  static const char *task_name()
+  static const char* task_name()
   {
     static std::string result;
     if (result.empty()) {
       int status      = 0;
-      char *demangled = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
+      char* demangled = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
       result          = demangled;
       free(demangled);
     }
 
     return result.c_str();
   }
-  static void show_progress(const Legion::Task *task, Legion::Context ctx, Legion::Runtime *runtime)
+  static void show_progress(const Legion::Task* task, Legion::Context ctx, Legion::Runtime* runtime)
   {
     if (!Core::show_progress) return;
     const auto exec_proc = runtime->get_executing_processor(ctx);
@@ -97,7 +97,7 @@ class LegateTask {
         : (exec_proc.kind() == Legion::Processor::TOC_PROC) ? "GPU" : "OpenMP";
 
     std::stringstream point_str;
-    const auto &point = task->index_point;
+    const auto& point = task->index_point;
     point_str << point[0];
     for (int32_t dim = 1; dim < task->index_point.dim; ++dim) point_str << "," << point[dim];
 
@@ -110,10 +110,10 @@ class LegateTask {
 
   // Task wrappers so we can instrument all Legate tasks if we want
   template <typename RET_T, LegateVariantImpl<RET_T> TASK_PTR>
-  static RET_T legate_task_wrapper(const Legion::Task *task,
-                                   const std::vector<Legion::PhysicalRegion> &regions,
+  static RET_T legate_task_wrapper(const Legion::Task* task,
+                                   const std::vector<Legion::PhysicalRegion>& regions,
                                    Legion::Context legion_context,
-                                   Legion::Runtime *runtime)
+                                   Legion::Runtime* runtime)
   {
     show_progress(task, legion_context, runtime);
 
@@ -124,8 +124,8 @@ class LegateTask {
  public:
   // Methods for registering variants
   template <LegateVariantImpl<> TASK_PTR>
-  static void register_variant(Legion::ExecutionConstraintSet &execution_constraints,
-                               Legion::TaskLayoutConstraintSet &layout_constraints,
+  static void register_variant(Legion::ExecutionConstraintSet& execution_constraints,
+                               Legion::TaskLayoutConstraintSet& layout_constraints,
                                LegateVariantCode var,
                                Legion::Processor::Kind kind,
                                bool leaf       = false,
@@ -152,8 +152,8 @@ class LegateTask {
                                  ret_size);
   }
   template <typename RET_T, LegateVariantImpl<RET_T> TASK_PTR>
-  static void register_variant(Legion::ExecutionConstraintSet &execution_constraints,
-                               Legion::TaskLayoutConstraintSet &layout_constraints,
+  static void register_variant(Legion::ExecutionConstraintSet& execution_constraints,
+                               Legion::TaskLayoutConstraintSet& layout_constraints,
                                LegateVariantCode var,
                                Legion::Processor::Kind kind,
                                bool leaf       = false,
@@ -346,10 +346,10 @@ template <typename RET_T, typename REDUC_T>
 class LegateTaskRegistrar {
  public:
   void record_variant(Legion::TaskID tid,
-                      const char *task_name,
-                      const Legion::CodeDescriptor &desc,
-                      Legion::ExecutionConstraintSet &execution_constraints,
-                      Legion::TaskLayoutConstraintSet &layout_constraints,
+                      const char* task_name,
+                      const Legion::CodeDescriptor& desc,
+                      Legion::ExecutionConstraintSet& execution_constraints,
+                      Legion::TaskLayoutConstraintSet& layout_constraints,
                       LegateVariantCode var,
                       Legion::Processor::Kind kind,
                       bool leaf,
@@ -358,7 +358,7 @@ class LegateTaskRegistrar {
                       size_t ret_size);
 
  public:
-  void register_all_tasks(Legion::Runtime *runtime, LibraryContext &context);
+  void register_all_tasks(Legion::Runtime* runtime, LibraryContext& context);
 
  private:
   struct PendingTaskVariant : public Legion::TaskVariantRegistrar {
@@ -369,9 +369,9 @@ class LegateTaskRegistrar {
     }
     PendingTaskVariant(Legion::TaskID tid,
                        bool global,
-                       const char *var_name,
-                       const char *t_name,
-                       const Legion::CodeDescriptor &desc,
+                       const char* var_name,
+                       const char* t_name,
+                       const Legion::CodeDescriptor& desc,
                        LegateVariantCode v,
                        size_t ret)
       : Legion::TaskVariantRegistrar(tid, global, var_name),
@@ -383,7 +383,7 @@ class LegateTaskRegistrar {
     }
 
    public:
-    const char *task_name;
+    const char* task_name;
     Legion::CodeDescriptor descriptor;
     LegateVariantCode var;
     size_t ret_size;

--- a/src/utilities/deserializer.cc
+++ b/src/utilities/deserializer.cc
@@ -22,10 +22,10 @@ namespace legate {
 
 using namespace Legion;
 
-Deserializer::Deserializer(const Task *task, const std::vector<PhysicalRegion> &regions)
+Deserializer::Deserializer(const Task* task, const std::vector<PhysicalRegion>& regions)
   : regions_{regions.data(), regions.size()},
     futures_{task->futures.data(), task->futures.size()},
-    task_args_{static_cast<const int8_t *>(task->args), task->arglen},
+    task_args_{static_cast<const int8_t*>(task->args), task->arglen},
     outputs_()
 {
   auto runtime = Runtime::get_runtime();
@@ -33,12 +33,12 @@ Deserializer::Deserializer(const Task *task, const std::vector<PhysicalRegion> &
   runtime->get_output_regions(ctx, outputs_);
 }
 
-void Deserializer::_unpack(LegateTypeCode &value)
+void Deserializer::_unpack(LegateTypeCode& value)
 {
   value = static_cast<LegateTypeCode>(unpack<int32_t>());
 }
 
-void Deserializer::_unpack(Store &value)
+void Deserializer::_unpack(Store& value)
 {
   auto is_future = unpack<bool>();
   auto dim       = unpack<int32_t>();
@@ -61,7 +61,7 @@ void Deserializer::_unpack(Store &value)
   }
 }
 
-void Deserializer::_unpack(Scalar &value)
+void Deserializer::_unpack(Scalar& value)
 {
   auto tuple = unpack<bool>();
   auto code  = unpack<LegateTypeCode>();
@@ -69,7 +69,7 @@ void Deserializer::_unpack(Scalar &value)
   task_args_ = task_args_.subspan(value.size());
 }
 
-void Deserializer::_unpack(FutureWrapper &value)
+void Deserializer::_unpack(FutureWrapper& value)
 {
   auto future = futures_[0];
   futures_    = futures_.subspan(1);
@@ -85,7 +85,7 @@ void Deserializer::_unpack(FutureWrapper &value)
   value = FutureWrapper(domain, future);
 }
 
-void Deserializer::_unpack(RegionField &value)
+void Deserializer::_unpack(RegionField& value)
 {
   auto dim = unpack<int32_t>();
   auto idx = unpack<uint32_t>();
@@ -94,7 +94,7 @@ void Deserializer::_unpack(RegionField &value)
   value = RegionField(dim, regions_[idx], fid);
 }
 
-void Deserializer::_unpack(OutputRegionField &value)
+void Deserializer::_unpack(OutputRegionField& value)
 {
   auto dim = unpack<int32_t>();
   assert(dim == 1);

--- a/src/utilities/deserializer.h
+++ b/src/utilities/deserializer.h
@@ -36,7 +36,7 @@ class OutputRegionField;
 
 class Deserializer {
  public:
-  Deserializer(const Legion::Task *task, const std::vector<Legion::PhysicalRegion> &regions);
+  Deserializer(const Legion::Task* task, const std::vector<Legion::PhysicalRegion>& regions);
 
  public:
   template <typename T>
@@ -48,28 +48,28 @@ class Deserializer {
   }
 
  private:
-  template <typename T, std::enable_if_t<legate_type_code_of<T> != MAX_TYPE_NUMBER> * = nullptr>
-  void _unpack(T &value)
+  template <typename T, std::enable_if_t<legate_type_code_of<T> != MAX_TYPE_NUMBER>* = nullptr>
+  void _unpack(T& value)
   {
-    value      = *reinterpret_cast<const T *>(task_args_.ptr());
+    value      = *reinterpret_cast<const T*>(task_args_.ptr());
     task_args_ = task_args_.subspan(sizeof(T));
   }
 
  private:
   template <typename T>
-  void _unpack(std::vector<T> &values)
+  void _unpack(std::vector<T>& values)
   {
     auto size = unpack<uint32_t>();
     for (uint32_t idx = 0; idx < size; ++idx) values.push_back(unpack<T>());
   }
 
  private:
-  void _unpack(LegateTypeCode &value);
-  void _unpack(Store &value);
-  void _unpack(Scalar &value);
-  void _unpack(FutureWrapper &value);
-  void _unpack(RegionField &value);
-  void _unpack(OutputRegionField &value);
+  void _unpack(LegateTypeCode& value);
+  void _unpack(Store& value);
+  void _unpack(Scalar& value);
+  void _unpack(FutureWrapper& value);
+  void _unpack(RegionField& value);
+  void _unpack(OutputRegionField& value);
 
  private:
   std::unique_ptr<StoreTransform> unpack_transform();

--- a/src/utilities/dispatch.h
+++ b/src/utilities/dispatch.h
@@ -23,7 +23,7 @@ namespace legate {
 template <int DIM>
 struct inner_type_dispatch_fn {
   template <typename Functor, typename... Fnargs>
-  constexpr decltype(auto) operator()(LegateTypeCode code, Functor f, Fnargs &&... args)
+  constexpr decltype(auto) operator()(LegateTypeCode code, Functor f, Fnargs&&... args)
   {
     switch (code) {
       case LegateTypeCode::BOOL_LT: {
@@ -79,7 +79,7 @@ struct inner_type_dispatch_fn {
 template <int DIM>
 struct inner_dim_dispatch_fn {
   template <typename Functor, typename... Fnargs>
-  constexpr decltype(auto) operator()(int dim, Functor f, Fnargs &&... args)
+  constexpr decltype(auto) operator()(int dim, Functor f, Fnargs&&... args)
   {
     switch (dim) {
       case 1: {
@@ -132,7 +132,7 @@ struct inner_dim_dispatch_fn {
 };
 
 template <typename Functor, typename... Fnargs>
-constexpr decltype(auto) double_dispatch(int dim, LegateTypeCode code, Functor f, Fnargs &&... args)
+constexpr decltype(auto) double_dispatch(int dim, LegateTypeCode code, Functor f, Fnargs&&... args)
 {
   switch (dim) {
 #if LEGION_MAX_DIM >= 1
@@ -186,7 +186,7 @@ constexpr decltype(auto) double_dispatch(int dim, LegateTypeCode code, Functor f
 }
 
 template <typename Functor, typename... Fnargs>
-constexpr decltype(auto) double_dispatch(int dim1, int dim2, Functor f, Fnargs &&... args)
+constexpr decltype(auto) double_dispatch(int dim1, int dim2, Functor f, Fnargs&&... args)
 {
   switch (dim1) {
 #if LEGION_MAX_DIM >= 1
@@ -240,7 +240,7 @@ constexpr decltype(auto) double_dispatch(int dim1, int dim2, Functor f, Fnargs &
 }
 
 template <typename Functor, typename... Fnargs>
-constexpr decltype(auto) dim_dispatch(int dim, Functor f, Fnargs &&... args)
+constexpr decltype(auto) dim_dispatch(int dim, Functor f, Fnargs&&... args)
 {
   switch (dim) {
 #if LEGION_MAX_DIM >= 1
@@ -294,7 +294,7 @@ constexpr decltype(auto) dim_dispatch(int dim, Functor f, Fnargs &&... args)
 }
 
 template <typename Functor, typename... Fnargs>
-constexpr decltype(auto) type_dispatch(LegateTypeCode code, Functor f, Fnargs &&... args)
+constexpr decltype(auto) type_dispatch(LegateTypeCode code, Functor f, Fnargs&&... args)
 {
   switch (code) {
     case LegateTypeCode::BOOL_LT: {

--- a/src/utilities/span.h
+++ b/src/utilities/span.h
@@ -23,11 +23,11 @@ namespace legate {
 template <typename T>
 struct Span {
  public:
-  Span()             = default;
-  Span(const Span &) = default;
+  Span()            = default;
+  Span(const Span&) = default;
 
  public:
-  Span(T *data, size_t size) : data_(data), size_(size) {}
+  Span(T* data, size_t size) : data_(data), size_(size) {}
 
  public:
   size_t size() const { return size_; }
@@ -47,10 +47,10 @@ struct Span {
   }
 
  public:
-  const T *ptr() const { return data_; }
+  const T* ptr() const { return data_; }
 
  private:
-  T *data_{nullptr};
+  T* data_{nullptr};
   size_t size_{0};
 };
 


### PR DESCRIPTION
This PR is to force left alignment for pointers and references in C++ source files. Previously, we let the formatter to choose the most common alignment in each file (i.e., `DerivePointerAlignment` set to `true`), and this made the files end up using different alignments.