### PR TITLE
Report pytest exit code on fail

### DIFF
--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -112,4 +112,4 @@ def log_proc(
     elif proc.returncode == 0:
         LOG(passed(msg, details=details))
     else:
-        LOG(failed(msg, details=details))
+        LOG(failed(msg, details=details, exit_code=proc.returncode))

--- a/legate/util/ui.py
+++ b/legate/util/ui.py
@@ -110,7 +110,9 @@ def error(text: str) -> str:
     return red(f"ERROR: {text}")
 
 
-def failed(msg: str, *, details: Details | None = None) -> str:
+def failed(
+    msg: str, *, details: Details | None = None, exit_code: int | None = None
+) -> str:
     """Report a failed test result with a bright red [FAIL].
 
     Parameters
@@ -122,9 +124,11 @@ def failed(msg: str, *, details: Details | None = None) -> str:
         A sequenece of text lines to diplay below the ``msg`` line
 
     """
+    fail = f"{bright(red('[FAIL]'))}"
+    exit = f"{bright(white(f' (exit: {exit_code}) '))}" if exit_code else ""
     if details:
-        return f"{bright(red('[FAIL]'))} {msg}\n{_format_details(details)}"
-    return f"{bright(red('[FAIL]'))} {msg}"
+        return f"{fail} {msg}{exit}\n{_format_details(details)}"
+    return f"{fail} {msg}{exit}"
 
 
 def passed(msg: str, *, details: Details | None = None) -> str:

--- a/tests/unit/legate/util/test_ui.py
+++ b/tests/unit/legate/util/test_ui.py
@@ -321,6 +321,20 @@ def test_failed_plain(use_plain_text: UsePlainTextFixture) -> None:
 
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")
+def test_failed_with_exit_code() -> None:
+    assert (
+        m.failed("msg", exit_code=10)
+        == f"{colors.bright(colors.red('[FAIL]'))} msg{colors.bright(colors.white(' (exit: 10) '))}"  # noqa
+    )
+
+
+def test_failed_with_exit_code_plain(
+    use_plain_text: UsePlainTextFixture,
+) -> None:
+    assert m.failed("msg", exit_code=10) == "[FAIL] msg (exit: 10) "
+
+
+@pytest.mark.skipif(colorama is None, reason="colorama required")
 def test_failed_with_details() -> None:
     assert (
         m.failed("msg", details=["a", "b"])
@@ -332,6 +346,23 @@ def test_failed_with_details_plain(
     use_plain_text: UsePlainTextFixture,
 ) -> None:
     assert m.failed("msg", details=["a", "b"]) == "[FAIL] msg\n   a\n   b"
+
+
+@pytest.mark.skipif(colorama is None, reason="colorama required")
+def test_failed_with_details_and_exit_code() -> None:
+    assert (
+        m.failed("msg", details=["a", "b"], exit_code=10)
+        == f"{colors.bright(colors.red('[FAIL]'))} msg{colors.bright(colors.white(' (exit: 10) '))}\n   a\n   b"  # noqa
+    )
+
+
+def test_failed_with_details_and_exit_code_plain(
+    use_plain_text: UsePlainTextFixture,
+) -> None:
+    assert (
+        m.failed("msg", details=["a", "b"], exit_code=10)
+        == "[FAIL] msg (exit: 10) \n   a\n   b"
+    )
 
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")

--- a/tests/unit/legate/util/test_ui.py
+++ b/tests/unit/legate/util/test_ui.py
@@ -322,10 +322,9 @@ def test_failed_plain(use_plain_text: UsePlainTextFixture) -> None:
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")
 def test_failed_with_exit_code() -> None:
-    assert (
-        m.failed("msg", exit_code=10)
-        == f"{colors.bright(colors.red('[FAIL]'))} msg{colors.bright(colors.white(' (exit: 10) '))}"  # noqa
-    )
+    fail = colors.bright(colors.red("[FAIL]"))
+    exit = colors.bright(colors.white(" (exit: 10) "))
+    assert m.failed("msg", exit_code=10) == f"{fail} msg{exit}"  # noqa
 
 
 def test_failed_with_exit_code_plain(
@@ -350,9 +349,11 @@ def test_failed_with_details_plain(
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")
 def test_failed_with_details_and_exit_code() -> None:
+    fail = colors.bright(colors.red("[FAIL]"))
+    exit = colors.bright(colors.white(" (exit: 10) "))
     assert (
         m.failed("msg", details=["a", "b"], exit_code=10)
-        == f"{colors.bright(colors.red('[FAIL]'))} msg{colors.bright(colors.white(' (exit: 10) '))}\n   a\n   b"  # noqa
+        == f"{fail} msg{exit}\n   a\n   b"
     )
 
 


### PR DESCRIPTION
This PR adds explicit reporting of `pytest.main` exit codes on failure, since there are currently some cases where all individual tests are passing, yet the process is failing overall. 

Looks like:
```
[FAIL] (Eager) tests/integration/test_slicing.py (exit: 1) 
```

ref: https://docs.pytest.org/en/stable/reference/exit-codes.html
