### PR TITLE
Flag to use empty tasks

### DIFF
--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -33,6 +33,8 @@ static const char* const core_library_name = "legate.core";
 
 /*static*/ bool Core::show_progress = false;
 
+/*static*/ bool Core::use_empty_task = false;
+
 /*static*/ void Core::parse_config(void)
 {
 #ifndef LEGATE_USE_CUDA
@@ -64,6 +66,9 @@ static const char* const core_library_name = "legate.core";
 #endif
   const char* progress = getenv("LEGATE_SHOW_PROGRESS");
   if (progress != NULL) show_progress = true;
+
+  const char* empty_task = getenv("LEGATE_EMPTY_TASK");
+  if (empty_task != NULL && atoi(empty_task) > 0) use_empty_task = true;
 }
 
 static ReturnValues extract_scalar_task(const Task* task,

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -34,6 +34,7 @@ class Core {
  public:
   // Configuration settings
   static bool show_progress;
+  static bool use_empty_task;
 };
 
 }  // namespace legate

--- a/src/core/task/task.h
+++ b/src/core/task/task.h
@@ -110,7 +110,7 @@ class LegateTask {
     show_progress(task, legion_context, runtime);
 
     TaskContext context(task, regions, legion_context, runtime);
-    (*TASK_PTR)(context);
+    if (!Core::use_empty_task) (*TASK_PTR)(context);
 
     return context.pack_return_values();
   }


### PR DESCRIPTION
This PR adds an environment variable through which users can run the code with empty tasks. This is going to be useful to study the runtime overhead.