### PR TITLE
Refactor the task wrapper for scalar outputs

### DIFF
--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -100,13 +100,15 @@ class ScalarArg(object):
 
 
 class FutureStoreArg(object):
-    def __init__(self, store, read_only):
+    def __init__(self, store, read_only, has_storage):
         self._store = store
         self._read_only = read_only
+        self._has_storage = has_storage
 
     def pack(self, buf):
         self._store.serialize(buf)
         buf.pack_bool(self._read_only)
+        buf.pack_bool(self._has_storage)
         buf.pack_32bit_int(self._store.type.size)
         _pack(buf, self._store.get_root().shape, ty.int64, True)
 
@@ -563,10 +565,14 @@ class TaskLauncher(object):
 
     def add_store(self, args, store, proj, perm, tag, flags):
         if store.kind is Future:
-            read_only = perm == Permission.READ
-            if read_only:
+            if store.has_storage:
                 self.add_future(store.storage)
-            args.append(FutureStoreArg(store, read_only))
+            elif perm == Permission.READ or perm == Permission.REDUCTION:
+                raise RuntimeError(
+                    "Read access to an uninitialized store is disallowed"
+                )
+            read_only = perm == Permission.READ
+            args.append(FutureStoreArg(store, read_only, store.has_storage))
 
         else:
             region = store.storage.region
@@ -595,7 +601,7 @@ class TaskLauncher(object):
         )
 
     def add_reduction(self, store, proj, tag=0, flags=0, read_write=False):
