### PR TITLE
Use data structures with deterministic iteration order in the solver

### DIFF
--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -18,6 +18,7 @@ import legate.core.types as ty
 from .launcher import CopyLauncher, TaskLauncher
 from .solver import EqClass
 from .store import Store
+from .utils import OrderedSet
 
 
 class Operation(object):
@@ -30,7 +31,7 @@ class Operation(object):
         self._scalar_outputs = []
         self._scalar_reductions = []
         self._constraints = EqClass()
-        self._broadcasts = set()
+        self._broadcasts = OrderedSet()
 
     @property
     def context(self):
@@ -70,9 +71,9 @@ class Operation(object):
 
     def get_all_stores(self):
         stores = (
-            set(self._inputs)
-            | set(self._outputs)
-            | set(store for (store, _) in self._reductions)
+            OrderedSet(self._inputs)
+            | OrderedSet(self._outputs)
+            | OrderedSet(store for (store, _) in self._reductions)
         )
         return stores
 

--- a/legate/core/solver.py
+++ b/legate/core/solver.py
@@ -16,6 +16,7 @@
 from .legion import Future, Rect
 from .partition import NoPartition
 from .shape import Shape
+from .utils import OrderedSet
 
 
 class EqClass(object):
@@ -152,7 +153,7 @@ class Partitioner(object):
     def _solve_broadcast_constraints(
         self, stores, constraints, broadcasts, partitions
     ):
-        to_remove = set()
+        to_remove = OrderedSet()
         for store in stores:
             if not (store.kind is Future or store in broadcasts):
                 continue
@@ -174,7 +175,7 @@ class Partitioner(object):
     def _solve_unbound_constraints(
         self, stores, constraints, partitions, fspaces
     ):
-        to_remove = set()
+        to_remove = OrderedSet()
         for store in stores:
             if not store.unbound:
                 continue
@@ -217,9 +218,9 @@ class Partitioner(object):
         return all_restrictions
 
     def partition_stores(self):
-        stores = set()
+        stores = OrderedSet()
         constraints = EqClass()
-        broadcasts = set()
+        broadcasts = OrderedSet()
         for op in self._ops:
             stores.update(op.get_all_stores())
             constraints.union(op.constraints)

--- a/legate/core/utils.py
+++ b/legate/core/utils.py
@@ -13,6 +13,44 @@
 # limitations under the License.
 #
 
+from collections.abc import MutableSet
+
+
+class OrderedSet(MutableSet):
+    """
+    A set() variant whose iterator returns elements in insertion order.
+
+    The implementation of this class piggybacks off of the corresponding
+    iteration order guarantee for dict(), starting with Python 3.7. This is
+    useful for guaranteeing symmetric execution of algorithms on different
+    shards in a replicated context.
+    """
+
+    def __init__(self, copy_from=None):
+        self._dict = {}
+        if copy_from is not None:
+            for obj in copy_from:
+                self.add(obj)
+
+    def add(self, obj):
+        self._dict[obj] = None
+
+    def update(self, other):
+        for obj in other:
+            self.add(obj)
+
+    def discard(self, obj):
+        self._dict.pop(obj, None)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __contains__(self, obj):
+        return obj in self._dict
+
+    def __iter__(self):
+        return iter(self._dict)
+
 
 def cast_tuple(value):
     return value if isinstance(value, tuple) else tuple(value)


### PR DESCRIPTION
With non-deterministic iteration orders we may end up emitting
runtime calls in a different order on different shards, thus
causing control replication violations.