### PR TITLE
Fix unordered field destruction

### DIFF
--- a/legate/core/_legion/__init__.py
+++ b/legate/core/_legion/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from .env import LEGATE_MAX_DIM, LEGATE_MAX_FIELDS
+from .field import FieldID
 from .future import Future, FutureMap
 from .geometry import Point, Rect, Domain
 from .operation import (
@@ -49,7 +50,6 @@ from .util import (
     dispatch,
     BufferBuilder,
     ExternalResources,
-    FieldID,
     FieldListLike,
     legate_task_preamble,
     legate_task_postamble,

--- a/legate/core/_legion/field.py
+++ b/legate/core/_legion/field.py
@@ -1,0 +1,56 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import FieldSpace
+
+
+class FieldID:
+    def __init__(self, field_space: FieldSpace, fid: int, type: Any) -> None:
+        """
+        A FieldID class wraps a `legion_field_id_t` in the Legion C API.
+        It provides a canonical way to represent an allocated field in a
+        field space and means by which to deallocate the field.
+
+        Parameters
+        ----------
+        field_space : FieldSpace
+            The owner field space for this field
+        fid : int
+            The ID for this field
+        type : type
+            The type of this field
+        """
+        self.field_space = field_space
+        self._type = type
+        self.field_id = fid
+
+    def destroy(self, unordered: bool = False) -> None:
+        """
+        Deallocate this field from the field space
+        """
+        self.field_space.destroy_field(self.field_id, unordered)
+
+    @property
+    def fid(self) -> int:
+        return self.field_id
+
+    @property
+    def type(self) -> Any:
+        return self._type

--- a/legate/core/_legion/operation.py
+++ b/legate/core/_legion/operation.py
@@ -26,7 +26,7 @@ from .space import IndexSpace
 from .util import Dispatchable, ExternalResources, FieldID, dispatch
 
 if TYPE_CHECKING:
-    from . import FieldListLike, FutureMap, Rect
+    from . import FieldListLike, Rect
 
 
 class InlineMapping(Dispatchable[PhysicalRegion]):
@@ -130,7 +130,7 @@ class Fill(Dispatchable[None]):
         region: Region,
         parent: Region,
         field: Union[int, FieldID],
-        future: FutureMap,
+        future: Future,
         mapper: int = 0,
         tag: int = 0,
     ) -> None:

--- a/legate/core/_legion/space.py
+++ b/legate/core/_legion/space.py
@@ -19,12 +19,13 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from .. import ffi, legion
 from ..types import _Dtype
 from .env import LEGATE_MAX_FIELDS
+from .field import FieldID
 from .future import Future
 from .geometry import Domain
 from .pending import _pending_unordered
 
 if TYPE_CHECKING:
-    from . import FieldID, IndexPartition, Rect
+    from . import IndexPartition, Rect
 
 
 class IndexSpace:

--- a/legate/core/_legion/util.py
+++ b/legate/core/_legion/util.py
@@ -20,12 +20,13 @@ from typing import TYPE_CHECKING, Any, Generic, List, Optional, TypeVar, Union
 import numpy as np
 
 from .. import legion
+from .field import FieldID
 from .geometry import Point
 from .partition import IndexPartition
 from .pending import _pending_deletions, _pending_unordered
 
 if TYPE_CHECKING:
-    from . import AffineTransform, FieldSpace
+    from . import AffineTransform
 
 
 def legate_task_preamble(
@@ -165,41 +166,6 @@ class Dispatchable(Generic[T]):
         **kwargs: Any,
     ) -> T:
         ...
-
-
-class FieldID:
-    def __init__(self, field_space: FieldSpace, fid: int, type: Any) -> None:
-        """
-        A FieldID class wraps a `legion_field_id_t` in the Legion C API.
-        It provides a canonical way to represent an allocated field in a
-        field space and means by which to deallocate the field.
-
-        Parameters
-        ----------
-        field_space : FieldSpace
-            The owner field space for this field
-        fid : int
-            The ID for this field
-        type : type
-            The type of this field
-        """
-        self.field_space = field_space
-        self._type = type
-        self.field_id = fid
-
-    def destroy(self, unordered: bool = False) -> None:
-        """
-        Deallocate this field from the field space
-        """
-        self.field_space.destroy_field(self.field_id, unordered)
-
-    @property
-    def fid(self) -> int:
-        return self.field_id
-
-    @property
-    def type(self) -> Any:
-        return self._type
 
 
 # todo: (bev) use list[...] when feasible


### PR DESCRIPTION
The unordered field destruction turns out to have been broken when legion.py was refactored. This PR fixes the issue, and also fixes another minor typing issue.