### PR TITLE
make sure communicators are destroyed one by one

### DIFF
--- a/legate/core/communicator.py
+++ b/legate/core/communicator.py
@@ -161,3 +161,4 @@ class CPUCommunicator(Communicator):
         task = Task(self._context, self._finalize_cpucoll, tag=self._tag)
         task.add_future_map(handle)
         task.execute(Rect([volume]))
+        self._runtime.issue_execution_fence()


### PR DESCRIPTION
Fix the hang of destroy of CPU communicators.
To destroy a communicator, `collCommDestroy` needs to be called by all ranks within the communicator CONCURRENTLY, so we need to make sure communicators are destroyed one by one, otherwise, we may run out of the CPUs to make sure all ranks call `collCommDestroy` concurrently. 