### PR TITLE
Fix for `set_storage`

### DIFF
--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -601,7 +601,7 @@ class TaskLauncher(object):
         )
 
     def add_reduction(self, store, proj, tag=0, flags=0, read_write=False):
-        if read_write and not store.scalar:
+        if read_write and store.kind is not Future:
             self.add_store(
                 self._reductions,
                 store,

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -17,6 +17,7 @@ import legate.core.types as ty
 
 from .constraints import PartSym
 from .launcher import CopyLauncher, TaskLauncher
+from .legion import Future
 from .store import Store
 from .utils import OrderedSet
 
@@ -108,7 +109,7 @@ class Operation(object):
 
     def add_output(self, store, partition=None):
         self._check_store(store)
-        if store.scalar:
+        if store.kind is Future:
             self._scalar_outputs.append(len(self._outputs))
         if partition is None:
             partition = self._get_unique_partition(store)
@@ -117,7 +118,7 @@ class Operation(object):
 
     def add_reduction(self, store, redop, partition=None):
         self._check_store(store)
-        if store.scalar:
+        if store.kind is Future:
             self._scalar_reductions.append(len(self._reductions))
         if partition is None:
             partition = self._get_unique_partition(store)

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -609,13 +609,18 @@ class Store(object):
         return my_tile.tile_shape.volume()
 
     def set_storage(self, storage):
-        assert type(storage) is self._kind
+        # We should never set region fields manually
+        assert (
+            self._kind is Future and type(storage) is Future
+        ) or self._storage is None
         self._storage = storage
         if self._shape is None:
             assert isinstance(storage, RegionField)
             self._shape = storage.shape
         else:
             assert isinstance(storage, Future)
+        if self._parent is not None:
+            self._parent.set_storage(storage)
 
     def invert_partition(self, partition):
         if self._parent is not None:


### PR DESCRIPTION
This PR fixes two issues: 1) the launcher wasn't tagging a store promoted from another future-backed store as a future-backed store; 2) `set_storage` wasn't updating the parent's storage, leading to a bi-furcation.