### PR TITLE
Support for offline device linking

### DIFF
--- a/src/legate.mk
+++ b/src/legate.mk
@@ -58,6 +58,8 @@ NVCC_FLAGS ?=
 NVCC_FLAGS += -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda -ccbin=$(CXX)
 NVCC_FLAGS += -I$(LEGATE_DIR)/include
 
+DEVICE_LD_FLAGS ?=
+
 ifeq ($(strip $(DEBUG)),1)
 ifeq ($(strip $(DARWIN)),1)
 CC_FLAGS   += -O0 -glldb
@@ -123,7 +125,8 @@ NVCC_FLAGS	+= -DAMPERE_ARCH
 endif
 
 COMMA=,
-NVCC_FLAGS += $(foreach X,$(subst $(COMMA), ,$(GPU_ARCH)),-gencode arch=compute_$(X)$(COMMA)code=sm_$(X))
+ARCH_FLAGS = $(foreach X,$(subst $(COMMA), ,$(GPU_ARCH)),-gencode arch=compute_$(X)$(COMMA)code=sm_$(X))
+NVCC_FLAGS += $(ARCH_FLAGS)
 CC_FLAGS	+= -DLEGATE_USE_CUDA -I$(CUDA)/include
 NVCC_FLAGS	+= -DLEGATE_USE_CUDA -I$(CUDA)/include
 LD_FLAGS	+= -L$(CUDA)/lib -L$(CUDA)/lib64
@@ -133,14 +136,22 @@ GEN_SRC		?=
 GEN_CPU_SRC	?=
 GEN_CPU_SRC	+= $(GEN_SRC)
 
+GEN_GPU_SRC	?=
+
+GEN_DEVICE_SRC ?=
+
 GEN_CPU_DEPS	:= $(GEN_CPU_SRC:.cc=.cc.d)
 GEN_CPU_OBJS	:= $(GEN_CPU_SRC:.cc=.cc.o)
 ifeq ($(strip $(USE_CUDA)),1)
-GEN_GPU_DEPS	:= $(GEN_GPU_SRC:.cu=.cu.d)
+GEN_GPU_DEPS	:= $(GEN_GPU_SRC:.cu=.cu.d) $(GEN_DEVICE_SRC:.cu=.cu.d)
 GEN_GPU_OBJS	:= $(GEN_GPU_SRC:.cu=.cu.o)
+GEN_DEVICE_OBJS	:= $(GEN_DEVICE_SRC:.cu=.cu.o)
+GEN_DEVICE_LINK_OBJS	:= $(GEN_DEVICE_SRC:.cu=.cu.dlink.o)
 else
 GEN_GPU_DEPS	:=
 GEN_GPU_OBJS	:=
+GEN_DEVICE_OBJS	:=
+GEN_DEVICE_LINK_OBJS	:=
 endif
 
 CC_FLAGS += -fPIC
@@ -190,7 +201,7 @@ install:
 	$(error Must specify PREFIX for installation)
 endif
 
-$(DLIB) : $(GEN_CPU_OBJS) $(GEN_GPU_OBJS)
+$(DLIB) : $(GEN_CPU_OBJS) $(GEN_GPU_OBJS) $(GEN_DEVICE_OBJS) $(GEN_DEVICE_LINK_OBJS)
 	@echo "---> Linking objects into one library: $(DLIB)"
 	$(CXX) -o $(DLIB) $^ $(LD_FLAGS)
 
@@ -205,8 +216,15 @@ $(GEN_GPU_OBJS) : %.cu.o : %.cu $(LEGION_DEFINES_HEADER) $(REALM_DEFINES_HEADER)
 	$(NVCC) -o $<.d -M -MT $@ $< $(INC_FLAGS) $(NVCC_FLAGS)
 	$(NVCC) -o $@ -c $< $(INC_FLAGS) $(NVCC_FLAGS)
 
+$(GEN_DEVICE_OBJS) : %.cu.o : %.cu $(LEGION_DEFINES_HEADER) $(REALM_DEFINES_HEADER)
+	$(NVCC) -o $<.d -M -MT $@ $< $(INC_FLAGS) $(NVCC_FLAGS)
+	$(NVCC) -o $<.o -dc $< $(INC_FLAGS) $(NVCC_FLAGS)
+
+$(GEN_DEVICE_LINK_OBJS) : %.cu.dlink.o : %.cu.o
+	$(NVCC) -o $@ $< -dlink $(ARCH_FLAGS) $(DEVICE_LD_FLAGS) --compiler-options -fPIC
+
 clean:
-	$(RM) -f $(DLIB) $(GEN_CPU_DEPS) $(GEN_CPU_OBJS) $(GEN_GPU_DEPS) $(GEN_GPU_OBJS)
+	$(RM) -f $(DLIB) $(GEN_CPU_DEPS) $(GEN_CPU_OBJS) $(GEN_GPU_DEPS) $(GEN_GPU_OBJS) $(GEN_DEVICE_OBJS) $(GEN_DEVICE_LINK_OBJS)
 
 # disable gmake's default rule for building % from %.o
 % : %.o


### PR DESCRIPTION
This PR contains changes to support offline device linking. From now on, any CUDA source files for device linking need to be added to `GEN_DEVICE_SRC` and linker flags for the device linking can be passed via `DEVICE_LD_FLAGS`.