### PR TITLE
let gasnet to handle mpi init and finalize

### DIFF
--- a/src/core/comm/coll.cc
+++ b/src/core/comm/coll.cc
@@ -251,7 +251,10 @@ int collInit(int argc, char* argv[])
   int provided, init_flag = 0;
   CHECK_MPI(MPI_Initialized(&init_flag));
   if (!init_flag) {
-    CHECK_MPI(MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided));
+    log_coll.fatal(
+      "MPI has not been initialized, it should be initialized by "
+      "GASNet");
+    LEGATE_ABORT;
   } else {
     int mpi_thread_model;
     MPI_Query_thread(&mpi_thread_model);
@@ -291,7 +294,10 @@ int collFinalize(void)
   mpi_comms.clear();
   int fina_flag = 0;
   CHECK_MPI(MPI_Finalized(&fina_flag));
-  if (fina_flag == 0) { CHECK_MPI(MPI_Finalize()); }
+  if (fina_flag == 1) {
+    log_coll.fatal("MPI should not been finalized");
+    LEGATE_ABORT;
+  }
   return CollSuccess;
 #else
   for (int i = 0; i < MAX_NB_COMMS; i++) { assert(thread_comms[i].ready_flag == false); }

--- a/src/core/comm/coll.cc
+++ b/src/core/comm/coll.cc
@@ -295,7 +295,7 @@ int collFinalize(void)
   int fina_flag = 0;
   CHECK_MPI(MPI_Finalized(&fina_flag));
   if (fina_flag == 1) {
-    log_coll.fatal("MPI should not been finalized");
+    log_coll.fatal("MPI should not have been finalized");
     LEGATE_ABORT;
   }
   return CollSuccess;


### PR DESCRIPTION
I had a case that GASNet will crash if I finalize the MPI in the `collFinalize` function, so we will just let GASNet to handle the initialization and finalization of MPI. 