### PR TITLE
Broaden add_scalar_arg type

### DIFF
--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -120,7 +120,7 @@ class ScalarArg:
         self,
         core_types: ty.TypeSystem,
         value: Any,
-        dtype: Union[DTType, tuple[DTType, ...]],
+        dtype: Union[DTType, tuple[DTType]],
         untyped: bool = True,
     ) -> None:
         self._core_types = core_types
@@ -747,7 +747,7 @@ class TaskLauncher:
     def add_scalar_arg(
         self,
         value: Any,
-        dtype: Union[DTType, tuple[DTType, ...]],
+        dtype: Union[DTType, tuple[DTType]],
         untyped: bool = True,
     ) -> None:
         self._scalars.append(

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -120,7 +120,7 @@ class ScalarArg:
         self,
         core_types: ty.TypeSystem,
         value: Any,
-        dtype: Union[DTType, tuple[DTType]],
+        dtype: Union[DTType, tuple[DTType, ...]],
         untyped: bool = True,
     ) -> None:
         self._core_types = core_types
@@ -747,7 +747,7 @@ class TaskLauncher:
     def add_scalar_arg(
         self,
         value: Any,
-        dtype: DTType,
+        dtype: Union[DTType, tuple[DTType, ...]],
         untyped: bool = True,
     ) -> None:
         self._scalars.append(

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -106,7 +106,7 @@ class OperationProtocol(Protocol):
 
 class TaskProtocol(OperationProtocol, Protocol):
     _task_id: int
-    _scalar_args: list[tuple[Any, Union[DTType, tuple[DTType, ...]]]]
+    _scalar_args: list[tuple[Any, Union[DTType, tuple[DTType]]]]
     _comm_args: list[Communicator]
 
 
@@ -225,9 +225,7 @@ class Task(TaskProtocol):
     ) -> None:
         super().__init__(**kwargs)
         self._task_id = task_id
-        self._scalar_args: list[
-            tuple[Any, Union[DTType, tuple[DTType, ...]]]
-        ] = []
+        self._scalar_args: list[tuple[Any, Union[DTType, tuple[DTType]]]] = []
         self._comm_args: list[Communicator] = []
         self._exn_types: list[type] = []
         self._tb: Union[None, TracebackType] = None
@@ -241,7 +239,7 @@ class Task(TaskProtocol):
         return f"{libname}.Task(tid:{self._task_id}, uid:{self._op_id})"
 
     def add_scalar_arg(
-        self, value: Any, dtype: Union[DTType, tuple[DTType, ...]]
+        self, value: Any, dtype: Union[DTType, tuple[DTType]]
     ) -> None:
         self._scalar_args.append((value, dtype))
 

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -106,7 +106,7 @@ class OperationProtocol(Protocol):
 
 class TaskProtocol(OperationProtocol, Protocol):
     _task_id: int
-    _scalar_args: list[tuple[Any, DTType]]
+    _scalar_args: list[tuple[Any, Union[DTType, tuple[DTType, ...]]]]
     _comm_args: list[Communicator]
 
 
@@ -225,7 +225,9 @@ class Task(TaskProtocol):
     ) -> None:
         super().__init__(**kwargs)
         self._task_id = task_id
-        self._scalar_args: list[tuple[Any, DTType]] = []
+        self._scalar_args: list[
+            tuple[Any, Union[DTType, tuple[DTType, ...]]]
+        ] = []
         self._comm_args: list[Communicator] = []
         self._exn_types: list[type] = []
         self._tb: Union[None, TracebackType] = None
@@ -238,7 +240,9 @@ class Task(TaskProtocol):
         libname = self.context.library.get_name()
         return f"{libname}.Task(tid:{self._task_id}, uid:{self._op_id})"
 
-    def add_scalar_arg(self, value: Any, dtype: DTType) -> None:
+    def add_scalar_arg(
+        self, value: Any, dtype: Union[DTType, tuple[DTType, ...]]
+    ) -> None:
         self._scalar_args.append((value, dtype))
 
     def add_dtype_arg(self, dtype: DTType) -> None:


### PR DESCRIPTION
Original type for `add_scalar_arg` was too narrow, discovered in https://github.com/nv-legate/cunumeric/pull/438