### PR TITLE
WIP: Towards using Collective Instances

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -777,7 +777,7 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
   bool is_reduction = (reqs[0].get().privilege == LEGION_REDUCE) && (reqs[0].get().projection != 0);
   bool is_collective = (is_reduction || ro_broadcasted);
   // If we're making a reduction instance, we should just make it now
-  //std::cout << "IRINA DEBUG size of regions = " << regions.size() << " redop = " << redop
+  // std::cout << "IRINA DEBUG size of regions = " << regions.size() << " redop = " << redop
   //          << std::endl;
   if (redop != 0) {
     layout_constraints.add_constraint(SpecializedConstraint(REDUCTION_FOLD_SPECIALIZE, redop));
@@ -800,9 +800,10 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
         // collective_tag = linearize(lo, hi, p);
         // collective_tag = task.get_shard_id();
         collective_tag = task.index_point[0] * 10 + task.index_point[1];
-        //std::cout << "IRINA DEBUG collective tag = " << collective_tag << " lo = " << lo << " hi "
-        //          << hi << " p = " << p << " shard_point = " << task.get_shard_point()
-        //          << ", index point = " << task.index_point << std::endl;
+        // std::cout << "IRINA DEBUG collective tag = " << collective_tag << " lo = " << lo << " hi
+        // "
+        //           << hi << " p = " << p << " shard_point = " << task.get_shard_point()
+        //           << ", index point = " << task.index_point << std::endl;
       }
     }  // if is_collective
     if (!runtime->create_physical_instance(ctx,

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -777,8 +777,8 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
   bool is_reduction = (reqs[0].get().privilege == LEGION_REDUCE) && (reqs[0].get().projection != 0);
   bool is_collective = (is_reduction || ro_broadcasted);
   // If we're making a reduction instance, we should just make it now
-  std::cout << "IRINA DEBUG size of regions = " << regions.size() << " redop = " << redop
-            << std::endl;
+  //std::cout << "IRINA DEBUG size of regions = " << regions.size() << " redop = " << redop
+  //          << std::endl;
   if (redop != 0) {
     layout_constraints.add_constraint(SpecializedConstraint(REDUCTION_FOLD_SPECIALIZE, redop));
 
@@ -800,9 +800,9 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
         // collective_tag = linearize(lo, hi, p);
         // collective_tag = task.get_shard_id();
         collective_tag = task.index_point[0] * 10 + task.index_point[1];
-        std::cout << "IRINA DEBUG collective tag = " << collective_tag << " lo = " << lo << " hi "
-                  << hi << " p = " << p << " shard_point = " << task.get_shard_point()
-                  << ", index point = " << task.index_point << std::endl;
+        //std::cout << "IRINA DEBUG collective tag = " << collective_tag << " lo = " << lo << " hi "
+        //          << hi << " p = " << p << " shard_point = " << task.get_shard_point()
+        //          << ", index point = " << task.index_point << std::endl;
       }
     }  // if is_collective
     if (!runtime->create_physical_instance(ctx,

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -277,7 +277,8 @@ class BaseMapper : public Legion::Mapping::Mapper, public LegateMapper {
                      const std::vector<Legion::Mapping::PhysicalInstance>& valid,
                      Legion::Mapping::PhysicalInstance& result,
                      bool memoize,
-                     Legion::ReductionOpID redop = 0);
+                     Legion::ReductionOpID redop  = 0,
+                     bool require_collective_inst = false);
   void filter_failed_acquires(std::vector<Legion::Mapping::PhysicalInstance>& needed_acquires,
                               std::set<Legion::Mapping::PhysicalInstance>& failed_acquires);
   void report_failed_mapping(const Legion::Mappable& mappable,
@@ -287,7 +288,8 @@ class BaseMapper : public Legion::Mapping::Mapper, public LegateMapper {
   void legate_select_sources(const Legion::Mapping::MapperContext ctx,
                              const Legion::Mapping::PhysicalInstance& target,
                              const std::vector<Legion::Mapping::PhysicalInstance>& sources,
-                             std::deque<Legion::Mapping::PhysicalInstance>& ranking);
+                             std::deque<Legion::Mapping::PhysicalInstance>& ranking,
+                             const Legion::DomainPoint& index_point);
 
  protected:
   bool has_variant(const Legion::Mapping::MapperContext ctx,

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -262,7 +262,7 @@ class BaseMapper : public Legion::Mapping::Mapper, public LegateMapper {
                               Legion::Mapping::PhysicalInstance& result,
                               Strictness strictness = Strictness::hint);
   bool map_legate_store(const Legion::Mapping::MapperContext ctx,
-                        const Legion::Mappable& mappable,
+                        const Legion::Task& task,
                         const StoreMapping& mapping,
                         std::vector<std::reference_wrapper<const Legion::RegionRequirement>> reqs,
                         Legion::Processor target_proc,


### PR DESCRIPTION
What has been changed:

map_inline: if collective instances required , make all instances collective
map_task (legate_create_store):
  - for reduction instances only: 
    a) make reduction instances (with REDUCTION privilege or broadcasted ( read-only without projection) collective
    b) add tags to instances with REDUCTION privilege without projections

instance caching :  do not cache collective instances. (TODO: add separate caching logic for collective instances)

Since collective instances are not cached, performance is worse than before. At this point, I would like to get feedback on the approach taken.