### PR TITLE
Make terminal colors explicitly opt-in

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -330,3 +330,11 @@ other.add_argument(
     required=False,
     help="Whether to run with rlwrap to improve readline ability",
 )
+
+other.add_argument(
+    "--color",
+    dest="color",
+    action="store_true",
+    required=False,
+    help="Whether to use color terminal output (if colorama is installed)",
+)

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -23,6 +23,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Protocol
 
+from ..util import colors
 from ..util.types import (
     ArgList,
     DataclassMixin,
@@ -156,6 +157,8 @@ class Config:
         self.argv = argv
 
         args, extra = parser.parse_known_args(self.argv[1:])
+
+        colors.ENABLED = args.color
 
         # only saving this for help with testing
         self._args = args

--- a/legate/jupyter/args.py
+++ b/legate/jupyter/args.py
@@ -105,3 +105,11 @@ info.add_argument(
     default=0,
     help="Display verbose output. Use -vv for even more output (test stdout)",
 )
+
+info.add_argument(
+    "--color",
+    dest="color",
+    action="store_true",
+    required=False,
+    help="Whether to use color terminal output (if colorama is installed)",
+)

--- a/legate/jupyter/config.py
+++ b/legate/jupyter/config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+import legate.util.colors as colors
 from legate.driver.config import (
     Binding,
     Core,
@@ -63,6 +64,8 @@ class Config:
 
         # only saving these for help with testing
         self._args = args
+
+        colors.ENABLED = args.color
 
         if args.display_name is None:
             args.display_name = args.spec_name

--- a/legate/tester/args.py
+++ b/legate/tester/args.py
@@ -248,3 +248,11 @@ test_opts.add_argument(
     action="store_true",
     help="Print out the commands that are to be executed",
 )
+
+parser.add_argument(
+    "--color",
+    dest="color",
+    action="store_true",
+    required=False,
+    help="Whether to use color terminal output (if colorama is installed)",
+)

--- a/legate/tester/config.py
+++ b/legate/tester/config.py
@@ -21,6 +21,7 @@ import os
 from argparse import Namespace
 from pathlib import Path
 
+from ..util import colors
 from ..util.types import ArgList, EnvDict
 from . import DEFAULT_PROCESS_ENV, FEATURES, SKIPPED_EXAMPLES, FeatureType
 from .args import parser
@@ -41,6 +42,8 @@ class Config:
         self.argv = argv
 
         args, self._extra_args = parser.parse_known_args(self.argv[1:])
+
+        colors.ENABLED = args.color
 
         # which tests to run
         self.examples = False if args.cov_bin else True

--- a/legate/util/colors.py
+++ b/legate/util/colors.py
@@ -37,6 +37,9 @@ __all__ = (
 )
 
 
+ENABLED = False
+
+
 def _text(text: str) -> str:
     return text
 
@@ -45,27 +48,43 @@ try:
     import colorama  # type: ignore[import]
 
     def bright(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Style.BRIGHT}{text}{colorama.Style.RESET_ALL}"
 
     def dim(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Style.DIM}{text}{colorama.Style.RESET_ALL}"
 
     def white(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.WHITE}{text}{colorama.Style.RESET_ALL}"
 
     def cyan(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.CYAN}{text}{colorama.Style.RESET_ALL}"
 
     def red(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.RED}{text}{colorama.Style.RESET_ALL}"
 
     def magenta(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.MAGENTA}{text}{colorama.Style.RESET_ALL}"
 
     def green(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.GREEN}{text}{colorama.Style.RESET_ALL}"
 
     def yellow(text: str) -> str:
+        if not ENABLED:
+            return text
         return f"{colorama.Fore.YELLOW}{text}{colorama.Style.RESET_ALL}"
 
     if sys.platform == "win32":

--- a/legate/util/colors.py
+++ b/legate/util/colors.py
@@ -37,6 +37,9 @@ __all__ = (
 )
 
 
+# Color terminal output needs to be explicitly opt-in. Applications that want
+# to enable it should set this global flag to True, e.g based on a command line
+# argument or other user-supplied configuration
 ENABLED = False
 
 

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -23,6 +23,7 @@ from pytest_mock import MockerFixture
 
 import legate.driver.config as m
 import legate.driver.defaults as defaults
+from legate.util import colors
 from legate.util.colors import scrub
 from legate.util.types import DataclassMixin
 
@@ -173,6 +174,8 @@ class TestConfig:
 
         c = m.Config(["legate"])
 
+        assert colors.ENABLED is False
+
         assert c.multi_node == m.MultiNode(
             nodes=defaults.LEGATE_NODES,
             ranks_per_node=defaults.LEGATE_RANKS_PER_NODE,
@@ -231,6 +234,11 @@ class TestConfig:
         assert c.info == m.Info(progress=False, mem_usage=False, verbose=False)
 
         assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
+
+    def test_color_arg(self) -> None:
+        m.Config(["legate", "--color"])
+
+        assert colors.ENABLED is True
 
     def test_arg_conversions(self, mocker: MockerFixture) -> None:
 

--- a/tests/unit/legate/jupyter/test_config.py
+++ b/tests/unit/legate/jupyter/test_config.py
@@ -22,6 +22,7 @@ from pytest_mock import MockerFixture
 import legate.driver.defaults as defaults
 import legate.jupyter.config as m
 from legate.driver.config import Core, Memory, MultiNode
+from legate.util import colors
 from legate.util.types import DataclassMixin
 
 
@@ -46,6 +47,8 @@ class TestConfig:
         # is that the generated config matches those values, whatever they are.
 
         c = m.Config(["legate-jupyter"])
+
+        assert colors.ENABLED is False
 
         assert c.multi_node == m.MultiNode(
             nodes=defaults.LEGATE_NODES,
@@ -107,6 +110,11 @@ class TestConfig:
         assert c.info == m.Info(progress=False, mem_usage=False, verbose=False)
 
         assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
+
+    def test_color_arg(self) -> None:
+        m.Config(["legate-jupyter", "--color"])
+
+        assert colors.ENABLED is True
 
     def test_arg_conversions(self, mocker: MockerFixture) -> None:
 

--- a/tests/unit/legate/tester/test_config.py
+++ b/tests/unit/legate/tester/test_config.py
@@ -32,11 +32,14 @@ from legate.tester import (
     config as m,
 )
 from legate.tester.args import PIN_OPTIONS, PinOptionsType
+from legate.util import colors
 
 
 class TestConfig:
     def test_default_init(self) -> None:
         c = m.Config([])
+
+        assert colors.ENABLED is False
 
         assert c.examples is True
         assert c.integration is True
@@ -74,6 +77,11 @@ class TestConfig:
         assert c.cov_bin is None
         assert c.cov_args == "run -a --branch"
         assert c.cov_src_path is None
+
+    def test_color_arg(self) -> None:
+        m.Config(["test.py", "--color"])
+
+        assert colors.ENABLED is True
 
     @pytest.mark.parametrize("feature", FEATURES)
     def test_env_features(

--- a/tests/unit/legate/util/test_colors.py
+++ b/tests/unit/legate/util/test_colors.py
@@ -57,9 +57,17 @@ STYLE_FUNCS = (
 )
 
 
+def test_default_ENABLED() -> None:
+    assert m.ENABLED is False
+
+
 @pytest.mark.skipif(colorama is None, reason="colorama required")
 @pytest.mark.parametrize("color", COLOR_FUNCS)
-def test_color_functions(color: str) -> None:
+def test_color_functions_ENABLED_True(
+    mocker: MockerFixture, color: str
+) -> None:
+    mocker.patch.object(m, "ENABLED", True)
+
     cfunc = getattr(m, color)
     cprop = getattr(colorama.Fore, color.upper())
 
@@ -68,15 +76,45 @@ def test_color_functions(color: str) -> None:
     assert out == f"{cprop}some text{colorama.Style.RESET_ALL}"
 
 
+@pytest.mark.parametrize("color", COLOR_FUNCS)
+def test_color_functions_ENABLED_False(
+    mocker: MockerFixture, color: str
+) -> None:
+    mocker.patch.object(m, "ENABLED", False)
+
+    cfunc = getattr(m, color)
+
+    out = cfunc("some text")
+
+    assert out == "some text"
+
+
 @pytest.mark.skipif(colorama is None, reason="colorama required")
 @pytest.mark.parametrize("style", STYLE_FUNCS)
-def test_style_functions(style: str) -> None:
+def test_style_functions_ENABLED_True(
+    mocker: MockerFixture, style: str
+) -> None:
+    mocker.patch.object(m, "ENABLED", True)
+
     sfunc = getattr(m, style)
     sprop = getattr(colorama.Style, style.upper())
 
     out = sfunc("some text")
 
     assert out == f"{sprop}some text{colorama.Style.RESET_ALL}"
+
+
+@pytest.mark.parametrize("style", STYLE_FUNCS)
+def test_style_functions_ENABLED_False(
+    mocker: MockerFixture, style: str
+) -> None:
+    mocker.patch.object(m, "ENABLED", False)
+
+    sfunc = getattr(m, style)
+
+    out = sfunc("some text")
+
+    assert out == "some text"
 
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")


### PR DESCRIPTION
The current terminal colors are not good on light terminal backgrounds. A real solution to this would require "themes" (at least light and dark). For now, make terminal colors explicitly opt-in via a `--color` command line arg, even if `colorama` is installed.

I don't love the implementation here, but it will do for now. If we really want to improve this, we can address that at that time. But if we want to really improve things I would probably advocate for taking on [`rich`](https://github.com/Textualize/rich) as a dependency and jettisoning all my simplistic TUI code. 