### PR TITLE
Specify an upper bound for return value sizes for `core::extract_scalar`

### DIFF
--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -389,7 +389,11 @@ class Task(TaskProtocol):
             self._demux_scalar_stores_future(result)
         else:
             assert isinstance(result, FutureMap)
-            self._demux_scalar_stores_future_map(result, launch_domain)
+            if launch_domain.get_volume() == 1:
+                future = result.get_future(launch_domain.lo)
+                self._demux_scalar_stores_future(future)
+            else:
+                self._demux_scalar_stores_future_map(result, launch_domain)
 
     def add_nccl_communicator(self) -> None:
         comm = self._context.get_nccl_communicator()

--- a/src/core/comm/comm_cpu.cc
+++ b/src/core/comm/comm_cpu.cc
@@ -64,7 +64,7 @@ static coll::CollComm init_cpucoll(const Legion::Task* task,
   assert(mapping_table[point] == comm->mpi_rank);
   free(mapping_table);
 #else
-  coll::collCommCreate(comm, num_ranks, point, unique_id, NULL);
+  coll::collCommCreate(comm, num_ranks, point, unique_id, nullptr);
 #endif
 
   return comm;
@@ -83,7 +83,7 @@ static void finalize_cpucoll(const Legion::Task* task,
   assert(comm->global_rank == point);
   coll::collCommDestroy(comm);
   free(comm);
-  comm = NULL;
+  comm = nullptr;
 }
 
 void register_tasks(Legion::Machine machine,

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -113,7 +113,7 @@ BaseMapper::~BaseMapper(void)
 {
   // Compute the size of all our remaining instances in each memory
   const char* show_usage = getenv("LEGATE_SHOW_USAGE");
-  if (show_usage != NULL) {
+  if (show_usage != nullptr) {
     auto mem_sizes             = local_instances->aggregate_instance_sizes();
     const char* memory_kinds[] = {
 #define MEM_NAMES(name, desc) desc,

--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -31,9 +31,9 @@ using namespace Legion::Mapping;
 uint32_t extract_env(const char* env_name, const uint32_t default_value, const uint32_t test_value)
 {
   const char* env_value = getenv(env_name);
-  if (env_value == NULL) {
+  if (nullptr == env_value) {
     const char* legate_test = getenv("LEGATE_TEST");
-    if (legate_test != NULL)
+    if (legate_test != nullptr)
       return test_value;
     else
       return default_value;

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -20,6 +20,7 @@
 #include "core/runtime/projection.h"
 #include "core/runtime/shard.h"
 #include "core/task/exception.h"
+#include "core/task/task.h"
 #include "core/utilities/deserializer.h"
 #include "legate.h"
 
@@ -150,8 +151,10 @@ void register_legate_core_tasks(Machine machine, Runtime* runtime, const Library
   {
     auto registrar =
       make_registrar(extract_scalar_task_id, extract_scalar_task_name, Processor::LOC_PROC);
-    runtime->register_task_variant<ReturnValues, extract_scalar_task>(registrar,
-                                                                      LEGATE_CPU_VARIANT);
+    Legion::CodeDescriptor desc(
+      Legion::LegionTaskWrapper::legion_task_wrapper<ReturnValues, extract_scalar_task>);
+    runtime->register_task_variant(
+      registrar, desc, nullptr, 0, LEGATE_MAX_SIZE_SCALAR_RETURN, LEGATE_CPU_VARIANT);
   }
   comm::register_tasks(machine, runtime, context);
 }

--- a/src/core/task/task.cc
+++ b/src/core/task/task.cc
@@ -63,7 +63,7 @@ void LegateTaskRegistrar::register_all_tasks(Runtime* runtime, LibraryContext& c
       context.get_task_id(task.task_id);  // Convert a task local task id to a global id
     // Attach the task name too for debugging
     runtime->attach_name(task.task_id, task.task_name, false /*mutable*/, true /*local only*/);
-    runtime->register_task_variant(task, task.descriptor, NULL, 0, task.ret_size, task.var);
+    runtime->register_task_variant(task, task.descriptor, nullptr, 0, task.ret_size, task.var);
   }
   pending_task_variants_.clear();
 }

--- a/src/core/task/task.h
+++ b/src/core/task/task.h
@@ -248,7 +248,7 @@ class LegateTaskRegistrar {
   struct PendingTaskVariant : public Legion::TaskVariantRegistrar {
    public:
     PendingTaskVariant(void)
-      : Legion::TaskVariantRegistrar(), task_name(NULL), var(LEGATE_NO_VARIANT)
+      : Legion::TaskVariantRegistrar(), task_name(nullptr), var(LEGATE_NO_VARIANT)
     {
     }
     PendingTaskVariant(Legion::TaskID tid,


### PR DESCRIPTION
This PR is to specify an upper bound for return value sizes for `core::extract_scalar`. This also includes a minor optimization for the demux logic that treats future maps of size 1 as futures.