### PR TITLE
Correctly inline map 0d stores

### DIFF
--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -340,7 +340,7 @@ class RegionField:
 
         physical_region = self.get_inline_mapped_region(context)
         # We need a pointer to the physical allocation for this physical region
-        dim = len(shape)
+        dim = max(shape.ndim, 1)
         # Build the accessor for this physical region
         if transform is not None:
             # We have a transform so build the accessor special with a
@@ -367,9 +367,13 @@ class RegionField:
             )
         # Now that we've got our accessor we can get a pointer to the memory
         rect = ffi.new(f"legion_rect_{dim}d_t *")
-        for d in range(dim):
-            rect[0].lo.x[d] = 0
-            rect[0].hi.x[d] = shape[d] - 1  # inclusive
+        if shape.ndim == 0:
+            rect[0].lo.x[0] = 0
+            rect[0].hi.x[0] = 0  # inclusive
+        else:
+            for d in range(dim):
+                rect[0].lo.x[d] = 0
+                rect[0].hi.x[d] = shape[d] - 1  # inclusive
         subrect = ffi.new(f"legion_rect_{dim}d_t *")
         offsets = ffi.new("legion_byte_offset_t[]", dim)
         func = getattr(legion, f"legion_accessor_array_{dim}d_raw_rect_ptr")
@@ -385,7 +389,7 @@ class RegionField:
         ptr = ffi.cast("size_t", base_ptr)
         return InlineMappedAllocation(
             self,
-            tuple(shape),
+            tuple(shape) if shape.ndim > 0 else (1,),
             int(ptr),  # type: ignore[call-overload]
             strides,
         )

--- a/legate/core/transform.py
+++ b/legate/core/transform.py
@@ -363,6 +363,8 @@ class Project(Transform):
 
     def get_inverse_transform(self, ndim: int) -> AffineTransform:
         parent_ndim = ndim + 1
+        if ndim == 0:
+            return AffineTransform(parent_ndim, parent_ndim, False)
         result = AffineTransform(parent_ndim, ndim, False)
         result.offset[self._dim] = self._index
         child_dim = 0

--- a/src/core/data/store.inl
+++ b/src/core/data/store.inl
@@ -330,7 +330,7 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor() const
   if (is_future_) return future_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, shape<DIM>());
 
   if (!transform_->identity()) {
-    auto transform = transform_->inverse_transform(DIM);
+    auto transform = transform_->inverse_transform(dim_);
     return region_field_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, shape<DIM>(), transform);
   }
   return region_field_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, shape<DIM>());
@@ -346,7 +346,7 @@ AccessorRO<T, DIM> Store::read_accessor(const Legion::Rect<DIM>& bounds) const
   if (is_future_) return future_.read_accessor<T, DIM>(bounds);
 
   if (!transform_->identity()) {
-    auto transform = transform_->inverse_transform(DIM);
+    auto transform = transform_->inverse_transform(dim_);
     return region_field_.read_accessor<T, DIM>(bounds, transform);
   }
   return region_field_.read_accessor<T, DIM>(bounds);
@@ -362,7 +362,7 @@ AccessorWO<T, DIM> Store::write_accessor(const Legion::Rect<DIM>& bounds) const
   if (is_future_) return future_.write_accessor<T, DIM>(bounds);
 
   if (!transform_->identity()) {
-    auto transform = transform_->inverse_transform(DIM);
+    auto transform = transform_->inverse_transform(dim_);
     return region_field_.write_accessor<T, DIM>(bounds, transform);
   }
   return region_field_.write_accessor<T, DIM>(bounds);
@@ -378,7 +378,7 @@ AccessorRW<T, DIM> Store::read_write_accessor(const Legion::Rect<DIM>& bounds) c
   if (is_future_) return future_.read_write_accessor<T, DIM>(bounds);
 
   if (!transform_->identity()) {
-    auto transform = transform_->inverse_transform(DIM);
+    auto transform = transform_->inverse_transform(dim_);
     return region_field_.read_write_accessor<T, DIM>(bounds, transform);
   }
   return region_field_.read_write_accessor<T, DIM>(bounds);
@@ -394,7 +394,7 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Legion::Rect<DIM>& b
   if (is_future_) return future_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, bounds);
 
   if (!transform_->identity()) {
-    auto transform = transform_->inverse_transform(DIM);
+    auto transform = transform_->inverse_transform(dim_);
     return region_field_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, bounds, transform);
   }
   return region_field_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, bounds);

--- a/src/core/data/transform.cc
+++ b/src/core/data/transform.cc
@@ -63,9 +63,11 @@ Legion::DomainAffineTransform TransformStack::inverse_transform(int32_t in_dim) 
 
 void TransformStack::print(std::ostream& out) const
 {
-#ifdef DEBUG_LEGATE
-  assert(transform_ != nullptr);
-#endif
+  if (identity()) {
+    out << "(identity)";
+    return;
+  }
+
   transform_->print(out);
   if (!parent_->identity()) {
     out << " >> ";


### PR DESCRIPTION
The inline mapping code had been crashing when the store was 0D. This PR fixes that bug.