### PR TITLE
Minor type fix

### DIFF
--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -27,8 +27,6 @@ from typing import (
     overload,
 )
 
-import pyarrow as pa
-
 from . import (
     ArgumentMap,
     BufferBuilder,
@@ -748,7 +746,7 @@ class TaskLauncher:
     def add_scalar_arg(
         self,
         value: Any,
-        dtype: Union[bool, pa.lib.DataType],
+        dtype: DTType,
         untyped: bool = True,
     ) -> None:
         self._scalars.append(

--- a/legate/core/types.py
+++ b/legate/core/types.py
@@ -15,14 +15,14 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Any, Union
+from typing import Any, Type, Union
 
 import pyarrow as pa
 
 from . import legion
 from .corelib import core_library
 
-DTType = Union[bool, pa.lib.DataType]
+DTType = Union[Type[bool], pa.lib.DataType]
 
 
 class Complex64Dtype(pa.ExtensionType):


### PR DESCRIPTION
This seems to be correct since `bool` is passed in, rather than a boolean value. Evidently it was not exercised until some `cunumeric`, where these mypy errors surfaced:
```
dev38 ❯ mypy ../legate.core/install38/lib/python3.8/site-packages/legate /home/bryan/work/legate.core/typings/ cunumeric
cunumeric/linalg/cholesky.py: note: In function "tril":
cunumeric/linalg/cholesky.py:167:31: error: Argument 2 to "add_scalar_arg" of "Task" has incompatible type "Type[bool]"; expected "Union[bool, DataType]"  [arg-type]
        task.add_scalar_arg(True, bool)
                                  ^
cunumeric/linalg/cholesky.py:170:31: error: Argument 2 to "add_scalar_arg" of "Task" has incompatible type "Type[bool]"; expected "Union[bool, DataType]"  [arg-type]
```