### PR TITLE
NVTX: Use RangePush and Domain

### DIFF
--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -45,6 +45,11 @@ static const char* const core_library_name = "legate.core";
 
 /*static*/ bool Core::has_socket_mem = false;
 
+#ifdef LEGATE_USE_CUDA
+/*static*/ const char* const nvtx::Range::domainName = "Legate";
+/*static*/ nvtxDomainHandle_t nvtx::Range::domain;
+#endif
+
 /*static*/ void Core::parse_config(void)
 {
 #ifndef LEGATE_USE_CUDA
@@ -83,6 +88,10 @@ static const char* const core_library_name = "legate.core";
   parse_variable("LEGATE_EMPTY_TASK", use_empty_task);
   parse_variable("LEGATE_SYNC_STREAM_VIEW", synchronize_stream_view);
   parse_variable("LEGATE_LOG_MAPPING", log_mapping_decisions);
+
+#ifdef LEGATE_USE_CUDA
+  nvtx::Range::initialize();
+#endif
 }
 
 static void extract_scalar_task(
@@ -107,7 +116,9 @@ static void extract_scalar_task(
 
 /*static*/ void Core::shutdown(void)
 {
-  // Nothing to do here yet...
+#ifdef LEGATE_USE_CUDA
+  nvtx::Range::shutdown();
+#endif
 }
 
 /*static*/ void Core::show_progress(const Legion::Task* task,

--- a/src/core/utilities/nvtx_help.h
+++ b/src/core/utilities/nvtx_help.h
@@ -27,8 +27,23 @@ namespace nvtx {
 
 class Range {
  public:
-  Range(const char* message) { nvtxRangePushA(message); }
-  ~Range() { nvtxRangePop(); }
+  Range(const char* message)
+  {
+    nvtxEventAttributes_t eventAttrib = {0};
+    eventAttrib.version               = NVTX_VERSION;
+    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
+    eventAttrib.message.ascii         = message;
+    nvtxDomainRangePushEx(domain, &eventAttrib);
+  }
+  ~Range() { nvtxDomainRangePop(domain); }
+
+  static void initialize() { domain = nvtxDomainCreateA(domainName); }
+  static void shutdown() { nvtxDomainDestroy(domain); }
+
+ private:
+  static const char* const domainName;
+  static nvtxDomainHandle_t domain;
 };
 
 }  // namespace nvtx

--- a/src/core/utilities/nvtx_help.h
+++ b/src/core/utilities/nvtx_help.h
@@ -27,11 +27,8 @@ namespace nvtx {
 
 class Range {
  public:
-  Range(const char* message) { range_ = nvtxRangeStartA(message); }
-  ~Range() { nvtxRangeEnd(range_); }
-
- private:
-  nvtxRangeId_t range_;
+  Range(const char* message) { nvtxRangePushA(message); }
+  ~Range() { nvtxRangePop(); }
 };
 
 }  // namespace nvtx


### PR DESCRIPTION
This branch makes two changes:

- Replaces the use of the nvtxRangeStart/RangeEnd API with RangePush/RangePop
- Tags NVTX events with a domain specific to legate.core for easy filtering