### PR TITLE
Use 32-bit integers for type codes

### DIFF
--- a/src/core/data/store.cc
+++ b/src/core/data/store.cc
@@ -146,7 +146,7 @@ ReturnValue FutureWrapper::pack() const
 }
 
 Store::Store(int32_t dim,
-             LegateTypeCode code,
+             int32_t code,
              int32_t redop_id,
              FutureWrapper future,
              std::shared_ptr<StoreTransform> transform)
@@ -162,7 +162,7 @@ Store::Store(int32_t dim,
 }
 
 Store::Store(int32_t dim,
-             LegateTypeCode code,
+             int32_t code,
              int32_t redop_id,
              RegionField&& region_field,
              std::shared_ptr<StoreTransform> transform)
@@ -179,9 +179,7 @@ Store::Store(int32_t dim,
   reducible_ = region_field_.is_reducible();
 }
 
-Store::Store(LegateTypeCode code,
-             OutputRegionField&& output,
-             std::shared_ptr<StoreTransform> transform)
+Store::Store(int32_t code, OutputRegionField&& output, std::shared_ptr<StoreTransform> transform)
   : is_future_(false),
     is_output_store_(true),
     dim_(-1),

--- a/src/core/data/store.h
+++ b/src/core/data/store.h
@@ -254,16 +254,16 @@ class Store {
  public:
   Store() {}
   Store(int32_t dim,
-        LegateTypeCode code,
+        int32_t code,
         int32_t redop_id,
         FutureWrapper future,
         std::shared_ptr<StoreTransform> transform = nullptr);
   Store(int32_t dim,
-        LegateTypeCode code,
+        int32_t code,
         int32_t redop_id,
         RegionField&& region_field,
         std::shared_ptr<StoreTransform> transform = nullptr);
-  Store(LegateTypeCode code,
+  Store(int32_t code,
         OutputRegionField&& output,
         std::shared_ptr<StoreTransform> transform = nullptr);
 
@@ -281,7 +281,11 @@ class Store {
 
  public:
   int32_t dim() const { return dim_; }
-  LegateTypeCode code() const { return code_; }
+  template <typename TYPE_CODE = LegateTypeCode>
+  TYPE_CODE code() const
+  {
+    return static_cast<TYPE_CODE>(code_);
+  }
 
  public:
   template <typename T, int32_t DIM>
@@ -336,7 +340,7 @@ class Store {
   bool is_future_{false};
   bool is_output_store_{false};
   int32_t dim_{-1};
-  LegateTypeCode code_{MAX_TYPE_NUMBER};
+  int32_t code_{-1};
   int32_t redop_id_{-1};
 
  private:


### PR DESCRIPTION
Legate stores were returning type codes in `LegateTypeCode`, but stores can use client specific types. This PR addresses the issue and makes `code()`  a template function so client libraries can override the type code types.