### PR TITLE
Update build.sh with specific CPU targeting

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -1,13 +1,47 @@
 # We rely on an environment variable to determine if we need to build cpu-only bits
+export CXXFLAGS="$CXXFLAGS -std=c++17"
+
+install_args=()
+
+# We rely on an environment variable to determine if we need to build cpu-only bits
+if [ -z "$CPU_ONLY" ]; then
+  # cuda, relying on the stub library provided by the toolkit
+  install_args+=("--cuda" "--with-cuda" "$PREFIX")
+
+  # nccl, relying on the conda nccl package
+  install_args+=("--with-nccl" "$PREFIX")
+
+  # targetted architecture to compile cubin support for
+  install_args+=("--arch" "70,75,80")
+fi
+
+#CPU targeting
+install_args+=("--march" "haswell")
+
+#openMP support
+install_args+=("--openmp")
+
+# Target directory
+install_args+=("--install-dir" "$PREFIX")
+
+# Verbose mode
+install_args+=("-v")
+
+# Move the stub library into the lib package to make the install think it's pointing at a live installation
 if [ -z "$CPU_ONLY" ]; then
   cp $PREFIX/lib/stubs/libcuda.so $PREFIX/lib/libcuda.so
   ln -s $PREFIX/lib $PREFIX/lib64
-  $PYTHON install.py --cuda --openmp --with-cuda $PREFIX --with-nccl $PREFIX --arch 70,75,80 --install-dir $PREFIX -v
+fi
+
+echo "Install command: $PYTHON install.py ${install_args[@]}"
+$PYTHON install.py "${install_args[@]}"
+
+# Remove the stub library and linking
+if [ -z "$CPU_ONLY" ]; then
   rm $PREFIX/lib/libcuda.so
   rm $PREFIX/lib64
-else
-  $PYTHON install.py --openmp  --install-dir $PREFIX -v
 fi
+
 # Legion leaves an egg-info file which will confuse conda trying to pick up the information
 # Remove it so the legate-core is the only egg-info file added
 rm -rf $SP_DIR/legion*egg-info


### PR DESCRIPTION
Updates build.sh with:
1) Set the std to c++17 to fix the type_traits templating issue
2) Builds up the install arguments in a variable and comments on each addition
3) Adds an install argument to target the CPU feature set equivalent to haswell