### PR TITLE
Require labels on pull requests

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "category:new-feature, category:improvement, category:bug-fix, category:task"


### PR DESCRIPTION
Exactly one of the `category` labels is required. Categories are:

- a bug fix (`category:bug-fix`)
- an improvement (`category:improvement`)
- a new feature (`category:new-feature`)
- a task (`category:task`)

The labels will be used to automatically generate release notes. A task is the only label that will cause a PR not to appear in the release notes.