### PR TITLE
Use Legion primitives to coordinate accesses to the shared instance manager

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -778,7 +778,7 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
   auto& fields = layout_constraints.field_constraint.field_set;
 
   // We need to hold the instance manager lock as we're about to try to find an instance
-  AutoLock lock(local_instances->lock());
+  AutoLock lock(local_instances->manager_lock());
 
   // This whole process has to appear atomic
   runtime->disable_reentrant(ctx);

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -778,7 +778,10 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
   auto& fields = layout_constraints.field_constraint.field_set;
 
   // We need to hold the instance manager lock as we're about to try to find an instance
-  local_instances->lock();
+  AutoLock lock(local_instances->lock());
+
+  // This whole process has to appear atomic
+  runtime->disable_reentrant(ctx);
 
   // See if we already have it in our local instances
   if (fields.size() == 1 && regions.size() == 1 &&
@@ -788,13 +791,10 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
     logger.debug() << get_mapper_name() << " found instance " << result << " for "
                    << regions.front();
 #endif
-    local_instances->unlock();
+    runtime->enable_reentrant(ctx);
     // Needs acquire to keep the runtime happy
     return true;
   }
-
-  // This whole process has to appear atomic
-  runtime->disable_reentrant(ctx);
 
   std::shared_ptr<RegionGroup> group{nullptr};
 
@@ -862,14 +862,12 @@ bool BaseMapper::map_legate_store(const MapperContext ctx,
       auto fid = fields.front();
       local_instances->record_instance(group, fid, result, policy);
     }
-    // We made it so no need for an acquire
     runtime->enable_reentrant(ctx);
-    local_instances->unlock();
+    // We made it so no need for an acquire
     return false;
   }
   // Done with the atomic part
   runtime->enable_reentrant(ctx);
-  local_instances->unlock();
 
   // If we make it here then we failed entirely
   auto req_indices = mapping.requirement_indices();

--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -338,10 +338,6 @@ std::map<Legion::Memory, size_t> InstanceManager::aggregate_instance_sizes() con
   return result;
 }
 
-void InstanceManager::lock() { manager_lock_.lock(); }
-
-void InstanceManager::unlock() { manager_lock_.unlock(); }
-
 /*static*/ InstanceManager* InstanceManager::get_instance_manager()
 {
   static InstanceManager* manager{nullptr};

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -152,8 +152,7 @@ class InstanceManager {
   void erase(Instance inst);
 
  public:
-  void lock();
-  void unlock();
+  Legion::Mapping::LocalLock& lock() { return manager_lock_; }
 
  public:
   static InstanceManager* get_instance_manager();
@@ -163,7 +162,7 @@ class InstanceManager {
 
  private:
   std::map<FieldMemInfo, InstanceSet> instance_sets_{};
-  std::mutex manager_lock_{};
+  Legion::Mapping::LocalLock manager_lock_{};
 };
 
 }  // namespace mapping

--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -152,7 +152,7 @@ class InstanceManager {
   void erase(Instance inst);
 
  public:
-  Legion::Mapping::LocalLock& lock() { return manager_lock_; }
+  Legion::Mapping::LocalLock& manager_lock() { return manager_lock_; }
 
  public:
   static InstanceManager* get_instance_manager();


### PR DESCRIPTION
#350 used `std::mutex` to synchronize accesses to the shared instance manager, which turns out to be problematic as the blocking behavior is invisible to the runtime and eventually leads to hangs. This PR replaces that mutex with Legion's locking mechanisms that are compatible with the runtime's thread management.