### PR TITLE
Support for mapper logging

### DIFF
--- a/src/core/runtime/context.cc
+++ b/src/core/runtime/context.cc
@@ -19,15 +19,19 @@
 #include "core/data/buffer.h"
 #include "core/data/scalar.h"
 #include "core/data/store.h"
+#include "core/mapping/base_mapper.h"
 #include "core/runtime/context.h"
+#include "core/runtime/runtime.h"
 #include "core/utilities/deserializer.h"
+
+#include "mappers/logging_wrapper.h"
 
 namespace legate {
 
 LibraryContext::LibraryContext(Legion::Runtime* runtime,
                                const std::string& library_name,
                                const ResourceConfig& config)
-  : library_name_(library_name)
+  : runtime_(runtime), library_name_(library_name)
 {
   task_scope_ = ResourceScope(
     runtime->generate_library_task_ids(library_name.c_str(), config.max_tasks), config.max_tasks);
@@ -138,6 +142,15 @@ bool LibraryContext::valid_projection_id(Legion::ProjectionID proj_id) const
 bool LibraryContext::valid_sharding_id(Legion::ShardingID shard_id) const
 {
   return shard_scope_.in_scope(shard_id);
+}
+
+void LibraryContext::register_mapper(mapping::BaseMapper* mapper, int64_t local_mapper_id) const
+{
+  auto mapper_id = get_mapper_id(local_mapper_id);
+  if (Core::log_mapping_decisions)
+    runtime_->add_mapper(mapper_id, new Legion::Mapping::LoggingWrapper(mapper, &mapper->logger));
+  else
+    runtime_->add_mapper(mapper_id, mapper);
 }
 
 TaskContext::TaskContext(const Legion::Task* task,

--- a/src/core/runtime/context.h
+++ b/src/core/runtime/context.h
@@ -23,6 +23,12 @@
 
 namespace legate {
 
+namespace mapping {
+
+class BaseMapper;
+
+}  // namespace mapping
+
 class Store;
 class Scalar;
 
@@ -95,7 +101,11 @@ class LibraryContext {
   bool valid_projection_id(Legion::ProjectionID proj_id) const;
   bool valid_sharding_id(Legion::ShardingID shard_id) const;
 
+ public:
+  void register_mapper(mapping::BaseMapper* mapper, int64_t local_mapper_id = 0) const;
+
  private:
+  Legion::Runtime* runtime_;
   const std::string library_name_;
   ResourceScope task_scope_;
   ResourceScope mapper_scope_;

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -40,6 +40,8 @@ static const char* const core_library_name = "legate.core";
 
 /*static*/ bool Core::synchronize_stream_view = false;
 
+/*static*/ bool Core::log_mapping_decisions = false;
+
 /*static*/ void Core::parse_config(void)
 {
 #ifndef LEGATE_USE_CUDA
@@ -69,14 +71,15 @@ static const char* const core_library_name = "legate.core";
     exit(1);
   }
 #endif
-  const char* progress = getenv("LEGATE_SHOW_PROGRESS");
-  if (progress != nullptr) show_progress_requested = true;
+  auto parse_variable = [](const char* variable, bool& result) {
+    const char* value = getenv(variable);
+    if (value != nullptr && atoi(value) > 0) result = true;
+  };
 
-  const char* empty_task = getenv("LEGATE_EMPTY_TASK");
-  if (empty_task != nullptr && atoi(empty_task) > 0) use_empty_task = true;
-
-  const char* sync_stream_view = getenv("LEGATE_SYNC_STREAM_VIEW");
-  if (sync_stream_view != nullptr && atoi(sync_stream_view) > 0) synchronize_stream_view = true;
+  parse_variable("LEGATE_SHOW_PROGRESS", show_progress_requested);
+  parse_variable("LEGATE_EMPTY_TASK", use_empty_task);
+  parse_variable("LEGATE_SYNC_STREAM_VIEW", synchronize_stream_view);
+  parse_variable("LEGATE_LOG_MAPPING", log_mapping_decisions);
 }
 
 static ReturnValues extract_scalar_task(const Task* task,

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -42,6 +42,7 @@ class Core {
   static bool show_progress_requested;
   static bool use_empty_task;
   static bool synchronize_stream_view;
+  static bool log_mapping_decisions;
 };
 
 }  // namespace legate


### PR DESCRIPTION
This PR adds a new shell variable `LEGATE_LOG_MAPPING` that produces detailed logging on mapping decisions when set.