### PR TITLE
Formalize "scalar" property on Stores

### DIFF
--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -561,7 +561,7 @@ class TaskLauncher(object):
     def add_store(self, args, store, proj, perm, tag, flags):
         if store.kind is Future:
             if perm != Permission.READ:
-                raise ValueError("Scalar stores must be read only")
+                raise ValueError("Future-backed stores must be read only")
             self.add_future(store.storage)
             args.append(FutureStoreArg(store))
 

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -21,6 +21,7 @@ from .legion import (
     ArgumentMap,
     BufferBuilder,
     Copy as SingleCopy,
+    Future,
     IndexCopy,
     IndexTask,
     Task as SingleTask,
@@ -558,7 +559,7 @@ class TaskLauncher(object):
         )
 
     def add_store(self, args, store, proj, perm, tag, flags):
-        if store.scalar:
+        if store.kind is Future:
             if perm != Permission.READ:
                 raise ValueError("Scalar stores must be read only")
             self.add_future(store.storage)
@@ -747,7 +748,7 @@ class CopyLauncher(object):
         del self._req_analyzer
 
     def add_store(self, store, proj, perm, tag, flags):
-        assert not store.scalar
+        assert store.kind is not Future
         assert store._transform is None
 
         region = store.storage.region

--- a/legate/core/legion.py
+++ b/legate/core/legion.py
@@ -2653,7 +2653,7 @@ class Future(object):
         return type(self) == type(other) and self.handle == other.handle
 
     def __str__(self):
-        return f"Future({self.handle})"
+        return f"Future({str(self.handle.impl)[16:-1]})"
 
     def destroy(self, unordered):
         """

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -16,6 +16,7 @@
 import legate.core.types as ty
 
 from .launcher import CopyLauncher, TaskLauncher
+from .legion import Future
 from .solver import EqClass
 from .store import Store
 
@@ -90,7 +91,7 @@ class Operation(object):
 
     def add_output(self, store):
         self._check_store(store)
-        if store.scalar:
+        if store.kind is Future:
             self._check_scalar_output()
             self._scalar_output = store
         else:
@@ -98,7 +99,7 @@ class Operation(object):
 
     def add_reduction(self, store, redop):
         self._check_store(store)
-        if store.scalar:
+        if store.kind is Future:
             self._check_scalar_output()
             self._scalar_reduction = (store, redop)
         else:

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -28,8 +28,8 @@ class Operation(object):
         self._inputs = []
         self._outputs = []
         self._reductions = []
-        self._scalar_output = None
-        self._scalar_reduction = None
+        self._future_output = None
+        self._future_reduction = None
         self._constraints = EqClass()
         self._broadcasts = set()
 
@@ -79,29 +79,31 @@ class Operation(object):
         self._inputs.append(store)
 
     @property
-    def _has_scalar_output(self):
+    def _has_future_output(self):
         return (
-            self._scalar_reduction is not None
-            or self._scalar_output is not None
+            self._future_reduction is not None
+            or self._future_output is not None
         )
 
-    def _check_scalar_output(self):
-        if self._has_scalar_output:
-            raise ValueError("Only one scalar store can be used for output")
+    def _check_future_output(self):
+        if self._has_future_output:
+            raise ValueError(
+                "Only one Future-backed store can be used for output"
+            )
 
     def add_output(self, store):
         self._check_store(store)
         if store.kind is Future:
-            self._check_scalar_output()
-            self._scalar_output = store
+            self._check_future_output()
+            self._future_output = store
         else:
             self._outputs.append(store)
 
     def add_reduction(self, store, redop):
         self._check_store(store)
         if store.kind is Future:
-            self._check_scalar_output()
-            self._scalar_reduction = (store, redop)
+            self._check_future_output()
+            self._future_reduction = (store, redop)
         else:
             self._reductions.append((store, redop))
 
@@ -172,10 +174,10 @@ class Task(Operation):
         for future in self._futures:
             launcher.add_future(future)
 
-        if self._scalar_output is not None:
-            strategy.launch(launcher, self._scalar_output)
-        elif self._scalar_reduction is not None:
-            (store, redop) = self._scalar_reduction
+        if self._future_output is not None:
+            strategy.launch(launcher, self._future_output)
+        elif self._future_reduction is not None:
+            (store, redop) = self._future_reduction
             strategy.launch(launcher, store, redop)
         else:
             strategy.launch(launcher)

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -848,7 +848,7 @@ class Runtime(object):
             return op.launch(self.legion_runtime, self.legion_context)
 
     def _schedule(self, ops):
-        must_be_single = any(op._scalar_output is not None for op in ops)
+        must_be_single = any(op._future_output is not None for op in ops)
         partitioner = Partitioner(self, ops, must_be_single=must_be_single)
         strategy = partitioner.partition_stores()
 

--- a/legate/core/solver.py
+++ b/legate/core/solver.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from .legion import Rect
+from .legion import Future, Rect
 from .partition import NoPartition
 from .shape import Shape
 
@@ -157,7 +157,7 @@ class Partitioner(object):
     ):
         to_remove = set()
         for store in stores:
-            if not (store.scalar or store in broadcasts):
+            if not (store.kind is Future or store in broadcasts):
                 continue
 
             to_remove.add(store)
@@ -165,7 +165,7 @@ class Partitioner(object):
             if store in partitions:
                 continue
 
-            if store.scalar:
+            if store.kind is Future:
                 partitions[store] = NoPartition()
             else:
                 cls = constraints.find(store)

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -368,6 +368,12 @@ class Store(object):
             or isinstance(storage, Future)
         )
         self._storage = storage
+        if parent is None:
+            assert transform is None
+        else:
+            assert transform is not None
+        self._parent = parent
+        self._transform = transform
         if isinstance(storage, Future):
             assert shape is not None
             self._scalar = True
@@ -377,8 +383,6 @@ class Store(object):
             self._scalar = (
                 optimize_scalar and shape is not None and shape.volume() <= 1
             )
-        self._parent = parent
-        self._transform = transform
         self._inverse_transform = None
         self._partitions = {}
         self._key_partition = None
@@ -408,9 +412,8 @@ class Store(object):
     @property
     def kind(self):
         """
