### PR TITLE
Freeze Compiler Versions

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -69,8 +69,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }} =11.2
+    - {{ compiler('cxx') }} =11.2
     - make
 {% if gpu_enabled_bool %}
     - cuda-nvcc ={{ cuda_version }}


### PR DESCRIPTION
The currently available version of nvcc does not support 12.1 compilers, so we need to freeze compilers at 11.2 until nvcc is ready.