### PR TITLE
src/core/comm: add simple implementation of pthread_barrier for mac

### DIFF
--- a/src/core/comm/coll.h
+++ b/src/core/comm/coll.h
@@ -22,6 +22,16 @@
 
 #ifdef LEGATE_USE_GASNET
 #include <mpi.h>
+#else
+// If we aren't using GASNet, we'll use pthread_barrier to
+// construct a communicator for thread-local communication. Mac OS
+// does not implement pthread barriers, so we need to include an
+// implementation in case they are not defined. We also need to
+// include unistd.h since that defines _POSIX_BARRIERS.
+#include <unistd.h>
+#if !defined(_POSIX_BARRIERS) || (_POSIX_BARRIERS < 0)
+#include "pthread_barrier.h"
+#endif
 #endif
 
 namespace legate {

--- a/src/core/comm/pthread_barrier.h
+++ b/src/core/comm/pthread_barrier.h
@@ -1,0 +1,59 @@
+#if !defined(_POSIX_BARRIERS) || (_POSIX_BARRIERS < 0)
+
+#ifndef PTHREAD_BARRIER_H_
+#define PTHREAD_BARRIER_H_
+
+#include <pthread.h>
+
+// This file provides a simple (and slow) implementation of pthread_barriers
+// for Mac OS, as Mac does not implement pthread barriers, and the Legate
+// implementation utilizes them when MPI is disabled.
+
+typedef int pthread_barrierattr_t;
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+    int tripCount;
+} pthread_barrier_t;
+
+inline int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count) {
+  if (count == 0) {
+    return -1;
+  }
+  if (pthread_mutex_init(&barrier->mutex, 0) < 0) {
+    return -1;
+  }
+  if (pthread_cond_init(&barrier->cond, 0) < 0) {
+    pthread_mutex_destroy(&barrier->mutex);
+    return -1;
+  }
+  barrier->tripCount = count;
+  barrier->count = 0;
+  return 0;
+}
+
+inline int pthread_barrier_destroy(pthread_barrier_t *barrier) {
+  pthread_cond_destroy(&barrier->cond);
+  pthread_mutex_destroy(&barrier->mutex);
+  return 0;
+}
+
+inline int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+  pthread_mutex_lock(&barrier->mutex);
+  ++(barrier->count);
+  if (barrier->count >= barrier->tripCount) {
+    barrier->count = 0;
+    pthread_cond_broadcast(&barrier->cond);
+    pthread_mutex_unlock(&barrier->mutex);
+    return 1;
+  } else {
+    pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+    pthread_mutex_unlock(&barrier->mutex);
+    return 0;
+  }
+}
+
+#endif // PTHREAD_BARRIER_H_
+#endif // _POSIX_BARRIERS

--- a/src/core/comm/pthread_barrier.h
+++ b/src/core/comm/pthread_barrier.h
@@ -11,35 +11,35 @@
 
 typedef int pthread_barrierattr_t;
 typedef struct {
-    pthread_mutex_t mutex;
-    pthread_cond_t cond;
-    int count;
-    int tripCount;
+  pthread_mutex_t mutex;
+  pthread_cond_t cond;
+  int count;
+  int tripCount;
 } pthread_barrier_t;
 
-inline int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count) {
-  if (count == 0) {
-    return -1;
-  }
-  if (pthread_mutex_init(&barrier->mutex, 0) < 0) {
-    return -1;
-  }
+inline int pthread_barrier_init(pthread_barrier_t* barrier,
+                                const pthread_barrierattr_t* attr,
+                                unsigned int count)
+{
+  if (count == 0) { return -1; }
+  if (pthread_mutex_init(&barrier->mutex, 0) < 0) { return -1; }
   if (pthread_cond_init(&barrier->cond, 0) < 0) {
     pthread_mutex_destroy(&barrier->mutex);
     return -1;
   }
   barrier->tripCount = count;
-  barrier->count = 0;
+  barrier->count     = 0;
   return 0;
 }
 
-inline int pthread_barrier_destroy(pthread_barrier_t *barrier) {
+inline int pthread_barrier_destroy(pthread_barrier_t* barrier)
+{
   pthread_cond_destroy(&barrier->cond);
   pthread_mutex_destroy(&barrier->mutex);
   return 0;
 }
 
-inline int pthread_barrier_wait(pthread_barrier_t *barrier)
+inline int pthread_barrier_wait(pthread_barrier_t* barrier)
 {
   pthread_mutex_lock(&barrier->mutex);
   ++(barrier->count);
@@ -55,5 +55,5 @@ inline int pthread_barrier_wait(pthread_barrier_t *barrier)
   }
 }
 
-#endif // PTHREAD_BARRIER_H_
-#endif // _POSIX_BARRIERS
+#endif  // PTHREAD_BARRIER_H_
+#endif  // _POSIX_BARRIERS


### PR DESCRIPTION
This commit adds a dummy implementation of pthread_barrier for Mac OS
since it does not support pthread_barriers. This is necessary for
performing builds on Macs without MPI.