### PR TITLE
Switch the default Legion branch to control_replication

### DIFF
--- a/install.py
+++ b/install.py
@@ -32,6 +32,8 @@ sys.stdout.reconfigure(line_buffering=True)
 
 os_name = platform.system()
 
+default_legion_branch = "control_replication"
+
 
 class BooleanFlag(argparse.Action):
     def __init__(
@@ -114,14 +116,18 @@ def find_active_python_version_and_path():
 
 
 def find_default_legion_branch(core_dir):
-    branch = verbose_check_output(
-        ["git", "symbolic-ref", "--short", "HEAD"], cwd=core_dir
-    )
+    try:
+        branch = verbose_check_output(
+            ["git", "symbolic-ref", "--short", "HEAD"], cwd=core_dir
+        )
+    except subprocess.CalledProcessError:
+        return default_legion_branch
+
     branch = branch.decode().strip()
     if branch in ("master", "main"):
         return "legate_stable"
     else:
-        return "control_replication"
+        return default_legion_branch
 
 
 def git_clone(repo_dir, url, branch=None, tag=None, commit=None):

--- a/install.py
+++ b/install.py
@@ -113,8 +113,10 @@ def find_active_python_version_and_path():
     return version, paths[0]
 
 
-def find_default_legion_branch():
-    branch = verbose_check_output(["git", "symbolic-ref", "--short", "HEAD"])
+def find_default_legion_branch(core_dir):
+    branch = verbose_check_output(
+        ["git", "symbolic-ref", "--short", "HEAD"], cwd=core_dir
+    )
     branch = branch.decode().strip()
     if branch in ("master", "main"):
         return "legate_stable"
@@ -549,13 +551,13 @@ def install(
     legion_branch,
     unknown,
 ):
-    if legion_branch is None:
-        legion_branch = find_default_legion_branch()
-
     global verbose_global
     verbose_global = verbose
 
     legate_core_dir = os.path.dirname(os.path.realpath(__file__))
+
+    if legion_branch is None:
+        legion_branch = find_default_legion_branch(legate_core_dir)
 
     cmake_config = os.path.join(legate_core_dir, ".cmake.json")
     dump_json_config(cmake_config, cmake)


### PR DESCRIPTION
This PR is to use the `control_replication` branch as the default Legion branch for all our development work so that we can keep `legate_stable` really stable. The install script now checks if we're on one of the development branches (i.e., we're not on either `main` or `master`) and if so, picks `control_replication` and `legate_stable` otherwise. The script will need to be updated once `control_replication` in Legion is merged with the `master`.