### PR TITLE
Instance manager improvements

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -808,7 +808,7 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
     const Domain domain = runtime->get_index_space_domain(ctx, is);
     group =
       local_instances->find_region_group(regions.front(), domain, fid, target_memory, policy.exact);
-    regions = group->regions;
+    regions = group->get_regions();
   }
 
   bool created     = false;
@@ -969,7 +969,7 @@ bool BaseMapper::map_raw_array(const MapperContext ctx,
   if (runtime->find_or_create_physical_instance(ctx,
                                                 target_memory,
                                                 layout_constraints,
-                                                group->regions,
+                                                group->get_regions(),
                                                 result,
                                                 created,
                                                 true /*acquire*/,

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -786,6 +786,7 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
 
   // This whole process has to appear atomic
   runtime->disable_reentrant(ctx);
+  local_instances->lock();
 
   std::shared_ptr<RegionGroup> group{nullptr};
 
@@ -854,10 +855,12 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
       local_instances->record_instance(group, fid, result, policy);
     }
     // We made it so no need for an acquire
+    local_instances->unlock();
     runtime->enable_reentrant(ctx);
     return false;
   }
   // Done with the atomic part
+  local_instances->unlock();
   runtime->enable_reentrant(ctx);
 
   // If we make it here then we failed entirely

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -45,7 +45,7 @@ BaseMapper::BaseMapper(Runtime* rt, Machine m, const LibraryContext& ctx)
     total_nodes(get_total_nodes(m)),
     mapper_name(std::move(create_name(local_node))),
     logger(create_logger_name().c_str()),
-    local_instances(std::make_unique<InstanceManager>())
+    local_instances(InstanceManager::get_instance_manager())
 {
   // Query to find all our local processors
   Machine::ProcessorQuery local_procs(machine);

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -350,7 +350,7 @@ class BaseMapper : public Legion::Mapping::Mapper, public LegateMapper {
   std::map<std::pair<Legion::TaskID, Legion::Processor::Kind>, Legion::VariantID> leaf_variants;
 
  protected:
-  std::unique_ptr<InstanceManager> local_instances;
+  InstanceManager* local_instances;
 
  protected:
   // Used for n-D cyclic distribution

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -44,12 +44,23 @@ std::vector<LogicalRegion> RegionGroup::get_regions() const
   return std::move(result);
 }
 
-bool RegionGroup::subsumes(const RegionGroup* other) const
+bool RegionGroup::subsumes(const RegionGroup* other)
 {
   if (regions.size() < other->regions.size()) return false;
-  for (auto& region : other->regions)
-    if (regions.find(region) == regions.end()) return false;
-  return true;
+  if (other->regions.size() == 1) {
+    return regions.find(*other->regions.begin()) != regions.end();
+  } else {
+    auto finder = subsumption_cache.find(other);
+    if (finder != subsumption_cache.end()) return finder->second;
+    for (auto& region : other->regions)
+      if (regions.find(region) == regions.end()) {
+        subsumption_cache[other] = false;
+        return false;
+      }
+
+    subsumption_cache[other] = true;
+    return true;
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, const RegionGroup& region_group)

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -231,5 +231,13 @@ std::map<Legion::Memory, size_t> InstanceManager::aggregate_instance_sizes() con
   return result;
 }
 
+/*static*/ InstanceManager* InstanceManager::get_instance_manager()
+{
+  static InstanceManager* manager{nullptr};
+
+  if (nullptr == manager) manager = new InstanceManager();
+  return manager;
+}
+
 }  // namespace mapping
 }  // namespace legate

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -133,14 +133,15 @@ struct construct_overlapping_region_group_fn {
       }
 
       // Only allow merging if the bloating isn't "too big"
