### PR TITLE
When generating CI images, name them after the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: echo "$MATRIX_CONTEXT"
       - name: Run CI build
         run: |
+          env
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/legate.core
           rm -rf ngc-artifacts || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - gh-pages  # deployment target branch (this workflow should not exist on that branch anyway)
 env:
   COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+  REF: ${{ github.event.pull_request.head.ref || github.ref }}
   PROJECT: github-core-ci
   # Prevent output buffering
   PYTHONUNBUFFERED: 1
@@ -20,7 +21,7 @@ jobs:
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/legate.core
           rm -rf ngc-artifacts || true
-          ./build.sh > ${COMMIT}-build.log 2>&1
+          ./build.sh > ${COMMIT}-build.log 2>&1 || true
           cat *artifacts/*/*
       - name: Upload Build Log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
   PROJECT: github-core-ci
   REF: ${{ github.event.pull_request.head.ref || github.ref }}
+  EVENT_NAME: ${{ github.event_name }}
   # Prevent output buffering
   PYTHONUNBUFFERED: 1
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   PROJECT: github-core-ci
   REF: ${{ github.event.pull_request.head.ref || github.ref }}
   EVENT_NAME: ${{ github.event_name }}
+  LABEL: ${{ github.event.pull_request.head.label }}
   # Prevent output buffering
   PYTHONUNBUFFERED: 1
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,30 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJSON(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJSON(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
       - name: Run CI build
         run: |
           /data/github-runner/legate-bin/setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
   PROJECT: github-core-ci
+  REF: ${{ github.event.pull_request.head.ref || github.ref }}
   # Prevent output buffering
   PYTHONUNBUFFERED: 1
 jobs:
@@ -41,7 +42,6 @@ jobs:
         run: echo "$MATRIX_CONTEXT"
       - name: Run CI build
         run: |
-          env
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/legate.core
           rm -rf ngc-artifacts || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - gh-pages  # deployment target branch (this workflow should not exist on that branch anyway)
 env:
   COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
-  REF: ${{ github.event.pull_request.head.ref || github.ref }}
   PROJECT: github-core-ci
   # Prevent output buffering
   PYTHONUNBUFFERED: 1


### PR DESCRIPTION
We want images for branches as we need to match the core image to the library version we are using in CI.