-        Return the type of the Legion storage object backing the
-        data in this storage object: either Future, FutureMap,
-        RegionField
+        Return the type of the Legion storage object backing the data in this
+        storage object: either Future, FutureMap, or RegionField.
         """
         if self._storage is not None:
             return type(self._storage)
@@ -428,9 +431,8 @@ class Store(object):
     @property
     def storage(self):
         """
-        Return the Legion storage objects actually backing the
-        data for this Store. These will have exactly the
-        type specified in by 'kind'
+        Return the Legion storage objects actually backing the data for this
+        Store. These will have exactly the type specified by `.kind`.
         """
         if self._storage is None:
             if self.unbound:

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -376,6 +376,7 @@ class Store(object):
         self._transform = transform
         if isinstance(storage, Future):
             assert shape is not None
+            assert self.get_root().shape.volume() <= 1
             self._scalar = True
         elif isinstance(storage, RegionField):
             self._scalar = False
@@ -415,10 +416,7 @@ class Store(object):
         Return the type of the Legion storage object backing the data in this
         storage object: either Future, FutureMap, or RegionField.
         """
-        if self._storage is not None:
-            return type(self._storage)
-        else:
-            return Future if self._scalar else RegionField
+        return Future if self._scalar else RegionField
 
     @property
     def unbound(self):
@@ -426,6 +424,9 @@ class Store(object):
 
     @property
     def scalar(self):
+        """
+        Equivalent to `.kind is Future`.
+        """
         return self._scalar
 
     @property

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -424,6 +424,10 @@ class Store(object):
         return self._shape is None
 
     @property
+    def scalar(self):
+        return self._kind is Future and self._shape.volume() == 1
+
+    @property
     def storage(self):
         """
         Return the Legion storage objects actually backing the data for this

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -368,10 +368,9 @@ class Store(object):
             or isinstance(storage, Future)
         )
         self._storage = storage
-        if parent is None:
-            assert transform is None
-        else:
-            assert transform is not None
+        assert (parent is None and transform is None) or (
+            parent is not None and transform is not None
+        )
         self._parent = parent
         self._transform = transform
         if isinstance(storage, Future):


### PR DESCRIPTION
"Scalar", as used by legate.numpy, assumes both that (a) the Store represents exactly one value, and (b) it is backed by a Future. (a) can happen without (b), e.g. if the Store is created with `optimize_scalar=False`, and (b) can happen without (a), e.g. if a Future-backed scalar array is broadcasted to a larger volume.