### PR TITLE
Improve support for incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .#*
 .DS_Store
 *.a
+*.d
 *.o
 *.so
 *.gz

--- a/install.py
+++ b/install.py
@@ -716,7 +716,7 @@ def install(
         openmp,
         spy,
         gasnet,
-        True,
+        clean_first,
         thread_count,
         verbose,
         unknown,

--- a/install.py
+++ b/install.py
@@ -256,7 +256,6 @@ def build_legion(
     pylib_name,
     maxdim,
     maxfields,
-    clean_first,
     extra_flags,
     thread_count,
     verbose,
@@ -270,11 +269,10 @@ def build_legion(
 
     if cmake:
         build_dir = os.path.join(legion_src_dir, "build")
-        if clean_first:
-            try:
-                shutil.rmtree(build_dir)
-            except FileNotFoundError:
-                pass
+        try:
+            shutil.rmtree(build_dir)
+        except FileNotFoundError:
+            pass
         if not os.path.exists(build_dir):
             os.mkdir(build_dir)
         flags = (
@@ -392,10 +390,7 @@ def build_legion(
         )
 
         legion_python_dir = os.path.join(legion_src_dir, "bindings", "python")
-        if clean_first:
-            verbose_check_call(
-                ["make"] + flags + ["clean"], cwd=legion_python_dir
-            )
+        verbose_check_call(["make"] + flags + ["clean"], cwd=legion_python_dir)
         verbose_check_call(
             ["make"] + flags + ["-j", str(thread_count), "install"],
             cwd=legion_python_dir,
@@ -666,42 +661,38 @@ def install(
 
     # Build Legion from scratch.
     legion_src_dir = os.path.join(legate_core_dir, "legion")
-    # Check to see if Legion is up-to-date or get it if it isn't
-    if os.path.exists(legion_src_dir):
-        if clean_first:
-            # Don't update Legion if not doing a clean build, to avoid
-            # spurious build errors.
+    if clean_first or not os.path.exists(legion_src_dir):
+        if os.path.exists(legion_src_dir):
             update_legion(legion_src_dir, branch=legion_branch)
-    else:
-        install_legion(legion_src_dir, branch=legion_branch)
-    build_legion(
-        legion_src_dir,
-        install_dir,
-        cmake,
-        cmake_exe,
-        cuda_dir,
-        debug,
-        debug_release,
-        check_bounds,
-        cuda,
-        arch,
-        openmp,
-        llvm,
-        hdf,
-        spy,
-        gasnet,
-        gasnet_dir,
-        conduit,
-        no_hijack,
-        pyversion,
-        pylib_name,
-        maxdim,
-        maxfields,
-        clean_first,
-        extra_flags,
-        thread_count,
-        verbose,
-    )
+        else:
+            install_legion(legion_src_dir, branch=legion_branch)
+        build_legion(
+            legion_src_dir,
+            install_dir,
+            cmake,
+            cmake_exe,
+            cuda_dir,
+            debug,
+            debug_release,
+            check_bounds,
+            cuda,
+            arch,
+            openmp,
+            llvm,
+            hdf,
+            spy,
+            gasnet,
+            gasnet_dir,
+            conduit,
+            no_hijack,
+            pyversion,
+            pylib_name,
+            maxdim,
+            maxfields,
+            extra_flags,
+            thread_count,
+            verbose,
+        )
 
     build_legate_core(
         install_dir,

--- a/src/core.mk
+++ b/src/core.mk
@@ -39,12 +39,6 @@ GEN_CPU_SRC	+= core/gpu/cudalibs.cc
 endif
 
 # Header files that we need to have installed for client legate libraries
-INSTALL_PATHS = core/data      \
-								core/mapping   \
-								core/runtime   \
-								core/task      \
-								core/utilities
-
 INSTALL_HEADERS = legate.h                        \
 									legate_defines.h                \
 									legate_preamble.h               \

--- a/src/legate.mk
+++ b/src/legate.mk
@@ -165,30 +165,25 @@ endif
 
 .PHONY: all
 all: $(DLIB)
+
 .PHONY: install
 ifdef PREFIX
-INSTALL_PATHS ?=
 INSTALL_HEADERS ?=
-ifneq ($(strip $(BOOTSTRAP)), 1)
-install: $(DLIB)
-	@echo "Installing $(DLIB) into $(PREFIX)..."
-	@mkdir -p $(PREFIX)/include
-	@$(foreach path,$(INSTALL_PATHS),mkdir -p $(PREFIX)/include/$(path);)
-	@$(foreach file,$(INSTALL_HEADERS),cp $(file) $(PREFIX)/include/$(file);)
-	@mkdir -p $(PREFIX)/lib
-	@cp $(DLIB) $(PREFIX)/lib/$(DLIB)
-	@echo "Installation complete"
-else
-install: $(DLIB)
-	@echo "Installing $(DLIB) into $(PREFIX)..."
-	@mkdir -p $(PREFIX)/include
-	@$(foreach path,$(INSTALL_PATHS),mkdir -p $(PREFIX)/include/$(path);)
-	@$(foreach file,$(INSTALL_HEADERS),cp $(file) $(PREFIX)/include/$(file);)
-	@mkdir -p $(PREFIX)/lib
-	@cp $(DLIB) $(PREFIX)/lib/$(DLIB)
-	@mkdir -p $(PREFIX)/share/legate
-	@cp legate.mk $(PREFIX)/share/legate
-	@echo "Installation complete"
+install: $(PREFIX)/lib/$(DLIB) $(addprefix $(PREFIX)/include/,$(INSTALL_HEADERS))
+$(PREFIX)/include/%.h: %.h
+	mkdir -p $(dir $@)
+	cp $< $@
+$(PREFIX)/include/%.inl: %.inl
+	mkdir -p $(dir $@)
+	cp $< $@
+$(PREFIX)/lib/$(DLIB): $(DLIB)
+	mkdir -p $(dir $@)
+	cp $< $@
+ifeq ($(strip $(BOOTSTRAP)), 1)
+install: $(PREFIX)/share/legate/legate.mk # in addition to items above
+$(PREFIX)/share/legate/legate.mk: legate.mk
+	mkdir -p $(dir $@)
+	cp $< $@
 endif
 else
 install:


### PR DESCRIPTION
Now `install.py --noclean` will work even if all outstanding changes are in header files, and it will automatically know to recompile downstream libraries when relevant core header files have changed.