### PR TITLE
Fix target_memory setting for task futures (#327)

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -608,8 +608,6 @@ void BaseMapper::map_task(const MapperContext ctx,
     auto& mapping    = mappings[mapping_idx];
     auto req_indices = mapping.requirement_indices();
 
-    if (req_indices.empty()) continue;
-
     if (req_indices.empty()) {
       // This is a mapping for futures
       output.future_locations.push_back(get_target_memory(task.target_proc, mapping.policy.target));


### PR DESCRIPTION
Now GPU tasks reading futures won't block on this transfer mid-execution

Co-authored-by: Manolis Papadakis <mpapadakis@nvidia.com>