### PR TITLE
Turn off the precise stacktrace capturing by default

### DIFF
--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -141,7 +141,7 @@ CoreMapper::CoreMapper(MapperRuntime* rt, Machine m, const LibraryContext& c)
                   64,
 #endif
                   1)),
-    precise_exception_trace(static_cast<bool>(extract_env("LEGATE_PRECISE_EXCEPTION_TRACE", 0, 1))),
+    precise_exception_trace(static_cast<bool>(extract_env("LEGATE_PRECISE_EXCEPTION_TRACE", 0, 0))),
     field_reuse_frac(extract_env("LEGATE_FIELD_REUSE_FRAC", 256, 256)),
     field_reuse_freq(extract_env("LEGATE_FIELD_REUSE_FREQ", 32, 32)),
     has_socket_mem(false)


### PR DESCRIPTION
The precise stacktrace capturing seems to be causing all sorts of confusion and problems as it's been turned on by default in debug mode. This PR requires it to be explicitly requested.