### PR TITLE
NVTX integration

### DIFF
--- a/src/core.mk
+++ b/src/core.mk
@@ -69,6 +69,7 @@ INSTALL_HEADERS = legate.h                        \
 									core/utilities/deserializer.inl \
 									core/utilities/dispatch.h       \
 									core/utilities/machine.h        \
+									core/utilities/nvtx_help.h      \
 									core/utilities/span.h           \
 									core/utilities/type_traits.h    \
 									core/utilities/typedefs.h

--- a/src/core/comm/comm_nccl.cu
+++ b/src/core/comm/comm_nccl.cu
@@ -17,6 +17,7 @@
 #include "core/comm/comm_nccl.h"
 #include "core/cuda/cuda_help.h"
 #include "core/cuda/stream_pool.h"
+#include "core/utilities/nvtx_help.h"
 #include "legate.h"
 
 #include <nccl.h>
@@ -55,10 +56,13 @@ static ncclUniqueId init_nccl_id(const Legion::Task* task,
                                  Legion::Context context,
                                  Legion::Runtime* runtime)
 {
+  legate::nvtx::Range auto_range("core::comm::nccl::init_id");
+
   Core::show_progress(task, context, runtime, task->get_task_name());
 
   ncclUniqueId id;
   CHECK_NCCL(ncclGetUniqueId(&id));
+
   return id;
 }
 
@@ -67,6 +71,8 @@ static ncclComm_t* init_nccl(const Legion::Task* task,
                              Legion::Context context,
                              Legion::Runtime* runtime)
 {
+  legate::nvtx::Range auto_range("core::comm::nccl::init");
+
   Core::show_progress(task, context, runtime, task->get_task_name());
 
   assert(task->futures.size() == 1);
@@ -110,6 +116,8 @@ static void finalize_nccl(const Legion::Task* task,
                           Legion::Context context,
                           Legion::Runtime* runtime)
 {
+  legate::nvtx::Range auto_range("core::comm::nccl::finalize");
+
   Core::show_progress(task, context, runtime, task->get_task_name());
 
   assert(task->futures.size() == 1);

--- a/src/core/task/task.h
+++ b/src/core/task/task.h
@@ -25,6 +25,7 @@
 #include "core/runtime/runtime.h"
 #include "core/task/return.h"
 #include "core/utilities/deserializer.h"
+#include "core/utilities/nvtx_help.h"
 #include "core/utilities/typedefs.h"
 
 namespace legate {
@@ -88,6 +89,10 @@ class LegateTask {
                                           Legion::Context legion_context,
                                           Legion::Runtime* runtime)
   {
+#ifdef LEGATE_USE_CUDA
+    nvtx::Range auto_range(task_name());
+#endif
+
     Core::show_progress(task, legion_context, runtime, task_name());
 
     TaskContext context(task, regions, legion_context, runtime);

--- a/src/core/utilities/nvtx_help.h
+++ b/src/core/utilities/nvtx_help.h
@@ -1,0 +1,40 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "legate.h"
+
+#ifdef LEGATE_USE_CUDA
+
+#include <nvtx3/nvToolsExt.h>
+
+namespace legate {
+namespace nvtx {
+
+class Range {
+ public:
+  Range(const char* message) { range_ = nvtxRangeStartA(message); }
+  ~Range() { nvtxRangeEnd(range_); }
+
+ private:
+  nvtxRangeId_t range_;
+};
+
+}  // namespace nvtx
+}  // namespace legate
+
+#endif


### PR DESCRIPTION
This PR makes an initial effort to integrate NVTX in Legate core. This creates an NVTX ranges for each task invocation, and with #208, the range can optionally represent the task's total execution time.