### PR TITLE
Revive dead region managers on field allocations

### DIFF
--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -264,14 +264,20 @@ class RegionManager:
         # unordered destructions
         self._region.destroy(unordered)
 
-    def increase_field_count(self) -> bool:
+    def increase_active_field_count(self) -> bool:
         revived = self._active_field_count == 0
         self._active_field_count += 1
         return revived
 
-    def decrease_field_count(self) -> bool:
+    def decrease_active_field_count(self) -> bool:
         self._active_field_count -= 1
         return self._active_field_count == 0
+
+    def increase_field_count(self) -> bool:
+        fresh = self._alloc_field_count == 0
+        self._alloc_field_count += 1
+        revived = self.increase_active_field_count()
+        return not fresh and revived
 
     @property
     def has_space(self) -> bool:
@@ -282,13 +288,12 @@ class RegionManager:
         self._next_field_id += 1
         return field_id
 
-    def allocate_field(self, field_size: Any) -> tuple[Region, int]:
+    def allocate_field(self, field_size: Any) -> tuple[Region, int, bool]:
         field_id = self._region.field_space.allocate_field(
             field_size, self.get_next_field_id()
         )
-        self._alloc_field_count += 1
-        self.increase_field_count()
-        return self._region, field_id
+        revived = self.increase_field_count()
+        return self._region, field_id, revived
 
 
 # This class manages the allocation and reuse of fields
@@ -316,18 +321,23 @@ class FieldManager:
     def allocate_field(self) -> tuple[Region, int]:
         if (result := self.try_reuse_field()) is not None:
             region_manager = self.runtime.find_region_manager(result[0])
-            if region_manager.increase_field_count():
+            if region_manager.increase_active_field_count():
                 self.runtime.revive_manager(region_manager)
             return result
         region_manager = self.runtime.find_or_create_region_manager(self.shape)
-        return region_manager.allocate_field(self.field_size)
+        region, field_id, revived = region_manager.allocate_field(
+            self.field_size
+        )
+        if revived:
+            self.runtime.revive_manager(region_manager)
+        return region, field_id
 
     def free_field(
         self, region: Region, field_id: int, ordered: bool = False
     ) -> None:
         self.free_fields.append((region, field_id))
         region_manager = self.runtime.find_region_manager(region)
-        if region_manager.decrease_field_count():
+        if region_manager.decrease_active_field_count():
             self.runtime.free_region_manager(
                 self.shape, region, unordered=not ordered
             )
@@ -1362,7 +1372,9 @@ class Runtime:
             self.region_managers_by_region[region] = region_mgr
             self.find_or_create_field_manager(shape, dtype.size)
 
-        region_mgr.increase_field_count()
+        revived = region_mgr.increase_field_count()
+        if revived:
+            self.revive_manager(region_mgr)
         return RegionField.create(region, field_id, dtype.size, shape)
 
     def create_output_region(

--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -145,7 +145,7 @@ CoreMapper::CoreMapper(MapperRuntime* rt, Machine m, const LibraryContext& c)
     precise_exception_trace(static_cast<bool>(extract_env("LEGATE_PRECISE_EXCEPTION_TRACE", 0, 0))),
     field_reuse_frac(extract_env("LEGATE_FIELD_REUSE_FRAC", 256, 256)),
     field_reuse_freq(extract_env("LEGATE_FIELD_REUSE_FREQ", 32, 32)),
-    max_lru_length(extract_env("LEGATE_MAX_LRU_LENGTH", 5, 0)),
+    max_lru_length(extract_env("LEGATE_MAX_LRU_LENGTH", 5, 1)),
     has_socket_mem(false)
 {
   // Query to find all our local processors


### PR DESCRIPTION
Fixes #407. The code was allowing field managers to create fields on dead region managers (i.e., those kept in the LRU queue) and when those fields are gc'ed, they "double free" their region managers. This PR fixes the problem by reviving dead region managers upon fresh field allocations.

Since this is a critical bug fix, this needs to be merged with `branch-22.10` first and ported to `branch-22.12`.