### PR TITLE
Add script wrapper for zero code-change patching

### DIFF
--- a/install.py
+++ b/install.py
@@ -770,6 +770,14 @@ def install(
         cwd=legate_core_dir,
     )
     verbose_check_call(
+        [
+            "cp",
+            "scripts/lgpatch.py",
+            os.path.join(install_dir, "bin", "lgpatch"),
+        ],
+        cwd=legate_core_dir,
+    )
+    verbose_check_call(
         ["cp", "bind.sh", os.path.join(install_dir, "bin", "bind.sh")],
         cwd=legate_core_dir,
     )

--- a/scripts/lgpatch.py
+++ b/scripts/lgpatch.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env legate
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import textwrap
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+KNOWN_PATCHES = {"numpy": "cunumeric"}
+
+newline = "\n"
+
+DESCRIPTION = textwrap.dedent(
+    f"""
+Patch existing libraries with legate equivalents.
+
+Currently the following patching can be applied:
+
+{newline.join(f'    {key} -> {value}' for key, value in KNOWN_PATCHES.items())}
+
+"""
+)
+
+EPILOG = """
+Any additional command line arguments are passed on to PROG as-is
+"""
+
+
+def parse_args():
+    parser = ArgumentParser(
+        prog="lgpatch",
+        description=DESCRIPTION,
+        allow_abbrev=False,
+        add_help=False,
+        epilog=EPILOG,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "prog", metavar="PROG", help="The legate program to run"
+    )
+    parser.add_argument(
+        "-patch",
+        action="store",
+        nargs="+",
+        help="Patch the specified libraries",
+        default=[],
+    )
+
+    # legate parser intercepts "-h" and "--help" earlier
+    if "-patch:help" in sys.argv:
+        parser.print_help()
+        sys.exit()
+
+    return parser.parse_known_args()
+
+
+def do_patch(name: str) -> None:
+    if name not in KNOWN_PATCHES:
+        raise ValueError(f"No patch available for module {name}")
+    if name in sys.modules:
+        raise RuntimeError(f"Cannot patch {name} -- it is already loaded")
+
+    cuname = KNOWN_PATCHES[name]
+    try:
+        module = __import__(cuname)
+        sys.modules[name] = module
+    except ImportError:
+        raise RuntimeError(f"Could not import patch module {cuname}")
+
+
+if __name__ == "__main__":
+    args, extra = parse_args()
+
+    for name in args.patch:
+        do_patch(name)
+
+    sys.argv[:] = [args.prog] + extra
+
+    with open(args.prog) as f:
+        exec(f.read(), {"__name__": "__main__"})

--- a/scripts/lgpatch.py
+++ b/scripts/lgpatch.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env legate
-# Copyright 2021-2022 NVIDIA Corporation
+# Copyright 2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION

This PR adds a wrapper for legate that can patch specified libraries and then execute a given script with those patches already in place.
```
~/work/legate.core bryanv/zcc
dev38 ❯ lgpatch.py test.py -patch numpy -cunumeric:report:coverage
cuNumeric API coverage: 4/4 (100.0%)
```

See below for `test.py` example script that only imports numpy. 

### Questions

* Is `scripts/lgpatch.py` the best place/name for this? Should it be installed (as `lgpatch`?) in the install bin directory?
* Is `-patch:help` suffient for help? Legate intercepts `-h` and `--help` before we can get to them so we can't use those. 
* This does not use the trivial `cunumeric.patch()` because I wanted to have more error checking. But we could move that to `patch` and simplify here if desired (but then every new lib would be responsible for checking individually in their `patch()`) If we did this the usage would also switch to `-patch cunumeric` instead of the current `-patch numpy`.
* Alternatively, we could also just remove `cunumeric.patch` if is not needed after this. 

---



#### test.py
```
import numpy as np

def cholesky(n, dtype):
    input = np.eye(n, dtype=dtype)
    np.linalg.cholesky(input)

if __name__ == "__main__":
    cholesky(10, np.float32)
```

#### `-patch:help`
```
dev38 ❯ ./scripts/lgpatch.py -patch:help                                    
usage: lgpatch [-patch PATCH [PATCH ...]] PROG

Patch existing libraries with legate equivalents.

Currently the following patching can be applied:

    numpy -> cunumeric

positional arguments:
  PROG                  The legate program to run

optional arguments:
  -patch PATCH [PATCH ...]
                        Patch the specified libraries

Any additional command line arguments are passed on to PROG as-is
```