### PR TITLE
Better error when GPU detection fails

### DIFF
--- a/legate/tester/test_plan.py
+++ b/legate/tester/test_plan.py
@@ -79,9 +79,9 @@ class TestPlan:
 
         cpus = len(self._system.cpus)
         try:
-            gpus = len(self._system.gpus)
-        except ImportError:
-            gpus = 0
+            gpus: int | str = len(self._system.gpus)
+        except RuntimeError:
+            gpus = "N/A"
 
         details = (
             f"* Feature stages       : {', '.join(yellow(x) for x in self._config.features)}",  # noqa E501

--- a/legate/util/system.py
+++ b/legate/util/system.py
@@ -121,7 +121,13 @@ class System:
             # fail.
             pynvml.nvmlInit()
         except Exception:
-            return ()
+            if platform.system() == "Darwin":
+                raise RuntimeError("GPU execution is not available on OSX.")
+            else:
+                raise RuntimeError(
+                    "GPU detection failed. Make sure nvml and pynvml are "
+                    "both installed."
+                )
 
         num_gpus = pynvml.nvmlDeviceGetCount()
 

--- a/tests/unit/legate/util/test_system.py
+++ b/tests/unit/legate/util/test_system.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-import sys
+import platform
 
 import pytest
 from pytest_mock import MockerFixture
@@ -98,8 +98,16 @@ class TestSystem:
         assert len(cpus) > 0
         assert all(len(cpu.ids) > 0 for cpu in cpus)
 
-    @pytest.mark.skipif(sys.platform != "linux", reason="pynvml required")
-    def test_gpus(self) -> None:
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Linux test")
+    def test_gpus_linux(self) -> None:
         s = m.System()
         # can't really assume / test much here
         s.gpus
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="OSX test")
+    def test_gpus_osx(self) -> None:
+        s = m.System()
+
+        msg = "GPU execution is not available on OSX."
+        with pytest.raises(RuntimeError, msg=msg):
+            s.gpus


### PR DESCRIPTION
This PR improves error messages when GPU detection fails (e.g. because `pynvml` is missing or because a platform is unsupported).

## Simulated error (on linux):

#### No GPU tests requested

If GPU tests are not requested, then the intro banner simply reports "N/A gpus" and continues
```
### * TestSystem description   : 6 cpus / N/A gpus
```
Note that if detection succeeds but there happen to be zero gpus, then it will report "0 gpus"

#### GPU tests requested

If GPU tests are requested, then the test runner immediately errors:
```
test38 ❯ ./test.py --use=cpus,cuda --omps=2 --ompthreads=1  --cpus 2  --gpus 2 --debug --cpu-pin=none  --color
Traceback (most recent call last):
  File "/home/bryan/work/legate.core/legate/util/system.py", line 123, in gpus
    1/0
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./test.py", line 30, in <module>
    plan = TestPlan(config, system)
  File "/home/bryan/work/legate.core/legate/tester/test_plan.py", line 47, in __init__
    self._stages = [
  File "/home/bryan/work/legate.core/legate/tester/test_plan.py", line 48, in <listcomp>
    STAGES[feature](config, system) for feature in config.features
  File "/home/bryan/work/legate.core/legate/tester/stages/_linux/gpu.py", line 50, in __init__
    self._init(config, system)
  File "/home/bryan/work/legate.core/legate/tester/stages/test_stage.py", line 272, in _init
    self.spec = self.compute_spec(config, system)
  File "/home/bryan/work/legate.core/legate/tester/stages/_linux/gpu.py", line 69, in compute_spec
    N = len(system.gpus)
  File "/home/bryan/anaconda3/envs/test38/lib/python3.8/functools.py", line 967, in __get__
    val = self.func(instance)
  File "/home/bryan/work/legate.core/legate/util/system.py", line 128, in gpus
    raise RuntimeError(
RuntimeError: GPU detection failed. Make sure nvml and pynvml are both installed.
```



