### PR TITLE
Switch to conda build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/legate.core
           rm -rf ngc-artifacts || true
-          ./build.sh > ${COMMIT}-build.log 2>&1
+          ./build-conda.sh > ${COMMIT}-build.log 2>&1
       - name: Process Output
         run: |
           cd legate-ci/github-ci/legate.core


### PR DESCRIPTION
Build legate.core using the conda build process we use for the release. The potential benefits are using the same process we use for the release and a drastically decreased image size.