### PR TITLE
src: switch to abolute include path for pthread_barrier.h

### DIFF
--- a/src/core.mk
+++ b/src/core.mk
@@ -61,7 +61,7 @@ INSTALL_HEADERS = legate.h                        \
 									legate_preamble.h               \
 									core/legate_c.h                 \
 									core/comm/communicator.h        \
-									core/comm/coll.h		        \
+									core/comm/coll.h                \
 									core/comm/pthread_barrier.h     \
 									core/cuda/cuda_help.h           \
 									core/cuda/stream_pool.h         \

--- a/src/core.mk
+++ b/src/core.mk
@@ -61,7 +61,8 @@ INSTALL_HEADERS = legate.h                        \
 									legate_preamble.h               \
 									core/legate_c.h                 \
 									core/comm/communicator.h        \
-									core/comm/coll.h		\
+									core/comm/coll.h		        \
+									core/comm/pthread_barrier.h     \
 									core/cuda/cuda_help.h           \
 									core/cuda/stream_pool.h         \
 									core/data/allocator.h           \

--- a/src/core/comm/coll.h
+++ b/src/core/comm/coll.h
@@ -30,7 +30,7 @@
 // include unistd.h since that defines _POSIX_BARRIERS.
 #include <unistd.h>
 #if !defined(_POSIX_BARRIERS) || (_POSIX_BARRIERS < 0)
-#include "pthread_barrier.h"
+#include "core/comm/pthread_barrier.h"
 #endif
 #endif
 


### PR DESCRIPTION
This commit switches the relative include of "pthread_barrier.h" to an
absolute path off of core/ so that client libraries that include
"core/comm.h" can find the file.