### PR TITLE
Driver verbose only for rank 0 or "none" launcher

### DIFF
--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -88,7 +88,9 @@ class Driver:
 
         """
         if self.config.info.verbose:
-            print_verbose(self.system, self)
+            # we only want to print verbose output on a "head" node
+            if self.launcher.kind != "none" or self.launcher.rank_id == "0":
+                print_verbose(self.system, self)
 
         self._darwin_gdb_warn()
 

--- a/tests/unit/legate/driver/test_driver.py
+++ b/tests/unit/legate/driver/test_driver.py
@@ -23,7 +23,7 @@ from util import Capsys, GenConfig
 import legate.driver.driver as m
 from legate.driver.args import LAUNCHERS
 from legate.driver.command import CMD_PARTS
-from legate.driver.launcher import Launcher
+from legate.driver.launcher import RANK_ENV_VARS, Launcher
 from legate.driver.system import System
 from legate.driver.types import LauncherType
 from legate.driver.ui import scrub
@@ -128,6 +128,35 @@ class TestDriver:
         pv_out = scrub(capsys.readouterr()[0]).strip()
 
         assert pv_out in run_out
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    def test_verbose_nonero_rank_id(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: Capsys,
+        genconfig: GenConfig,
+        rank_var: str,
+    ) -> None:
+        for name in RANK_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv(name, "1")
+
+        # set --dry-run to avoid needing to mock anything
+        config = genconfig(
+            ["--launcher", "none", "--verbose", "--dry-run"], multi_rank=(2, 2)
+        )
+        system = System()
+        driver = m.Driver(config, system)
+
+        driver.run()
+
+        run_out = scrub(capsys.readouterr()[0]).strip()
+
+        print_verbose(driver.system, driver)
+
+        pv_out = scrub(capsys.readouterr()[0]).strip()
+
+        assert pv_out not in run_out
 
     @pytest.mark.parametrize("launch", LAUNCHERS)
     def test_darwin_gdb_warning(


### PR DESCRIPTION
closes #401 

tests:

```
bldtest ❯ pt tests/unit/legate/driver -v -k test_verbose_nonero_rank_id
=================================================== test session starts ===================================================
platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- /home/bryan/anaconda3/envs/bldtest/bin/python
cachedir: .pytest_cache
rootdir: /home/bryan/work/legate.core
plugins: mock-3.8.2, cov-3.0.0, lazy-fixture-0.6.3
collected 1046 items / 1042 deselected / 4 selected                                                                       

tests/unit/legate/driver/test_driver.py::TestDriver::test_verbose_nonero_rank_id[OMPI_COMM_WORLD_RANK] PASSED       [ 25%]
tests/unit/legate/driver/test_driver.py::TestDriver::test_verbose_nonero_rank_id[PMI_RANK] PASSED                   [ 50%]
tests/unit/legate/driver/test_driver.py::TestDriver::test_verbose_nonero_rank_id[MV2_COMM_WORLD_RANK] PASSED        [ 75%]
tests/unit/legate/driver/test_driver.py::TestDriver::test_verbose_nonero_rank_id[SLURM_PROCID] PASSED               [100%]

=========================================== 4 passed, 1042 deselected in 0.16s ============================================

```