-        if read_write:
+        if read_write and not store.scalar:
             self.add_store(
                 self._reductions,
                 store,

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -16,7 +16,6 @@
 import legate.core.types as ty
 
 from .launcher import CopyLauncher, TaskLauncher
-from .legion import Future
 from .solver import EqClass
 from .store import Store
 
@@ -28,8 +27,8 @@ class Operation(object):
         self._inputs = []
         self._outputs = []
         self._reductions = []
-        self._future_output = None
-        self._future_reduction = None
+        self._scalar_outputs = []
+        self._scalar_reductions = []
         self._constraints = EqClass()
         self._broadcasts = set()
 
@@ -52,6 +51,14 @@ class Operation(object):
     @property
     def reductions(self):
         return self._reductions
+
+    @property
+    def scalar_outputs(self):
+        return self._scalar_outputs
+
+    @property
+    def scalar_reductions(self):
+        return self._scalar_reductions
 
     @property
     def constraints(self):
@@ -78,34 +85,17 @@ class Operation(object):
         self._check_store(store)
         self._inputs.append(store)
 
-    @property
-    def _has_future_output(self):
-        return (
-            self._future_reduction is not None
-            or self._future_output is not None
-        )
-
-    def _check_future_output(self):
-        if self._has_future_output:
-            raise ValueError(
-                "Only one Future-backed store can be used for output"
-            )
-
     def add_output(self, store):
         self._check_store(store)
-        if store.kind is Future:
-            self._check_future_output()
-            self._future_output = store
-        else:
-            self._outputs.append(store)
+        if store.scalar:
+            self._scalar_outputs.append(len(self._outputs))
+        self._outputs.append(store)
 
     def add_reduction(self, store, redop):
         self._check_store(store)
-        if store.kind is Future:
-            self._check_future_output()
-            self._future_reduction = (store, redop)
-        else:
-            self._reductions.append((store, redop))
+        if store.scalar:
+            self._scalar_reductions.append(len(self._reductions))
+        self._reductions.append((store, redop))
 
     def add_alignment(self, store1, store2):
         self._check_store(store1)
@@ -174,13 +164,7 @@ class Task(Operation):
         for future in self._futures:
             launcher.add_future(future)
 
-        if self._future_output is not None:
-            strategy.launch(launcher, self._future_output)
-        elif self._future_reduction is not None:
-            (store, redop) = self._future_reduction
-            strategy.launch(launcher, store, redop)
-        else:
-            strategy.launch(launcher)
+        strategy.launch(self, launcher)
 
 
 class Copy(Operation):
@@ -235,4 +219,4 @@ class Copy(Operation):
             proj.redop = redop
             launcher.add_reduction(reduction, proj)
 
-        strategy.launch(launcher)
+        strategy.launch(self, launcher)

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -26,6 +26,7 @@ from legate.core import types as ty
 
 from .context import Context
 from .corelib import CoreLib
+from .launcher import TaskLauncher
 from .legion import (
     FieldSpace,
     Future,
@@ -1058,6 +1059,30 @@ class Runtime(object):
         self._partition_manager.record_partition(
             index_space, functor, index_partition
         )
+
+    def extract_scalar(self, future, idx, launch_domain=None):
+        launcher = TaskLauncher(
+            self.core_context,
+            self.core_library.LEGATE_CORE_EXTRACT_SCALAR_TASK_ID,
+            tag=self.core_library.LEGATE_CPU_VARIANT,
+        )
+        launcher.add_future(future)
+        launcher.add_scalar_arg(idx, ty.int32)
+        if launch_domain is None:
+            return launcher.execute_single()
+        else:
+            return launcher.execute(launch_domain)
+
+    def reduce_future_map(self, future_map, redop):
+        if isinstance(future_map, Future):
+            return future_map
+        else:
+            return future_map.reduce(
+                self.legion_context,
+                self.legion_runtime,
+                redop,
+                mapper=self.core_context.get_mapper_id(0),
+            )
 
 
 _runtime = Runtime(CoreLib())

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -858,7 +858,7 @@ class Runtime(object):
             return op.launch(self.legion_runtime, self.legion_context)
 
     def _schedule(self, ops):
-        must_be_single = any(op._future_output is not None for op in ops)
+        must_be_single = any(len(op.scalar_outputs) > 0 for op in ops)
         partitioner = Partitioner(self, ops, must_be_single=must_be_single)
         strategy = partitioner.partition_stores()
 

--- a/legate/core/solver.py
+++ b/legate/core/solver.py
@@ -104,6 +104,11 @@ class Strategy(object):
     def parallel(self):
         return self._launch_shape is not None
 
+    @property
+    def launch_domain(self):
+        assert self.parallel
+        return Rect(self._launch_shape)
+
     def get_projection(self, store):
         partition = self.get_partition(store)
         return partition.get_requirement(self._launch_shape, store)
@@ -120,28 +125,11 @@ class Strategy(object):
             raise ValueError(f"No strategy is found for {store}")
         return self._fspaces[store]
 
-    def launch(self, op, launcher):
-        output = None
-        redop = None
-        if len(op.scalar_outputs) + len(op.scalar_reductions) > 0:
-            assert len(op.scalar_outputs) + len(op.scalar_reductions) == 1
-            if len(op.scalar_outputs) == 1:
-                output = op.outputs[op.scalar_outputs[0]]
-            else:
-                (output, redop) = op.reductions[op.scalar_reductions[0]]
-
-        if output is None:
-            if self._launch_shape is None:
-                launcher.execute_single()
-            else:
-                launcher.execute(Rect(self._launch_shape))
+    def launch(self, launcher):
+        if self.parallel:
+            return launcher.execute(self.launch_domain)
         else:
-            if self._launch_shape is None:
-                result = launcher.execute_single()
-            else:
-                assert redop is not None
-                result = launcher.execute(Rect(self._launch_shape), redop)
-            output.set_storage(result)
+            return launcher.execute_single()
 
     def __str__(self):
         st = "[Strategy]"

--- a/legate/core/solver.py
+++ b/legate/core/solver.py
@@ -120,7 +120,16 @@ class Strategy(object):
             raise ValueError(f"No strategy is found for {store}")
         return self._fspaces[store]
 
-    def launch(self, launcher, output=None, redop=None):
+    def launch(self, op, launcher):
+        output = None
+        redop = None
+        if len(op.scalar_outputs) + len(op.scalar_reductions) > 0:
+            assert len(op.scalar_outputs) + len(op.scalar_reductions) == 1
+            if len(op.scalar_outputs) == 1:
+                output = op.outputs[op.scalar_outputs[0]]
+            else:
+                (output, redop) = op.reductions[op.scalar_reductions[0]]
+
         if output is None:
             if self._launch_shape is None:
                 launcher.execute_single()

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -461,6 +461,10 @@ class Store(object):
 
         return self._storage
 
+    @property
+    def has_storage(self):
+        return self._storage is not None
+
     def get_root(self):
         if self._parent is None:
             return self

--- a/src/core.mk
+++ b/src/core.mk
@@ -24,8 +24,10 @@ GEN_CPU_SRC	= legate_c.cc               \
 							runtime/projection.cc     \
 							runtime/runtime.cc        \
 							runtime/shard.cc          \
+							task/return.cc            \
 							task/task.cc              \
-							utilities/deserializer.cc
+							utilities/deserializer.cc \
+							utilities/machine.cc
 
 ifeq ($(strip $(USE_CUDA)),1)
 GEN_CPU_SRC	+= gpu/cudalibs.cc
@@ -50,9 +52,11 @@ INSTALL_HEADERS = legate.h                 \
 									data/transform.h         \
 									runtime/context.h        \
 									runtime/runtime.h        \
+									task/return.h            \
 									task/task.h              \
 									utilities/deserializer.h \
 									utilities/dispatch.h     \
+									utilities/machine.h      \
 									utilities/span.h         \
 									utilities/type_traits.h  \
 									utilities/typedefs.h

--- a/src/data/store.cc
+++ b/src/data/store.cc
@@ -89,7 +89,7 @@ FutureWrapper::FutureWrapper(
     auto mem_kind = find_memory_kind_for_executing_processor();
     assert(!initialize || future_.get_untyped_size() == field_size);
     auto p_init_value = initialize ? future_.get_buffer(mem_kind) : nullptr;
-    buffer_           = Legion::UntypedDeferredValue(field_size, mem_kind, p_init_value);
+    buffer_           = UntypedDeferredValue(field_size, mem_kind, p_init_value);
   }
 }
 

--- a/src/data/store.cc
+++ b/src/data/store.cc
@@ -76,17 +76,29 @@ OutputRegionField& OutputRegionField::operator=(OutputRegionField&& other) noexc
   return *this;
 }
 
+FutureWrapper::FutureWrapper(Domain domain, int32_t field_size) : read_only_{false}, domain_(domain)
+{
+  assert(field_size > 0);
+  auto mem_kind = find_memory_kind_for_executing_processor();
+  buffer_       = Legion::UntypedDeferredValue(field_size, mem_kind);
+}
+
 FutureWrapper::FutureWrapper(Domain domain, Future future) : domain_(domain), future_(future) {}
 
 FutureWrapper::FutureWrapper(const FutureWrapper& other) noexcept
-  : domain_(other.domain_), future_(other.future_)
+  : read_only_(other.read_only_),
+    domain_(other.domain_),
+    future_(other.future_),
+    buffer_(other.buffer_)
 {
 }
 
 FutureWrapper& FutureWrapper::operator=(const FutureWrapper& other) noexcept
 {
-  domain_ = other.domain_;
-  future_ = other.future_;
+  domain_    = other.domain_;
+  future_    = other.future_;
+  read_only_ = other.read_only_;
+  buffer_    = other.buffer_;
   return *this;
 }
 

