### PR TITLE
Add missing includes to aid intellisense providers

### DIFF
--- a/src/core/legate_c.h
+++ b/src/core/legate_c.h
@@ -17,6 +17,12 @@
 #ifndef __LEGATE_C_H__
 #define __LEGATE_C_H__
 
+#ifndef LEGATE_USE_PYTHON_CFFI
+#include "legion/legion_config.h"
+//
+#include <cstdint>
+#endif
+
 typedef enum legate_core_task_id_t {
   LEGATE_CORE_EXTRACT_SCALAR_TASK_ID,
   LEGATE_CORE_INIT_NCCL_ID_TASK_ID,


### PR DESCRIPTION
Add `#include` directives for `legion_config.h` and `cstdint`. This ensures `legate_c.h` can be included from other C++ headers without respect to other `#include` directives, and aids intellisense providers (like `clangd`) who infer the compile commands from the C++ build.

Related to:
* https://gitlab.com/StanfordLegion/legion/-/merge_requests/498
