### PR TITLE
Adjust consensus match frequency based on field sizes

### DIFF
--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1272,12 +1272,7 @@ class Runtime:
         return self.region_managers_by_region[region]
 
     def revive_manager(self, region_mgr: RegionManager) -> None:
-        lru_managers: Deque[RegionManager] = deque()
-        for to_check in self.lru_managers:
-            if to_check is not region_mgr:
-                lru_managers.append(to_check)
-        assert len(lru_managers) < len(self.lru_managers)
-        self.lru_managers = lru_managers
+        self.lru_managers.remove(region_mgr)
 
     def free_region_manager(
         self, shape: Shape, region: Region, unordered: bool = False


### PR DESCRIPTION
PR #364 accidentally removed the heuristic that issues consensus matches more frequently for bigger fields. This PR recovers that heuristic in the form of match credits: Each field manager is now assigned a credit based on its size. Whenever a new free field arrives at the field manager, it adds its credit to the match manager's counter. When the counter exceeds a threshold, the match manager issues a consensus match.