### PR TITLE
Scalar store fix

### DIFF
--- a/legate.py
+++ b/legate.py
@@ -483,11 +483,11 @@ def run_legate(
         )
         print()
         print(
-            "(lldb) process launch -v "
+            "(lldb) process launch -E "
             + LIB_PATH
             + "="
             + cmd_env[LIB_PATH]
-            + " -v PYTHONPATH="
+            + " -E PYTHONPATH="
             + cmd_env["PYTHONPATH"]
         )
         print()

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -763,7 +763,16 @@ class TaskLauncher:
             if TYPE_CHECKING:
                 assert isinstance(store.storage, Future)
 
-            has_storage = perm != Permission.WRITE
+            # In theory we need to copy the storage's current value only when
+            # the store can ever be read by the task, but the permission being
+            # WRITE alone doesn't guarantee the read access freedom, as
+            # the same store can also be passed as an input and we don't
+            # perform coalescing analyses for future-backed stores as we do
+            # for region-backed ones. Here we simply pass the storage's
+            # current value whenever the store has a storage. (if this
+            # was a write-only store, it would not have a storage yet, but
+            # the inverse isn't true.)
+            has_storage = store.has_storage
             read_only = perm == Permission.READ
             if has_storage:
                 self.add_future(store.storage)

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -950,6 +950,10 @@ class Store:
             )
         return self._storage.data
 
+    @property
+    def has_storage(self) -> bool:
+        return self._storage.has_data
+
     def same_root(self, rhs: Store) -> bool:
         return self._storage.get_root() is rhs._storage.get_root()
 


### PR DESCRIPTION
Scalar stores didn't work correctly if they were passed as inout arguments (i.e., when the same scalar store is passed as both an input and an output). This PR fixes the issue.