### PR TITLE
Allow scalars to own buffers

### DIFF
--- a/src/core/data/scalar.cc
+++ b/src/core/data/scalar.cc
@@ -19,9 +19,40 @@
 
 namespace legate {
 
+Scalar::Scalar(const Scalar& other) : own_(other.own_), tuple_(other.tuple_), code_(other.code_)
+{
+  copy(other);
+}
+
 Scalar::Scalar(bool tuple, LegateTypeCode code, const void* data)
   : tuple_(tuple), code_(code), data_(data)
 {
+}
+
+Scalar::~Scalar()
+{
+  if (own_)
+    // We know we own this buffer
+    free(const_cast<void*>(data_));
+}
+
+Scalar& Scalar::operator=(const Scalar& other)
+{
+  own_   = other.own_;
+  tuple_ = other.tuple_;
+  code_  = other.code_;
+  copy(other);
+}
+
+void Scalar::copy(const Scalar& other)
+{
+  if (other.own_) {
+    auto size   = other.size();
+    auto buffer = malloc(size);
+    memcpy(buffer, other.data_, size);
+    data_ = buffer;
+  } else
+    data_ = other.data_;
 }
 
 struct elem_size_fn {

--- a/src/core/data/scalar.h
+++ b/src/core/data/scalar.h
@@ -24,16 +24,22 @@ namespace legate {
 
 class Scalar {
  public:
-  Scalar()              = default;
-  Scalar(const Scalar&) = default;
+  Scalar() = default;
+  Scalar(const Scalar& other);
   Scalar(bool tuple, LegateTypeCode code, const void* data);
+  ~Scalar();
 
  public:
   template <typename T>
   Scalar(T value);
+  template <typename T>
+  Scalar(const std::vector<T>& values);
 
  public:
-  Scalar& operator=(const Scalar&) = default;
+  Scalar& operator=(const Scalar& other);
+
+ private:
+  void copy(const Scalar& other);
 
  public:
   bool is_tuple() const { return tuple_; }
@@ -47,6 +53,7 @@ class Scalar {
   const void* ptr() const { return data_; }
 
  private:
+  bool own_{false};
   bool tuple_{false};
   LegateTypeCode code_{MAX_TYPE_NUMBER};
   const void* data_;

--- a/src/core/data/scalar.inl
+++ b/src/core/data/scalar.inl
@@ -17,8 +17,22 @@
 namespace legate {
 
 template <typename T>
-Scalar::Scalar(T value) : tuple_(false), code_(legate_type_code_of<T>), data_(new T(value))
+Scalar::Scalar(T value) : own_(true), tuple_(false), code_(legate_type_code_of<T>)
 {
+  auto buffer = malloc(sizeof(T));
+  memcpy(buffer, &value, sizeof(T));
+  data_ = buffer;
+}
+
+template <typename T>
+Scalar::Scalar(const std::vector<T>& values)
+  : own_(true), tuple_(true), code_(legate_type_code_of<T>)
+{
+  auto data_size                  = sizeof(T) * values.size();
+  auto buffer                     = malloc(sizeof(uint32_t) + data_size);
+  *static_cast<uint32_t*>(buffer) = values.size();
+  memcpy(static_cast<int8_t*>(buffer) + sizeof(uint32_t), values.data(), data_size);
+  data_ = buffer;
 }
 
 template <typename VAL>


### PR DESCRIPTION
This PR adds a code path to `Scalar` to allow scalars to own buffers.