### PR TITLE
Fix an issue with editable installs

### DIFF
--- a/legate/util/fs.py
+++ b/legate/util/fs.py
@@ -281,50 +281,52 @@ def get_legion_paths(legate_paths: LegatePaths) -> LegionPaths:
     cmake_cache_txt = legate_build_dir / "CMakeCache.txt"
 
     try:
-        # Test whether Legion_DIR is set. If it isn't, then we built Legion as
-        # a side-effect of building legate_core
-        read_cmake_cache_value(
-            cmake_cache_txt, "Legion_DIR:PATH=Legion_DIR-NOTFOUND"
-        )
-    except Exception:
-        # If Legion_DIR is a valid path, check whether it's a
-        # Legion build dir, i.e. `-D Legion_ROOT=/legion/build`
-        legion_dir = Path(
-            read_cmake_cache_value(cmake_cache_txt, "Legion_DIR:PATH=")
-        )
-        if legion_dir.joinpath("CMakeCache.txt").exists():
-            cmake_cache_txt = legion_dir / "CMakeCache.txt"
-
-    try:
-        # If Legion_SOURCE_DIR and Legion_BINARY_DIR are in CMakeCache.txt,
-        # return the paths to Legion in the legate_core build dir.
-        legion_source_dir = Path(
+        try:
+            # Test whether Legion_DIR is set. If it isn't, then we built
+            # Legion as a side-effect of building legate_core
             read_cmake_cache_value(
-                cmake_cache_txt, "Legion_SOURCE_DIR:STATIC="
+                cmake_cache_txt, "Legion_DIR:PATH=Legion_DIR-NOTFOUND"
             )
-        )
-        legion_binary_dir = Path(
-            read_cmake_cache_value(
-                cmake_cache_txt, "Legion_BINARY_DIR:STATIC="
+        except Exception:
+            # If Legion_DIR is a valid path, check whether it's a
+            # Legion build dir, i.e. `-D Legion_ROOT=/legion/build`
+            legion_dir = Path(
+                read_cmake_cache_value(cmake_cache_txt, "Legion_DIR:PATH=")
             )
-        )
+            if legion_dir.joinpath("CMakeCache.txt").exists():
+                cmake_cache_txt = legion_dir / "CMakeCache.txt"
 
-        legion_runtime_dir = legion_binary_dir / "runtime"
-        legion_bindings_dir = legion_source_dir / "bindings"
-
-        return LegionPaths(
-            legion_bin_path=legion_binary_dir / "bin",
-            legion_lib_path=legion_binary_dir / "lib",
-            realm_defines_h=legion_runtime_dir / "realm_defines.h",
-            legion_defines_h=legion_runtime_dir / "legion_defines.h",
-            legion_spy_py=legion_source_dir / "tools" / "legion_spy.py",
-            legion_prof_py=legion_source_dir / "tools" / "legion_prof.py",
-            legion_python=legion_binary_dir / "bin" / "legion_python",
-            legion_module=legion_bindings_dir / "python" / "build" / "lib",
-            legion_jupyter_module=legion_source_dir / "jupyter_notebook",
-        )
     except Exception:
-        pass
+        try:
+            # If Legion_SOURCE_DIR and Legion_BINARY_DIR are in CMakeCache.txt,
+            # return the paths to Legion in the legate_core build dir.
+            legion_source_dir = Path(
+                read_cmake_cache_value(
+                    cmake_cache_txt, "Legion_SOURCE_DIR:STATIC="
+                )
+            )
+            legion_binary_dir = Path(
+                read_cmake_cache_value(
+                    cmake_cache_txt, "Legion_BINARY_DIR:STATIC="
+                )
+            )
+
+            legion_runtime_dir = legion_binary_dir / "runtime"
+            legion_bindings_dir = legion_source_dir / "bindings"
+
+            return LegionPaths(
+                legion_bin_path=legion_binary_dir / "bin",
+                legion_lib_path=legion_binary_dir / "lib",
+                realm_defines_h=legion_runtime_dir / "realm_defines.h",
+                legion_defines_h=legion_runtime_dir / "legion_defines.h",
+                legion_spy_py=legion_source_dir / "tools" / "legion_spy.py",
+                legion_prof_py=legion_source_dir / "tools" / "legion_prof.py",
+                legion_python=legion_binary_dir / "bin" / "legion_python",
+                legion_module=legion_bindings_dir / "python" / "build" / "lib",
+                legion_jupyter_module=legion_source_dir / "jupyter_notebook",
+            )
+        except Exception:
+            pass
 
     # Otherwise return the installation paths.
     return installed_legion_paths(Path(sys.argv[0]).parents[1])

--- a/tests/unit/legate/driver/test_main.py
+++ b/tests/unit/legate/driver/test_main.py
@@ -14,6 +14,8 @@
 #
 from __future__ import annotations
 
+import sys
+
 from pytest_mock import MockerFixture
 
 import legate.driver as m
@@ -34,8 +36,9 @@ def test_main(mocker: MockerFixture) -> None:
     system_spy = mocker.spy(legate.util.system.System, "__init__")
     driver_spy = mocker.spy(legate.driver.driver.Driver, "__init__")
     mocker.patch("legate.driver.driver.Driver.run", return_value=123)
+    mocker.patch.object(sys, "argv", ["foo", "bar"])
 
-    result = m.main(["foo", "bar"])
+    result = m.main()
 
     assert config_spy.call_count == 1
     assert config_spy.call_args[0][1:] == (["foo", "bar"],)


### PR DESCRIPTION
A call to `read_cmake_cache_value` in an `except` block could itself also raise an exception, this needed to be guarded against. 