### PR TITLE
Raise an exception if there's no usable processor

### DIFF
--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -498,6 +498,12 @@ class PartitionManager:
             ty.int64,
         )
 
+        if self._num_pieces == 0:
+            raise RuntimeError(
+                "No processors are available to run Legate tasks. Please "
+                "enable at least one processor of any kind. "
+            )
+
         self._launch_spaces = {}
         factors = list()
         pieces = self._num_pieces


### PR DESCRIPTION
The core runtime hangs in the prime factorization when the number of usable processors is 0. This PR instead raises an exception when that happens.