### PR TITLE
Use stdlib typing where possible

### DIFF
--- a/legate/core/constraints.py
+++ b/legate/core/constraints.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Protocol, Union
 
 from .partition import Restriction
 

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -20,13 +20,14 @@ from typing import (
     Any,
     Callable,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Union,
+    overload,
 )
 
 import pyarrow as pa
-from typing_extensions import Protocol, overload
 
 from . import (
     ArgumentMap,

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -14,9 +14,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Protocol, Union
 
 import legate.core.types as ty
 

--- a/legate/core/shape.py
+++ b/legate/core/shape.py
@@ -15,9 +15,9 @@
 from __future__ import annotations
 
 from functools import reduce
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Union, overload
 
-from typing_extensions import TypeAlias, overload
+from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from . import IndexSpace

--- a/legate/core/transform.py
+++ b/legate/core/transform.py
@@ -14,10 +14,9 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Protocol, Tuple
 
 import numpy as np
-from typing_extensions import Protocol
 
 from . import AffineTransform
 from .partition import Replicate, Restriction, Tiling


### PR DESCRIPTION
`Protocol` and `overload` are available in stdlib `typing` in Python>=3.8 so there is no need to use `typing_extensions` for them.

https://docs.python.org/3.8/library/typing.html


