### PR TITLE
Instance management fixes to avoid intra-GPU copies

### DIFF
--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -131,6 +131,9 @@ std::set<InstanceSet::Instance> InstanceSet::record_instance(RegionGroupP group,
     if (finder == groups_.end())
       groups_[region] = group;
     else if (finder->second != group) {
+      // NOTE: This assumes that when a Region changes groups, all other Regions originally in the
+      // same group also move to a new group. This is guaranteed in the BaseMapper because the new
+      // group is synthesized within the same atomic block as the record_instance call we are in.
       removed_groups.insert(finder->second);
       finder->second = group;
     }


### PR DESCRIPTION
Two issues combined to cause the mapper to create two separate instances for two mostly-overlapping Region Requirements in the CFD solver example, which then created a lot of back-and-forth copies between them:

* RegionGroups were not being removed from the `instances_` map after they got merged into bigger groups.
* A heuristic was stopping a Region from being merged into a group if the merge would not grow the bounding box of the group being created.

Here is an example run which shows this happening. With the old code, `LogicalRegion(1,IndexSpace(16,4),FieldSpace(1))` could have been merged into RegionGroup `0x7f0d6c442220`, but didn't.

```
cache miss for:
  RegionRequirement[100](privilege=WRITE_DISCARD,tree=1,domain=<0,5000>..<9999,9999>,fields=1048582)
  LogicalRegion(1,IndexSpace(7,4),FieldSpace(1))
merged into group 0x7f0d6c23bfa0 with bounding box <0,5000>..<9999,9999> which contains:
  LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) fid=1048582 domain=<0,5000>..<9999,9999>
recorded instance 4000000000c00006 under group 0x7f0d6c23bfa0
  inside bin FieldMemInfo(tid=1,fid=1048582,memory=1e00000000000003):
    Region -> RegionGroup
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) -> 0x7f0d6c23bfa0
    RegionGroup 0x7f0d6c23bfa0 with bounding box <0,5000>..<9999,9999> -> PhysicalInstance[4000000000c00006](memory=1e00000000000003,domain=<0,5000>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>

cache miss for:
  RegionRequirement[100](privilege=READ_ONLY,tree=1,domain=<1,5000>..<9998,9999>,fields=1048582)
  LogicalRegion(1,IndexSpace(16,4),FieldSpace(1))
merged into group 0x7f0d6c435e20 with bounding box <0,5000>..<9999,9999> which contains:
  LogicalRegion(1,IndexSpace(16,4),FieldSpace(1)) fid=1048582 domain=<1,5000>..<9998,9999>
  LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) fid=1048582 domain=<0,5000>..<9999,9999>
recorded instance 4000000000c00006 under group 0x7f0d6c435e20
  inside bin FieldMemInfo(tid=1,fid=1048582,memory=1e00000000000003):
    Region -> RegionGroup
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) -> 0x7f0d6c435e20
      LogicalRegion(1,IndexSpace(16,4),FieldSpace(1)) -> 0x7f0d6c435e20
    RegionGroup 0x7f0d6c23bfa0 with bounding box <0,5000>..<9999,9999> -> PhysicalInstance[4000000000c00006](memory=1e00000000000003,domain=<0,5000>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>
    RegionGroup 0x7f0d6c435e20 with bounding box <0,5000>..<9999,9999> -> PhysicalInstance[4000000000c00006](memory=1e00000000000003,domain=<0,5000>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(16,4),FieldSpace(1)) domain=<1,5000>..<9998,9999>
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>

cache miss for region requirement:
  RegionRequirement[100](privilege=READ_ONLY,tree=1,domain=<1,4998>..<9998,9997>,fields=1048582)
  region LogicalRegion(1,IndexSpace(18,4),FieldSpace(1))
merged into group 0x7f0d6c442220 with bounding box <0,4998>..<9999,9999> which contains:
  LogicalRegion(1,IndexSpace(18,4),FieldSpace(1)) fid=1048582 domain=<1,4998>..<9998,9997>
  LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) fid=1048582 domain=<0,5000>..<9999,9999>
recorded instance 4000000000c00036 under group 0x7f0d6c442220
  inside bin FieldMemInfo(tid=1,fid=1048582,memory=1e00000000000003):
    Region -> RegionGroup
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) -> 0x7f0d6c442220
      LogicalRegion(1,IndexSpace(16,4),FieldSpace(1)) -> 0x7f0d6c435e20
      LogicalRegion(1,IndexSpace(18,4),FieldSpace(1)) -> 0x7f0d6c442220
    RegionGroup 0x7f0d6c23bfa0 with bounding box <0,5000>..<9999,9999> -> PhysicalInstance[4000000000c00006](memory=1e00000000000003,domain=<0,5000>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>
    RegionGroup 0x7f0d6c435e20 with bounding box <0,5000>..<9999,9999> -> PhysicalInstance[4000000000c00006](memory=1e00000000000003,domain=<0,5000>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(16,4),FieldSpace(1)) domain=<1,5000>..<9998,9999>
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>
    RegionGroup 0x7f0d6c442220 with bounding box <0,4998>..<9999,9999> -> PhysicalInstance[4000000000c00036](memory=1e00000000000003,domain=<0,4998>..<9999,9999>,fields=1048582,layout=SoA:XY)
      LogicalRegion(1,IndexSpace(18,4),FieldSpace(1)) domain=<1,4998>..<9998,9997>
      LogicalRegion(1,IndexSpace(7,4),FieldSpace(1)) domain=<0,5000>..<9999,9999>
```