### PR TITLE
Bump up NumPy version

### DIFF
--- a/conda/core_dev.yml
+++ b/conda/core_dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - clang-tools>=8
   - mock
   - nccl
-  - numpy
+  - numpy>=1.22
   - pre-commit
   - pyarrow>=5
   - pydata-sphinx-theme

--- a/legate/core/_legion/transform.py
+++ b/legate/core/_legion/transform.py
@@ -143,7 +143,7 @@ class AffineTransform:
             raise ValueError("Dimension mismatch")
         pin = np.ones(self.N + 1, dtype=np.int64)
         pin[: self.N] = point
-        pout = np.dot(self.transform, pin)  # type: ignore[no-untyped-call]
+        pout = np.dot(self.transform, pin)
         return tuple(pout[: self.M])
 
     def compose(self, outer: AffineTransform) -> AffineTransform:

--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -168,7 +168,7 @@ class Context:
             )
         )
         buf = fut.get_buffer(dt.itemsize)
-        return np.frombuffer(buf, dtype=dt)[0]  # type: ignore [no-untyped-call] # noqa: E501
+        return np.frombuffer(buf, dtype=dt)[0]
 
     def get_unique_op_id(self) -> int:
         return self._runtime.get_unique_op_id()


### PR DESCRIPTION
This PR bumps up the minimum NumPy version to 1.22 and removes code that becomes obsolete due to that change.