--- a/src/data/store.h
+++ b/src/data/store.h
@@ -182,8 +182,11 @@ class OutputRegionField {
 class FutureWrapper {
  public:
   FutureWrapper() {}
-  FutureWrapper(Legion::Domain domain, int32_t field_size);
-  FutureWrapper(Legion::Domain domain, Legion::Future future);
+  FutureWrapper(bool read_only,
+                int32_t field_size,
+                Legion::Domain domain,
+                Legion::Future future,
+                bool initialize = false);
 
  public:
   FutureWrapper(const FutureWrapper& other) noexcept;
@@ -223,16 +226,17 @@ class FutureWrapper {
   Legion::Domain domain() const;
 
  public:
-  ReturnValue pack() const { return ReturnValue(rawptr_, field_size_); }
+  ReturnValue pack() const;
 
  private:
   bool read_only_{true};
+  size_t field_size_{0};
   Legion::Domain domain_{};
   Legion::Future future_{};
   Legion::UntypedDeferredValue buffer_{};
 
  private:
-  mutable size_t field_size_{0};
+  mutable bool uninitialized_{true};
   mutable void* rawptr_{nullptr};
 };
 

--- a/src/data/store.h
+++ b/src/data/store.h
@@ -197,12 +197,21 @@ class FutureWrapper {
   AccessorRO<T, DIM> read_accessor() const;
   template <typename T, int32_t DIM>
   AccessorWO<T, DIM> write_accessor() const;
+  template <typename T, int32_t DIM>
+  AccessorRW<T, DIM> read_write_accessor() const;
+  template <typename OP, bool EXCLUSIVE, int32_t DIM>
+  AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(int32_t redop_id) const;
 
  public:
   template <typename T, int32_t DIM>
   AccessorRO<T, DIM> read_accessor(const Legion::Rect<DIM>& bounds) const;
   template <typename T, int32_t DIM>
   AccessorWO<T, DIM> write_accessor(const Legion::Rect<DIM>& bounds) const;
+  template <typename T, int32_t DIM>
+  AccessorRW<T, DIM> read_write_accessor(const Legion::Rect<DIM>& bounds) const;
+  template <typename OP, bool EXCLUSIVE, int32_t DIM>
+  AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(int32_t redop_id,
+                                                 const Legion::Rect<DIM>& bounds) const;
 
  public:
   template <typename VAL>

--- a/src/data/store.inl
+++ b/src/data/store.inl
@@ -143,6 +143,7 @@ Legion::Rect<DIM> RegionField::shape() const
 template <typename T, int DIM>
 AccessorRO<T, DIM> FutureWrapper::read_accessor() const
 {
+  assert(read_only_);
   auto memkind = Legion::Memory::Kind::NO_MEMKIND;
   return AccessorRO<T, DIM>(future_, memkind);
 }
@@ -150,8 +151,33 @@ AccessorRO<T, DIM> FutureWrapper::read_accessor() const
 template <typename T, int DIM>
 AccessorRO<T, DIM> FutureWrapper::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
+  assert(read_only_);
   auto memkind = Legion::Memory::Kind::NO_MEMKIND;
   return AccessorRO<T, DIM>(future_, bounds, memkind);
+}
+
+template <typename T, int DIM>
+AccessorWO<T, DIM> FutureWrapper::write_accessor() const
+{
+  assert(!read_only_);
+  auto acc = AccessorWO<T, DIM>(buffer_);
+  if (nullptr == rawptr_) {
+    rawptr_     = acc.ptr(Legion::Point<DIM>::ZEROES());
+    field_size_ = sizeof(T);
+  }
+  return acc;
+}
+
+template <typename T, int DIM>
+AccessorWO<T, DIM> FutureWrapper::write_accessor(const Legion::Rect<DIM>& bounds) const
+{
+  assert(!read_only_);
+  auto acc = AccessorWO<T, DIM>(buffer_, bounds);
+  if (nullptr == rawptr_) {
+    rawptr_     = acc.ptr(bounds.lo);
+    field_size_ = sizeof(T);
+  }
+  return acc;
 }
 
 template <int32_t DIM>
@@ -163,7 +189,10 @@ Legion::Rect<DIM> FutureWrapper::shape() const
 template <typename VAL>
 VAL FutureWrapper::scalar() const
 {
-  return future_.get_result<VAL>();
+  if (!read_only_)
+    return buffer_.operator Legion::DeferredValue<VAL>().read();
+  else
+    return future_.get_result<VAL>();
 }
 
 template <typename VAL>
@@ -176,9 +205,9 @@ void OutputRegionField::return_data(Buffer<VAL>& buffer, size_t num_elements)
 template <typename T, int DIM>
 AccessorRO<T, DIM> Store::read_accessor() const
 {
-  assert(DIM == dim_ || dim_ == 0);
   if (is_future_) return future_.read_accessor<T, DIM>();
 
+  assert(DIM == dim_ || dim_ == 0);
   if (nullptr != transform_) {
     auto transform = transform_->inverse_transform(dim_);
     return region_field_.read_accessor<T, DIM>(transform);
@@ -189,8 +218,9 @@ AccessorRO<T, DIM> Store::read_accessor() const
 template <typename T, int DIM>
 AccessorWO<T, DIM> Store::write_accessor() const
 {
+  if (is_future_) return future_.write_accessor<T, DIM>();
+
   assert(DIM == dim_ || dim_ == 0);
-  assert(!is_future_);
   if (nullptr != transform_) {
     auto transform = transform_->inverse_transform(dim_);
     return region_field_.write_accessor<T, DIM>(transform);
@@ -226,9 +256,9 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor() const
 template <typename T, int DIM>
 AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
-  assert(DIM == dim_);
   if (is_future_) return future_.read_accessor<T, DIM>(bounds);
 
+  assert(DIM == dim_ || dim_ == 0);
   if (nullptr != transform_) {
     auto transform = transform_->inverse_transform(DIM);
     return region_field_.read_accessor<T, DIM>(bounds, transform);
@@ -239,8 +269,9 @@ AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM>& bounds) const
 template <typename T, int DIM>
 AccessorWO<T, DIM> Store::write_accessor(const Legion::Rect<DIM>& bounds) const
 {
-  assert(!is_future_);
-  assert(DIM == dim_);
+  if (is_future_) return future_.write_accessor<T, DIM>(bounds);
+
+  assert(DIM == dim_ || dim_ == 0);
   if (nullptr != transform_) {
     auto transform = transform_->inverse_transform(DIM);
     return region_field_.write_accessor<T, DIM>(bounds, transform);
@@ -275,7 +306,13 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Legion::Rect<DIM>& b
 template <int32_t DIM>
 Legion::Rect<DIM> Store::shape() const
 {
-  return Legion::Rect<DIM>(domain());
+  auto dom = domain();
+  if (dom.dim > 0)
+    return Legion::Rect<DIM>(dom);
+  else {
+    auto p = Legion::Point<DIM>::ZEROES();
+    return Legion::Rect<DIM>(p, p);
+  }
 }
 
 template <typename VAL>

--- a/src/data/store.inl
+++ b/src/data/store.inl
@@ -144,15 +144,14 @@ template <typename T, int DIM>
 AccessorRO<T, DIM> FutureWrapper::read_accessor() const
 {
   auto memkind = Legion::Memory::Kind::NO_MEMKIND;
-  return AccessorRO<T, DIM>(future_, memkind, sizeof(T), false, false, NULL, sizeof(uint64_t));
+  return AccessorRO<T, DIM>(future_, memkind);
 }
 
 template <typename T, int DIM>
 AccessorRO<T, DIM> FutureWrapper::read_accessor(const Legion::Rect<DIM>& bounds) const
 {
   auto memkind = Legion::Memory::Kind::NO_MEMKIND;
-  return AccessorRO<T, DIM>(
-    future_, bounds, memkind, sizeof(T), false, false, NULL, sizeof(uint64_t));
+  return AccessorRO<T, DIM>(future_, bounds, memkind);
 }
 
 template <int32_t DIM>

--- a/src/legate_c.h
+++ b/src/legate_c.h
@@ -20,6 +20,7 @@
 typedef enum legate_core_task_id_t {
   LEGATE_CORE_INITIALIZE_TASK_ID,
   LEGATE_CORE_FINALIZE_TASK_ID,
+  LEGATE_CORE_EXTRACT_SCALAR_TASK_ID,
   LEGATE_CORE_NUM_TASK_IDS,  // must be last
 } legate_core_task_id_t;
 

--- a/src/mapping/mapper.cc
+++ b/src/mapping/mapper.cc
@@ -80,6 +80,9 @@ class CoreMapper : public Legion::Mapping::NullMapper {
   virtual void configure_context(const MapperContext ctx,
                                  const Task& task,
                                  ContextConfigOutput& output);
+  void map_future_map_reduction(const MapperContext ctx,
+                                const FutureMapReductionInput& input,
+                                FutureMapReductionOutput& output);
   virtual void select_tunable_value(const MapperContext ctx,
                                     const Task& task,
                                     const SelectTunableInput& input,
@@ -315,6 +318,12 @@ void CoreMapper::pack_tunable(const int value, Mapper::SelectTunableOutput& outp
   *result      = value;
   output.value = result;
   output.size  = sizeof(value);
+}
+
+void CoreMapper::map_future_map_reduction(const MapperContext ctx,
+                                          const FutureMapReductionInput& input,
+                                          FutureMapReductionOutput& output)
+{
 }
 
 void CoreMapper::select_tunable_value(const MapperContext ctx,

--- a/src/runtime/context.cc
+++ b/src/runtime/context.cc
@@ -149,4 +149,20 @@ TaskContext::TaskContext(const Legion::Task* task,
   scalars_    = dez.unpack<std::vector<Scalar>>();
 }
 
+ReturnValues TaskContext::pack_return_values() const
+{
+  std::vector<ReturnValue> return_values;
+
+  for (auto& output : outputs_) {
+    if (!output.is_future()) continue;
+    return_values.push_back(output.pack());
+  }
+  for (auto& reduction : reductions_) {
+    if (!reduction.is_future()) continue;
+    return_values.push_back(reduction.pack());
+  }
+
+  return ReturnValues(std::move(return_values));
+}
+
 }  // namespace legate

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -18,6 +18,8 @@
 
 #include "legion.h"
 
+#include "task/return.h"
+
 namespace legate {
 
 class Store;
@@ -108,6 +110,9 @@ class TaskContext {
   std::vector<Store>& outputs() { return outputs_; }
   std::vector<Store>& reductions() { return reductions_; }
   std::vector<Scalar>& scalars() { return scalars_; }
+
+ public:
+  ReturnValues pack_return_values() const;
 
  private:
   const Legion::Task* task_;

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -51,7 +51,10 @@ class ResourceScope {
 
  public:
   bool valid() const { return base_ != -1; }
-  bool in_scope(int64_t resource_id) const { return base_ <= resource_id && resource_id < max_; }
+  bool in_scope(int64_t resource_id) const
+  {
+    return base_ <= resource_id && resource_id < base_ + max_;
+  }
 
  private:
   int64_t base_{-1};

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -16,8 +16,10 @@
 
 #include "legate.h"
 #include "mapping/mapper.h"
+#include "runtime/context.h"
 #include "runtime/projection.h"
 #include "runtime/shard.h"
+#include "utilities/deserializer.h"
 #ifdef LEGATE_USE_CUDA
 #include "gpu/cudalibs.h"
 #endif
@@ -107,6 +109,17 @@ static void finalize_cpu_resource_task(const Task* task,
   // Nothing to do here yet...
 }
 
+static ReturnValues extract_scalar_task(const Task* task,
+                                        const std::vector<PhysicalRegion>& regions,
+                                        Context legion_context,
+                                        Runtime* runtime)
+{
+  TaskContext context(task, regions, legion_context, runtime);
+  auto values = task->futures[0].get_result<ReturnValues>();
+  auto idx    = context.scalars()[0].value<int32_t>();
+  return ReturnValues({values[idx]});
+}
+
 #ifdef LEGATE_USE_CUDA
 static void initialize_gpu_resource_task(const Task* task,
                                          const std::vector<PhysicalRegion>& regions,
@@ -149,10 +162,16 @@ void register_legate_core_tasks(Machine machine, Runtime* runtime, const Library
   const char* initialize_task_name = "Legate Core Resource Initialization";
   runtime->attach_name(
     initialize_task_id, initialize_task_name, false /*mutable*/, true /*local only*/);
+
   const TaskID finalize_task_id  = context.get_task_id(LEGATE_CORE_FINALIZE_TASK_ID);
   const char* finalize_task_name = "Legate Core Resource Finalization";
   runtime->attach_name(
     finalize_task_id, finalize_task_name, false /*mutable*/, true /*local only*/);
+
+  const TaskID extract_scalar_task_id  = context.get_task_id(LEGATE_CORE_EXTRACT_SCALAR_TASK_ID);
+  const char* extract_scalar_task_name = "Legate Core Scalar Extraction";
+  runtime->attach_name(
+    extract_scalar_task_id, extract_scalar_task_name, false /*mutable*/, true /*local only*/);
 
   auto make_registrar = [&](auto task_id, auto* task_name, auto proc_kind) {
     TaskVariantRegistrar registrar(task_id, task_name);
@@ -170,6 +189,12 @@ void register_legate_core_tasks(Machine machine, Runtime* runtime, const Library
   {
     auto registrar = make_registrar(finalize_task_id, finalize_task_name, Processor::LOC_PROC);
     runtime->register_task_variant<finalize_cpu_resource_task>(registrar, LEGATE_CPU_VARIANT);
+  }
+  {
+    auto registrar =
+      make_registrar(extract_scalar_task_id, extract_scalar_task_name, Processor::LOC_PROC);
+    runtime->register_task_variant<ReturnValues, extract_scalar_task>(registrar,
+                                                                      LEGATE_CPU_VARIANT);
   }
 #ifdef LEGATE_USE_CUDA
   {

--- a/src/task/return.cc
+++ b/src/task/return.cc
@@ -21,6 +21,7 @@
 #include "legion.h"
 
 #include "task/return.h"
+#include "utilities/machine.h"
 #ifdef LEGATE_USE_CUDA
 #include <cuda.h>
 #endif
@@ -29,11 +30,19 @@ using namespace Legion;
 
 namespace legate {
 
+ReturnValues::ReturnValues() {}
+
 ReturnValues::ReturnValues(std::vector<ReturnValue>&& return_values)
   : return_values_(std::move(return_values))
 {
-  for (auto& ret : return_values_) buffer_size_ += ret.second;
+  if (return_values_.size() > 1) {
+    buffer_size_ += sizeof(uint32_t);
+    for (auto& ret : return_values_) buffer_size_ += sizeof(uint32_t) + ret.second;
+  } else if (return_values_.size() > 0)
+    buffer_size_ = return_values_[0].second;
 }
+
+ReturnValue ReturnValues::operator[](int32_t idx) const { return return_values_[idx]; }
 
 size_t ReturnValues::legion_buffer_size() const { return buffer_size_; }
 
@@ -44,12 +53,38 @@ void ReturnValues::legion_serialize(void* buffer) const
   auto kind = Processor::get_executing_processor().kind();
   if (kind == Processor::TOC_PROC) cudaDeviceSynchronize();
 #endif
-  for (auto& ret : return_values_) {
-    memcpy(ptr, ret.first, ret.second);
-    ptr += ret.second;
+  if (return_values_.size() > 1) {
+    *reinterpret_cast<size_t*>(ptr) = return_values_.size();
+    ptr += sizeof(uint32_t);
+    for (auto& ret : return_values_) {
+      *reinterpret_cast<uint32_t*>(ptr) = ret.second;
+      ptr += sizeof(uint32_t);
+      memcpy(ptr, ret.first, ret.second);
+      ptr += ret.second;
+    }
+  } else {
+    assert(return_values_.size() == 1);
+    memcpy(ptr, return_values_[0].first, return_values_[0].second);
   }
 }
 
-void ReturnValues::legion_deserialize(const void* buffer) { assert(false); }
+void ReturnValues::legion_deserialize(const void* buffer)
+{
+  auto mem_kind = find_memory_kind_for_executing_processor();
+
+  auto ptr        = static_cast<const int8_t*>(buffer);
+  auto num_values = *reinterpret_cast<const uint32_t*>(ptr);
+  ptr += sizeof(uint32_t);
+  return_values_.resize(num_values);
+
+  for (auto& ret : return_values_) {
+    auto size = *reinterpret_cast<const uint32_t*>(ptr);
+    ptr += sizeof(uint32_t);
+    ret.first  = ptr;
+    ret.second = size;
+    ptr += size;
+  }
+  buffer_size_ = ptr - static_cast<const int8_t*>(buffer);
+}
 
 }  // namespace legate

--- a/src/task/return.cc
+++ b/src/task/return.cc
@@ -1,0 +1,44 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "task/return.h"
+
+namespace legate {
+
+ReturnValues::ReturnValues(std::vector<ReturnValue>&& return_values)
+  : return_values_(std::move(return_values))
+{
+  for (auto& ret : return_values_) buffer_size_ += ret.second;
+}
+
+size_t ReturnValues::legion_buffer_size() const { return buffer_size_; }
+
+void ReturnValues::legion_serialize(void* buffer) const
+{
+  auto ptr = static_cast<int8_t*>(buffer);
+  for (auto& ret : return_values_) {
+    memcpy(ptr, ret.first, ret.second);
+    ptr += ret.second;
+  }
+}
+
+void ReturnValues::legion_deserialize(const void* buffer) { assert(false); }
+
+}  // namespace legate

--- a/src/task/return.cc
+++ b/src/task/return.cc
@@ -18,7 +18,14 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "legion.h"
+
 #include "task/return.h"
+#ifdef LEGATE_USE_CUDA
+#include <cuda.h>
+#endif
+
+using namespace Legion;
 
 namespace legate {
 
@@ -33,6 +40,10 @@ size_t ReturnValues::legion_buffer_size() const { return buffer_size_; }
 void ReturnValues::legion_serialize(void* buffer) const
 {
   auto ptr = static_cast<int8_t*>(buffer);
+#ifdef LEGATE_USE_CUDA
+  auto kind = Processor::get_executing_processor().kind();
+  if (kind == Processor::TOC_PROC) cudaDeviceSynchronize();
+#endif
   for (auto& ret : return_values_) {
     memcpy(ptr, ret.first, ret.second);
     ptr += ret.second;

--- a/src/task/return.h
+++ b/src/task/return.h
@@ -1,0 +1,47 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace legate {
+
+using ReturnValue = std::pair<const void*, size_t>;
+
+struct ReturnValues {
+ public:
+  ReturnValues(std::vector<ReturnValue>&& return_values);
+
+ public:
+  ReturnValues(const ReturnValues&) = default;
+  ReturnValues& operator=(const ReturnValues&) = default;
+
+ public:
+  ReturnValues(ReturnValues&&) = default;
+  ReturnValues& operator=(ReturnValues&&) = default;
+
+ public:
+  size_t legion_buffer_size() const;
+  void legion_serialize(void* buffer) const;
+  void legion_deserialize(const void* buffer);
+
+ private:
+  size_t buffer_size_{0};
+  std::vector<ReturnValue> return_values_;
+};
+
+}  // namespace legate

--- a/src/task/return.h
+++ b/src/task/return.h
@@ -24,6 +24,7 @@ using ReturnValue = std::pair<const void*, size_t>;
 
 struct ReturnValues {
  public:
+  ReturnValues();
   ReturnValues(std::vector<ReturnValue>&& return_values);
 
  public:
@@ -35,13 +36,16 @@ struct ReturnValues {
   ReturnValues& operator=(ReturnValues&&) = default;
 
  public:
+  ReturnValue operator[](int32_t idx) const;
+
+ public:
   size_t legion_buffer_size() const;
   void legion_serialize(void* buffer) const;
   void legion_deserialize(const void* buffer);
 
  private:
   size_t buffer_size_{0};
-  std::vector<ReturnValue> return_values_;
+  std::vector<ReturnValue> return_values_{};
 };
 
 }  // namespace legate

--- a/src/task/task.h
+++ b/src/task/task.h
@@ -23,23 +23,16 @@
 
 #include "runtime/context.h"
 #include "runtime/runtime.h"
+#include "task/return.h"
 #include "utilities/deserializer.h"
 #include "utilities/typedefs.h"
 
 namespace legate {
 
-template <typename T>
-struct ReturnSize {
-  static constexpr int32_t value = sizeof(T);
-};
+// We're going to allow for each task to use only up to 256 scalar output stores
+constexpr size_t LEGATE_MAX_SIZE_SCALAR_RETURN = 2048;
 
-template <>
-struct ReturnSize<void> {
-  static constexpr int32_t value = 0;
-};
-
-template <typename RET_T = void>
-using LegateVariantImpl = RET_T (*)(TaskContext&);
+using LegateVariantImpl = void (*)(TaskContext&);
 
 template <typename T>
 class LegateTask {
@@ -109,49 +102,23 @@ class LegateTask {
   }
 
   // Task wrappers so we can instrument all Legate tasks if we want
-  template <typename RET_T, LegateVariantImpl<RET_T> TASK_PTR>
-  static RET_T legate_task_wrapper(const Legion::Task* task,
-                                   const std::vector<Legion::PhysicalRegion>& regions,
-                                   Legion::Context legion_context,
-                                   Legion::Runtime* runtime)
+  template <LegateVariantImpl TASK_PTR>
+  static ReturnValues legate_task_wrapper(const Legion::Task* task,
+                                          const std::vector<Legion::PhysicalRegion>& regions,
+                                          Legion::Context legion_context,
+                                          Legion::Runtime* runtime)
   {
     show_progress(task, legion_context, runtime);
 
     TaskContext context(task, regions, legion_context, runtime);
-    return (*TASK_PTR)(context);
+    (*TASK_PTR)(context);
+
+    return context.pack_return_values();
   }
 
  public:
   // Methods for registering variants
-  template <LegateVariantImpl<> TASK_PTR>
-  static void register_variant(Legion::ExecutionConstraintSet& execution_constraints,
-                               Legion::TaskLayoutConstraintSet& layout_constraints,
-                               LegateVariantCode var,
-                               Legion::Processor::Kind kind,
-                               bool leaf       = false,
-                               bool inner      = false,
-                               bool idempotent = false)
-  {
-    // Construct the code descriptor for this task so that the library
-    // can register it later when it is ready
-    Legion::CodeDescriptor desc(Legion::LegionTaskWrapper::legion_task_wrapper<
-                                LegateTask<T>::template legate_task_wrapper<void, TASK_PTR>>);
-    auto task_id  = T::TASK_ID;
-    auto ret_size = ReturnSize<void>::value; /*non void return type*/
-
-    T::Registrar::record_variant(task_id,
-                                 T::task_name(),
-                                 desc,
-                                 execution_constraints,
-                                 layout_constraints,
-                                 var,
-                                 kind,
-                                 leaf,
-                                 inner,
-                                 idempotent,
-                                 ret_size);
-  }
-  template <typename RET_T, LegateVariantImpl<RET_T> TASK_PTR>
+  template <LegateVariantImpl TASK_PTR>
   static void register_variant(Legion::ExecutionConstraintSet& execution_constraints,
                                Legion::TaskLayoutConstraintSet& layout_constraints,
                                LegateVariantCode var,
@@ -164,9 +131,8 @@ class LegateTask {
     // can register it later when it is ready
     Legion::CodeDescriptor desc(
       Legion::LegionTaskWrapper::
-        legion_task_wrapper<RET_T, LegateTask<T>::template legate_task_wrapper<RET_T, TASK_PTR>>);
-    auto task_id  = T::TASK_ID;
-    auto ret_size = ReturnSize<RET_T>::value; /*non void return type*/
+        legion_task_wrapper<ReturnValues, LegateTask<T>::template legate_task_wrapper<TASK_PTR>>);
+    auto task_id = T::TASK_ID;
 
     T::Registrar::record_variant(task_id,
                                  T::task_name(),
@@ -178,7 +144,7 @@ class LegateTask {
                                  leaf,
                                  inner,
                                  idempotent,
-                                 ret_size);
+                                 LEGATE_MAX_SIZE_SCALAR_RETURN);
   }
 };
 
@@ -260,87 +226,6 @@ template <typename T>
   RegisterCPUVariant<T, LegateTask<T>, HasCPUVariant::value>::register_variant();
   RegisterOMPVariant<T, LegateTask<T>, HasOMPVariant::value>::register_variant();
   RegisterGPUVariant<T, LegateTask<T>, HasGPUVariant::value>::register_variant();
-}
-
-template <typename T, typename BASE, typename RET, bool HAS_CPU>
-class RegisterCPUVariantWithReturn {
- public:
-  static void register_variant()
-  {
-    Legion::ExecutionConstraintSet execution_constraints;
-    Legion::TaskLayoutConstraintSet layout_constraints;
-    BASE::template register_variant<RET, T::cpu_variant>(execution_constraints,
-                                                         layout_constraints,
-                                                         LEGATE_CPU_VARIANT,
-                                                         Legion::Processor::LOC_PROC,
-                                                         true /*leaf*/);
-  }
-};
-
-template <typename T, typename BASE, typename RET>
-class RegisterCPUVariantWithReturn<T, BASE, RET, false> {
- public:
-  static void register_variant()
-  {
-    // Do nothing
-  }
-};
-
-template <typename T, typename BASE, typename RET, bool HAS_OPENMP>
-class RegisterOMPVariantWithReturn {
- public:
-  static void register_variant()
-  {
-    Legion::ExecutionConstraintSet execution_constraints;
-    Legion::TaskLayoutConstraintSet layout_constraints;
-    BASE::template register_variant<RET, T::omp_variant>(execution_constraints,
-                                                         layout_constraints,
-                                                         LEGATE_OMP_VARIANT,
-                                                         Legion::Processor::OMP_PROC,
-                                                         true /*leaf*/);
-  }
-};
-
-template <typename T, typename BASE, typename RET>
-class RegisterOMPVariantWithReturn<T, BASE, RET, false> {
- public:
-  static void register_variant()
-  {
-    // Do nothing
-  }
-};
-
-template <typename T, typename BASE, typename RET, bool HAS_GPU>
-class RegisterGPUVariantWithReturn {
- public:
-  static void register_variant()
-  {
-    Legion::ExecutionConstraintSet execution_constraints;
-    Legion::TaskLayoutConstraintSet layout_constraints;
-    BASE::template register_variant<RET, T::gpu_variant>(execution_constraints,
-                                                         layout_constraints,
-                                                         LEGATE_GPU_VARIANT,
-                                                         Legion::Processor::TOC_PROC,
-                                                         true /*leaf*/);
-  }
-};
-
-template <typename T, typename BASE, typename RET>
-class RegisterGPUVariantWithReturn<T, BASE, RET, false> {
- public:
-  static void register_variant()
-  {
-    // Do nothing
-  }
-};
-
-template <typename T>
-template <typename RET_T, typename REDUC_T>
-/*static*/ void LegateTask<T>::register_variants_with_return()
-{
-  RegisterCPUVariantWithReturn<T, LegateTask<T>, RET_T, HasCPUVariant::value>::register_variant();
-  RegisterOMPVariantWithReturn<T, LegateTask<T>, RET_T, HasOMPVariant::value>::register_variant();
-  RegisterGPUVariantWithReturn<T, LegateTask<T>, REDUC_T, HasGPUVariant::value>::register_variant();
 }
 
 class LegateTaskRegistrar {

--- a/src/task/task.h
+++ b/src/task/task.h
@@ -29,7 +29,7 @@
 
 namespace legate {
 
-// We're going to allow for each task to use only up to 256 scalar output stores
+// We're going to allow for each task to use only up to 170 scalar output stores
 constexpr size_t LEGATE_MAX_SIZE_SCALAR_RETURN = 2048;
 
 using LegateVariantImpl = void (*)(TaskContext&);

--- a/src/utilities/deserializer.cc
+++ b/src/utilities/deserializer.cc
@@ -71,8 +71,8 @@ void Deserializer::_unpack(Scalar& value)
 
 void Deserializer::_unpack(FutureWrapper& value)
 {
-  auto future = futures_[0];
-  futures_    = futures_.subspan(1);
+  auto read_only  = unpack<bool>();
+  auto field_size = unpack<int32_t>();
 
   auto point = unpack<std::vector<int64_t>>();
   Domain domain;
@@ -82,7 +82,12 @@ void Deserializer::_unpack(FutureWrapper& value)
     domain.rect_data[idx + domain.dim] = point[idx] - 1;
   }
 
-  value = FutureWrapper(domain, future);
+  if (read_only) {
+    auto future = futures_[0];
+    futures_    = futures_.subspan(1);
+    value       = FutureWrapper(domain, future);
+  } else
+    value = FutureWrapper(domain, field_size);
 }
 
 void Deserializer::_unpack(RegionField& value)

--- a/src/utilities/deserializer.cc
+++ b/src/utilities/deserializer.cc
@@ -31,6 +31,8 @@ Deserializer::Deserializer(const Task* task, const std::vector<PhysicalRegion>& 
   auto runtime = Runtime::get_runtime();
   auto ctx     = Runtime::get_context();
   runtime->get_output_regions(ctx, outputs_);
+
+  first_task_ = !task->is_index_space || (task->index_point == task->index_domain.lo());
 }
 
 void Deserializer::_unpack(LegateTypeCode& value)
@@ -71,8 +73,9 @@ void Deserializer::_unpack(Scalar& value)
 
 void Deserializer::_unpack(FutureWrapper& value)
 {
-  auto read_only  = unpack<bool>();
-  auto field_size = unpack<int32_t>();
+  auto read_only   = unpack<bool>();
+  auto has_storage = unpack<bool>();
+  auto field_size  = unpack<int32_t>();
 
   auto point = unpack<std::vector<int64_t>>();
   Domain domain;
@@ -82,12 +85,13 @@ void Deserializer::_unpack(FutureWrapper& value)
     domain.rect_data[idx + domain.dim] = point[idx] - 1;
   }
 
-  if (read_only) {
-    auto future = futures_[0];
-    futures_    = futures_.subspan(1);
-    value       = FutureWrapper(domain, future);
-  } else
-    value = FutureWrapper(domain, field_size);
+  Future future;
+  if (has_storage) {
+    future   = futures_[0];
+    futures_ = futures_.subspan(1);
+  }
+
+  value = FutureWrapper(read_only, field_size, domain, future, has_storage && first_task_);
 }
 
 void Deserializer::_unpack(RegionField& value)

--- a/src/utilities/deserializer.h
+++ b/src/utilities/deserializer.h
@@ -75,6 +75,7 @@ class Deserializer {
   std::unique_ptr<StoreTransform> unpack_transform();
 
  private:
+  bool first_task_;
   Span<const Legion::PhysicalRegion> regions_;
   Span<const Legion::Future> futures_;
   Span<const int8_t> task_args_;

--- a/src/utilities/machine.cc
+++ b/src/utilities/machine.cc
@@ -1,0 +1,30 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "utilities/machine.h"
+
+using namespace Legion;
+
+namespace legate {
+
+Memory::Kind find_memory_kind_for_executing_processor()
+{
+  auto proc = Processor::get_executing_processor();
+  return proc.kind() == Processor::Kind::TOC_PROC ? Memory::Kind::GPU_FB_MEM
+                                                  : Memory::Kind::SYSTEM_MEM;
+}
+
+}  // namespace legate

--- a/src/utilities/machine.cc
+++ b/src/utilities/machine.cc
@@ -23,7 +23,7 @@ namespace legate {
 Memory::Kind find_memory_kind_for_executing_processor()
 {
   auto proc = Processor::get_executing_processor();
-  return proc.kind() == Processor::Kind::TOC_PROC ? Memory::Kind::GPU_FB_MEM
+  return proc.kind() == Processor::Kind::TOC_PROC ? Memory::Kind::Z_COPY_MEM
                                                   : Memory::Kind::SYSTEM_MEM;
 }
 

--- a/src/utilities/machine.h
+++ b/src/utilities/machine.h
@@ -1,0 +1,25 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "legion.h"
+
+namespace legate {
+
+Legion::Memory::Kind find_memory_kind_for_executing_processor();
+
+}  // namespace legate


### PR DESCRIPTION
This PR is to revise the task wrapper for scalar outputs in order to insulate client libraries from legate stores' underlying storage (i.e., whether they are future-backed or region-backed). We will also allow legate tasks to return multiple scalar outputs with this PR.