### PR TITLE
bug fix in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -104,7 +104,7 @@ def find_active_python_version_and_path():
     paths = [os.path.join(cv[p], cv["LDLIBRARY"]) for p in ("LIBDIR", "LIBPL")]
     # ensure that static libraries are replaced with the dynamic version
     paths = [
-        p.replace(".a", ".dylib" if os_name == "Darwin" else ".so")
+        os.path.splitext(p)[0] + (".dylib" if os_name == "Darwin" else ".so")
         for p in paths
     ]
     paths = [p for p in paths if os.path.isfile(p)]


### PR DESCRIPTION
In `find_active_python_version_and_path` function, the `p.replace(".a", ".dylib" if os_name == "Darwin" else ".so")` will lead to the bug if the directory path including the `.a` substring, e.g. `/home/software.ihep.ac.cn/python/libxxx.a` will be replaced with 
`/home/software.ihep.soc.cn/python/libxxx.so`, therefore a simple fix for this bug. 