### PR TITLE
Replace math.prod with itertools.product

### DIFF
--- a/legate/core/io.py
+++ b/legate/core/io.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from math import prod
+from itertools import product as prod
 from typing import Iterable, Tuple, Union
 
 from legion_cffi import ffi  # Make sure we only have one ffi instance


### PR DESCRIPTION
This PR is to use `itertools.product` instead of `math.prod`, as the latter is available only in Python >= 3.8 and we haven't bumped up the supported Python version yet.