### PR TITLE
add mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,17 @@ repos:
       hooks:
             - id: flake8
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: 'v14.0.6'  # Use the sha / tag you want to point at
+      rev: 'v14.0.6'
       hooks:
         - id: clang-format
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v0.971'
+      hooks:
+        - id: mypy
+          pass_filenames: false
+          args: ['legate']
+          additional_dependencies: [numpy]
 default_language_version:
     python: python3

--- a/legate/core/corelib.py
+++ b/legate/core/corelib.py
@@ -1,4 +1,5 @@
 # Copyright 2021-2022 NVIDIA Corporation
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/legate/core/corelib.py
+++ b/legate/core/corelib.py
@@ -1,4 +1,4 @@
-#
+# Copyright 2021-2022 NVIDIA Corporation
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/legate/core/corelib.py
+++ b/legate/core/corelib.py
@@ -1,4 +1,3 @@
-# Copyright 2021-2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +16,14 @@ from __future__ import annotations
 import os
 from typing import Any, Union
 
-from .install_info import header, libpath
+from .install_info import header, libpath  # type: ignore
 from .legate import Library
 from .resource import ResourceConfig
+
+# This is annoying but install_info is not present on unbuilt source, but is
+# present in built source. So we either get an unfollowed-import error, or an
+# unused-ignore error. Allow unused-ignores just in this file to work around
+# mypy: warn-unused-ignores=False
 
 
 class CoreLib(Library):


### PR DESCRIPTION
This PR adds a [pre-commit hook for mypy](https://github.com/pre-commit/mirrors-mypy). It should run `mypy legate` whenever there are relevant file changes.