### PR TITLE
Allow launcher_extra to split quoted values

### DIFF
--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -43,6 +43,14 @@ class MultiNode(DataclassMixin):
     launcher: LauncherType
     launcher_extra: list[str]
 
+    def __post_init__(self, **kw: dict[str, Any]) -> None:
+        # fix up launcher_extra to automaticaly handle quoted strings with
+        # internal whitespace, have to use __setattr__ for frozen
+        # https://docs.python.org/3/library/dataclasses.html#frozen-instances
+        if self.launcher_extra:
+            ex: list[str] = sum((x.split() for x in self.launcher_extra), [])
+            object.__setattr__(self, "launcher_extra", ex)
+
     @property
     def ranks(self) -> int:
         return self.nodes * self.ranks_per_node

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -54,6 +54,41 @@ class TestMultiNode:
     def test_mixin(self) -> None:
         assert issubclass(m.MultiNode, DataclassMixin)
 
+    @pytest.mark.parametrize(
+        "extra",
+        (["a"], ["a", "b c"], ["a", "b c", "d e"], ["a", "b c", "d e", "f"]),
+    )
+    def test_launcher_extra_fixup_basic(self, extra) -> None:
+        mn = m.MultiNode(
+            nodes=1,
+            ranks_per_node=1,
+            not_control_replicable=False,
+            launcher="launcher",
+            launcher_extra=extra,
+        )
+        assert mn.launcher_extra == sum((x.split() for x in extra), [])
+
+    def test_launcher_extra_fixup_complex(self) -> None:
+        mn = m.MultiNode(
+            nodes=1,
+            ranks_per_node=1,
+            not_control_replicable=False,
+            launcher="launcher",
+            launcher_extra=[
+                "-H g0002,g0002 -X SOMEENV --fork",
+                "-bind-to none",
+            ],
+        )
+        assert mn.launcher_extra == [
+            "-H",
+            "g0002,g0002",
+            "-X",
+            "SOMEENV",
+            "--fork",
+            "-bind-to",
+            "none",
+        ]
+
 
 class TestBinding:
     def test_fields(self) -> None:


### PR DESCRIPTION
This PR makes the driver automatically split `--launcher-extra` values on whitespace internally, Doing so allows for simpler invocations with quoted strings like this:
```
legate --launcher-extra="-H =g0002,g0003"
```
rather than having to manually split across multiple `--launcher-extra` arguments as is currently required:
```
legate --launcher-extra="-H" --launcher-extra="g0002,g0003"
```

cc @lightsighter 