### PR TITLE
Fixes for transformations

### DIFF
--- a/legate/core/transform.py
+++ b/legate/core/transform.py
@@ -20,6 +20,10 @@ from .partition import NoPartition, Restriction, Tiling
 from .shape import Shape
 
 
+class NonInvertibleError(Exception):
+    pass
+
+
 class Transform(object):
     def __repr__(self):
         return str(self)
@@ -416,7 +420,7 @@ class Delinearize(Transform):
                     new_offset,
                 )
             else:
-                raise ValueError(f"Unsupported partition: {partition}")
+                raise NonInvertibleError()
         else:
             raise ValueError(
                 f"Unsupported partition: {type(partition).__name__}"


### PR DESCRIPTION
This PR includes a fix for a bug that was converting a domain with a transformation stack in an incorrect order. This also has a change to raise a more informative error message when someone tries to create a slice that corresponds to a non-contiguous subset of a store.