### PR TITLE
Fix compile issue with cuda_help.h

### DIFF
--- a/src/core/cuda/cuda_help.h
+++ b/src/core/cuda/cuda_help.h
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <cuda_runtime.h>
+#include <stdio.h>
 
 #define CHECK_CUDA(expr)                                      \
   do {                                                        \


### PR DESCRIPTION
Some compilers don't seem to find `stderr` and `fprintf` when `cuda_help.h` is included.