### PR TITLE
Mapper fix for tasks with no store arguments

### DIFF
--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -312,6 +312,10 @@ class BaseMapper : public Legion::Mapping::Mapper, public LegateMapper {
                          const Legion::Task& task,
                          const SliceTaskInput& input,
                          SliceTaskOutput& output);
+  void slice_round_robin_task(const Legion::Mapping::MapperContext ctx,
+                              const Legion::Task& task,
+                              const SliceTaskInput& input,
+                              SliceTaskOutput& output);
 
  protected:
   static inline bool physical_sort_func(


### PR DESCRIPTION
This PR is to correctly distribute manually parallelized tasks having no store arguments.