### PR TITLE
Quickfix: Fix non-annotations on 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 legate/core/install_info.py
 /build
 /legion
-/install
+/install*
 config.mk
 /docs/legate/core/build
 *.egg-info

--- a/legate/core/legion.py
+++ b/legate/core/legion.py
@@ -17,7 +17,15 @@ from __future__ import annotations
 import os
 import struct  # For packing and unpacking C data into/out-of futures
 import weakref
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
 
 if TYPE_CHECKING:
     from .context import Context
@@ -1524,7 +1532,8 @@ class FieldID:
         return self._type
 
 
-FieldListLike = Union[int, FieldID, list[int], list[FieldID]]
+# todo: (bev) use list[...] when feasible
+FieldListLike = Union[int, FieldID, List[int], List[FieldID]]
 
 
 class Region:

--- a/legate/core/projection.py
+++ b/legate/core/projection.py
@@ -14,7 +14,7 @@
 #
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 from legion_cffi import ffi  # Make sure we only have one ffi instance
 
@@ -81,7 +81,8 @@ class ProjExpr:
         return ProjExpr(self._dim, self._weight, self._offset + other)
 
 
-Point = tuple[Union[ProjExpr, int], ...]
+# todo: (bev) use tuple[...] when feasible
+Point = Tuple[Union[ProjExpr, int], ...]
 
 
 def execute_functor_symbolically(

--- a/legate/core/utils.py
+++ b/legate/core/utils.py
@@ -20,7 +20,8 @@ from typing import Any, Hashable, Iterator, Optional, TypeVar
 TOrderedSet = TypeVar("TOrderedSet", bound="OrderedSet")
 
 
-class OrderedSet(MutableSet[Hashable]):
+# todo: (bev) use MutableSet[Hashable] when feasible
+class OrderedSet(MutableSet):  # type: ignore [type-arg]
     """
     A set() variant whose iterator returns elements in insertion order.
 


### PR DESCRIPTION
I did not realize Python 3.7 is not currently run in CI. Many thanks to @manopapad for noticing that there were issues in 3.7 due to `__future__` features unintentionally being used outside annotation contexts in a few places. The PR fixes those up, with TODOs for later. I have installed everything and run tests in a 3.7 env and will continue to develop under 3.7 for the time being. cc @magnatelee 