-      auto union_bbox  = bound.union_bbox(group_bbox);
-      size_t bound_vol = bound.volume();
-      size_t union_vol = union_bbox.volume();
-      if (too_big(union_vol, bound_vol, group_bbox.volume(), intersect.volume())) {
+      auto union_bbox      = bound.union_bbox(group_bbox);
+      size_t union_vol     = union_bbox.volume();
+      size_t group_vol     = group_bbox.volume();
+      size_t intersect_vol = intersect.volume();
+      if (too_big(union_vol, bound_vol, group_vol, intersect_vol)) {
 #ifdef DEBUG_LEGATE
         log_instmgr.debug() << "    too big to merge (union:" << union_bbox
-                            << ",bound:" << bound_vol << ",group:" << group_bbox.volume()
-                            << ",intersect:" << intersect.volume() << ")";
+                            << ",bound:" << bound_vol << ",group:" << group_vol
+                            << ",intersect:" << intersect_vol << ")";
 #endif
         continue;
       }

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -78,7 +78,7 @@ struct construct_overlapping_region_group_fn {
     for (const auto& pair : instances) {
       auto& group = pair.first;
 
-      Rect<DIM> group_bbox = group->bounding_box;
+      Rect<DIM> group_bbox = group->bounding_box.bounds<DIM, coord_t>();
       auto intersect       = bound.intersection(group_bbox);
       if (intersect.empty()) continue;
 

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -231,6 +231,10 @@ std::map<Legion::Memory, size_t> InstanceManager::aggregate_instance_sizes() con
   return result;
 }
 
+void InstanceManager::lock() { manager_lock_.lock(); }
+
+void InstanceManager::unlock() { manager_lock_.unlock(); }
+
 /*static*/ InstanceManager* InstanceManager::get_instance_manager()
 {
   static InstanceManager* manager{nullptr};

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -42,11 +42,12 @@ struct RegionGroup {
 
  public:
   std::vector<Region> get_regions() const;
-  bool subsumes(const RegionGroup* other) const;
+  bool subsumes(const RegionGroup* other);
 
  public:
   std::set<Region> regions;
   Domain bounding_box;
+  std::map<const RegionGroup*, bool> subsumption_cache;
 };
 
 std::ostream& operator<<(std::ostream& os, const RegionGroup& region_group);

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -141,6 +141,9 @@ class InstanceManager {
   void erase(Instance inst);
 
  public:
+  static InstanceManager* get_instance_manager();
+
+ public:
   std::map<Legion::Memory, size_t> aggregate_instance_sizes() const;
 
  private:

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -90,7 +90,7 @@ struct InstanceSet {
   void dump_and_sanity_check() const;
 
  private:
-  std::map<RegionGroupP, InstanceSpec> instances_;
+  std::map<RegionGroup*, InstanceSpec> instances_;
   std::map<Legion::LogicalRegion, RegionGroupP> groups_;
 };
 

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include "legion.h"
 
@@ -141,13 +142,18 @@ class InstanceManager {
   void erase(Instance inst);
 
  public:
+  void lock();
+  void unlock();
+
+ public:
   static InstanceManager* get_instance_manager();
 
  public:
   std::map<Legion::Memory, size_t> aggregate_instance_sizes() const;
 
  private:
-  std::map<FieldMemInfo, InstanceSet> instance_sets_;
+  std::map<FieldMemInfo, InstanceSet> instance_sets_{};
+  std::mutex manager_lock_{};
 };
 
 }  // namespace mapping

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -45,6 +45,8 @@ struct RegionGroup {
   Domain bounding_box;
 };
 
+std::ostream& operator<<(std::ostream& os, const RegionGroup& region_group);
+
 struct InstanceSet {
  public:
   using Region       = Legion::LogicalRegion;

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -42,6 +42,7 @@ struct RegionGroup {
 
  public:
   std::vector<Region> get_regions() const;
+  bool subsumes(const RegionGroup* other) const;
 
  public:
   std::set<Region> regions;
@@ -84,6 +85,9 @@ struct InstanceSet {
 
  public:
   size_t get_instance_size() const;
+
+ private:
+  void dump_and_sanity_check() const;
 
  private:
   std::map<RegionGroupP, InstanceSpec> instances_;

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -33,15 +33,18 @@ struct RegionGroup {
   using Domain = Legion::Domain;
 
  public:
-  RegionGroup(const std::vector<Region>& regions, const Domain bounding_box);
-  RegionGroup(std::vector<Region>&& regions, const Domain bounding_box);
+  RegionGroup(const std::set<Region>& regions, const Domain bounding_box);
+  RegionGroup(std::set<Region>&& regions, const Domain bounding_box);
 
  public:
   RegionGroup(const RegionGroup&) = default;
   RegionGroup(RegionGroup&&)      = default;
 
  public:
-  std::vector<Region> regions;
+  std::vector<Region> get_regions() const;
+
+ public:
+  std::set<Region> regions;
   Domain bounding_box;
 };
 


### PR DESCRIPTION
Mappers used separate instance managers, which prevented them from reusing instances created by others. This PR fixes that problem simply by sharing the same instance manager with all Legate mappers.

Update: this PR has been updated to contain changes from #351 and other improvements to the instance manager.