### PR TITLE
Use read-write privilege for scatter targets

### DIFF
--- a/legate/core/_legion/operation.py
+++ b/legate/core/_legion/operation.py
@@ -450,6 +450,7 @@ class Copy(Dispatchable[None]):
         parent: Optional[Region] = None,
         tag: int = 0,
         redop: int = 0,
+        privilege: int = legion.LEGION_WRITE_DISCARD,
         coherence: int = legion.LEGION_EXCLUSIVE,
         **kwargs: Any,
     ) -> None:
@@ -468,6 +469,9 @@ class Copy(Dispatchable[None]):
             A mapping tag to pass to the mapper for context of this requirement
         redop : int
             Optional reduction operator ID to reduce to the destination fields
+        privilege : int
+            Optional privilege for the destination. Ignored when `redop` is
+            non-zero. WRITE_DISCARD by default.
         coherence : int
             The coherence mode for which to access this region
         """
@@ -475,7 +479,7 @@ class Copy(Dispatchable[None]):
             legion.legion_copy_launcher_add_dst_region_requirement_logical_region(  # noqa: E501
                 self.launcher,
                 region.handle,
-                legion.LEGION_WRITE_DISCARD,
+                privilege,
                 coherence,
                 region.get_root().handle if parent is None else parent.handle,
                 tag,
@@ -775,6 +779,7 @@ class IndexCopy(Dispatchable[None]):
         parent: Optional[Region] = None,
         tag: int = 0,
         redop: int = 0,
+        privilege: int = legion.LEGION_WRITE_DISCARD,
         coherence: int = legion.LEGION_EXCLUSIVE,
         **kwargs: Any,
     ) -> None:
@@ -797,6 +802,9 @@ class IndexCopy(Dispatchable[None]):
             A mapping tag to pass to the mapper for context of this requirement
         redop : int
             Optional reduction operator ID to reduce the destination fields
+        privilege : int
+            Optional privilege for the destination. Ignored when `redop` is
+            non-zero. WRITE_DISCARD by default.
         coherence : int
             The coherence mode for which to access this region
         """
@@ -806,7 +814,7 @@ class IndexCopy(Dispatchable[None]):
                     self.launcher,
                     upper_bound.handle,
                     projection,
-                    legion.LEGION_WRITE_DISCARD,
+                    privilege,
                     coherence,
                     upper_bound.get_root().handle
                     if parent is None
@@ -833,7 +841,7 @@ class IndexCopy(Dispatchable[None]):
                     self.launcher,
                     upper_bound.handle,
                     projection,
-                    legion.LEGION_WRITE_DISCARD,
+                    privilege,
                     coherence,
                     upper_bound.get_root().handle
                     if parent is None

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -760,6 +760,8 @@ class Copy(AutoOperation):
             self._target_indirects
         ) == len(self._outputs)
 
+        scatter = len(self._target_indirects) > 0
+
         def get_requirement(
             store: Store, part_symb: PartSym
         ) -> tuple[Any, int, StorePartition]:
@@ -775,7 +777,10 @@ class Copy(AutoOperation):
         for store, part_symb in zip(self._outputs, self._output_parts):
             assert not store.unbound
             req, tag, store_part = get_requirement(store, part_symb)
-            launcher.add_output(store, req, tag=tag)
+            if scatter:
+                launcher.add_inout(store, req, tag=tag)
+            else:
+                launcher.add_output(store, req, tag=tag)
 
         for ((store, redop), part_symb) in zip(
             self._reductions, self._reduction_parts

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -760,6 +760,11 @@ class Copy(AutoOperation):
             self._target_indirects
         ) == len(self._outputs)
 
+        # FIXME: today a copy is a scatter copy only when a target indirection
+        # is given. In the future, we may pass store transforms directly to
+        # Legion and some transforms turn some copies into scatter copies even
+        # when no target indirection is provided. So, this scatter copy check
+        # will need to be extended accordingly.
         scatter = len(self._target_indirects) > 0
 
         def get_requirement(


### PR DESCRIPTION
Legate core was using write-discard privilege for scatter targets, which make them not fetch valid values for pass-through entries. This PR is to fix that issue.