### PR TITLE
Call bind.sh unconditionally

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -139,7 +139,7 @@ if [[ -n "${cpus+x}" || -n "${mems+x}" ]]; then
           set -- --membind "${mems[$rank]}" "$@"
       fi
       set -- numactl "$@"
-  elif [[ -n "${cpus+x}" || -n "${mems+x}" ]]; then
+  else
       echo "Warning: numactl is not available, cannot bind to cores or memories" 1>&2
   fi
 fi

--- a/bind.sh
+++ b/bind.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 help() {
-  cat <<EOM
+  cat 1>&2 <<EOM
 Usage: bind.sh [OPTIONS]... -- APP...
 
 Options:
@@ -61,7 +61,7 @@ do
       break
       ;;
     *)
-      echo "Unexpected option: $1"
+      echo "Unexpected option: $1" 1>&2
       help
       ;;
   esac
@@ -75,7 +75,7 @@ case "$launcher" in
   auto  ) rank="${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-unknown}}}" ;;
   local ) rank="0" ;;
   *)
-    echo "Unexpected launcher value: $launcher"
+    echo "Unexpected launcher value: $launcher" 1>&2
     help
     ;;
 esac

--- a/bind.sh
+++ b/bind.sh
@@ -13,92 +13,110 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -euo pipefail
-
-# Usage: bind.sh <launcher> [--cpus <spec>] [--gpus <spec>] [--mems <spec>] [--nics <spec>] <app> ...
+# Usage: bind.sh --launcher <launcher> [--cpus <spec>] [--gpus <spec>] [--mems <spec>] [--nics <spec>] -- <app> ...
 # <spec> specifies the resources to bind each node-local rank to, with ranks
 # separated by /, e.g. 0,1/2,3/4,5/6,7 for 4 ranks per node.
 
-# Detect node-local rank based on launcher
-IDX=none
-case "$1" in
-    mpirun) IDX="$OMPI_COMM_WORLD_LOCAL_RANK" ;;
-    jsrun) IDX="$OMPI_COMM_WORLD_LOCAL_RANK" ;;
-    srun) IDX="$SLURM_LOCALID" ;;
-    local) IDX=0 ;;
-    none) IDX="${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-none}}}" ;;
-esac
-shift
-if [[ "$IDX" == "none" ]]; then
-    echo "Error: Cannot detect node-local rank" 1>&2
-    exit 1
-fi
+set -euo pipefail
 
-# Read binding specifications
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --cpus)
-            CPUS=(${2//\// })
-            if [[ "$IDX" -ge "${#CPUS[@]}" ]]; then
-                echo "Error: Incomplete CPU binding specification" 1>&2
-                exit 1
-            fi
-            ;;
-        --gpus)
-            GPUS=(${2//\// })
-            if [[ "$IDX" -ge "${#GPUS[@]}" ]]; then
-                echo "Error: Incomplete GPU binding specification" 1>&2
-                exit 1
-            fi
-            ;;
-        --mems)
-            MEMS=(${2//\// })
-            if [[ "$IDX" -ge "${#MEMS[@]}" ]]; then
-                echo "Error: Incomplete MEM binding specification" 1>&2
-                exit 1
-            fi
-            ;;
-        --nics)
-            NICS=(${2//\// })
-            if [[ "$IDX" -ge "${#NICS[@]}" ]]; then
-                echo "Error: Incomplete NIC binding specification" 1>&2
-                exit 1
-            fi
-            ;;
-        *)
-            break
-            ;;
-    esac
-    shift 2
+help() {
+  echo "Usage: bind.sh -l | --launcher <mpirun,srun,jrun,local> [ -c | --cpus ] [ -g | --gpus ] [ -m | --mems ] [ -n | --nics ] -- <app>"
+  exit 2
+}
+
+while :
+do
+  case "$1" in
+    --launcher) launcher="$2" ;;
+    --cpus) cpus="$2" ;;
+    --gpus) gpus="$2" ;;
+    --mems) mems="$2" ;;
+    --nics) nics="$2" ;;
+    --help) help ;;
+    --)
+      shift;
+      break
+      ;;
+    *)
+      echo "Unexpected option: $1"
+      help
+      ;;
+  esac
+  shift 2
 done
 
-# Prepare environment
-if [[ -n "${GPUS+x}" ]]; then
-    export CUDA_VISIBLE_DEVICES="${GPUS[$IDX]}"
-fi
-if [[ -n "${NICS+x}" ]]; then
-    # Set all potentially relevant variables, hopefully they are ignored if we
-    # are not using the corresponding network.
-    NIC="${NICS[$IDX]}"
-    export UCX_NET_DEVICES="${NIC//,/:1,}":1
-    export NCCL_IB_HCA="$NIC"
-    NIC_ARR=(${NIC//,/ })
-    export GASNET_NUM_QPS="${#NIC_ARR[@]}"
-    export GASNET_IBV_PORTS="${NIC//,/+}"
+if [ -z "$launcher" ]; then
+  echo "bind.sh: -l / --launcher is a required argument"
 fi
 
-# Prepare command
-if command -v numactl &> /dev/null; then
-    if [[ -n "${CPUS+x}" ]]; then
-        set -- --physcpubind "${CPUS[$IDX]}" "$@"
-    fi
-    if [[ -n "${MEMS+x}" ]]; then
-        set -- --membind "${MEMS[$IDX]}" "$@"
-    fi
-    set -- numactl "$@"
-elif [[ -n "${CPUS+x}" || -n "${MEMS+x}" ]]; then
-    echo "Warning: numactl is not available, cannot bind to cores or memories" 1>&2
+case "$launcher" in
+  local) rank=0 ;;
+  mpirun) rank="$OMPI_COMM_WORLD_LOCAL_RANK" ;;
+  jsrun) rank="$OMPI_COMM_WORLD_LOCAL_RANK" ;;
+  srun) rank="$SLURM_LOCALID" ;;
+  *)
+    echo "Unexpected launcher value: $launcher"
+    help
+    ;;
+esac
+
+export LEGATE_RANK="$rank"
+
+if [ -n "${cpus+x}" ]; then
+  cpus=(${cpus//\// })
+  if [[ "$rank" -ge "${#cpus[@]}" ]]; then
+      echo "Error: Incomplete CPU binding specification" 1>&2
+      exit 1
+  fi
 fi
+
+if [ -n "${gpus+x}" ]; then
+  gpus=(${gpus//\// })
+  if [[ "$rank" -ge "${#gpus[@]}" ]]; then
+      echo "Error: Incomplete GPU binding specification" 1>&2
+      exit 1
+  fi
+  export CUDA_VISIBLE_DEVICES="${gpus[$rank]}"
+fi
+
+if [ -n "${mems+x}" ]; then
+  mems=(${mems//\// })
+  if [[ "$rank" -ge "${#mems[@]}" ]]; then
+      echo "Error: Incomplete MEM binding specification" 1>&2
+      exit 1
+  fi
+fi
+
+if [ -n "${nics+x}" ]; then
+  nics=(${nics//\// })
+  if [[ "$rank" -ge "${#nics[@]}" ]]; then
+      echo "Error: Incomplete NIC binding specification" 1>&2
+      exit 1
+  fi
+
+  # Set all potentially relevant variables (hopefully they are ignored if we
+  # are not using the corresponding network).
+  nic="${nics[$rank]}"
+  nic_array=(${nic//,/ })
+  export UCX_NET_DEVICES="${nic//,/:1,}":1
+  export NCCL_IB_HCA="$nic"
+  export GASNET_NUM_QPS="${#nic_array[@]}"
+  export GASNET_IBV_PORTS="${nic//,/+}"
+fi
+
+if [ $launcher != "local" ]; then
+  if command -v numactl &> /dev/null; then
+      if [[ -n "${cpus+x}" ]]; then
+          set -- --physcpubind "${cpus[$rank]}" "$@"
+      fi
+      if [[ -n "${mems+x}" ]]; then
+          set -- --membind "${mems[$rank]}" "$@"
+      fi
+      set -- numactl "$@"
+  elif [[ -n "${cpus+x}" || -n "${mems+x}" ]]; then
+      echo "Warning: numactl is not available, cannot bind to cores or memories" 1>&2
+  fi
+fi
+
 exec "$@"

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -30,18 +30,11 @@ __all__ = ("CMD_PARTS",)
 def cmd_bind(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
-    cpu_bind = config.binding.cpu_bind
-    mem_bind = config.binding.mem_bind
-    gpu_bind = config.binding.gpu_bind
-    nic_bind = config.binding.nic_bind
-
-    if all(x is None for x in (cpu_bind, mem_bind, gpu_bind, nic_bind)):
-        return ()
-
     ranks = config.multi_node.ranks
 
     opts: CommandPart = (
         str(system.legate_paths.bind_sh_path),
+        "--launcher",
         "local"
         if launcher.kind == "none" and ranks == 1
         else str(launcher.kind),
@@ -56,17 +49,17 @@ def cmd_bind(
             raise RuntimeError(errmsg.format(name=name))
 
     bindings = (
-        ("cpu", cpu_bind),
-        ("gpu", gpu_bind),
-        ("mem", mem_bind),
-        ("nic", nic_bind),
+        ("cpu", config.binding.cpu_bind),
+        ("gpu", config.binding.gpu_bind),
+        ("mem", config.binding.mem_bind),
+        ("nic", config.binding.nic_bind),
     )
     for name, binding in bindings:
         if binding is not None:
             check_bind_ranks(name, binding)
             opts += (f"--{name}s", binding)
 
-    return opts
+    return opts + ("--",)
 
 
 def cmd_gdb(

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -32,12 +32,15 @@ def cmd_bind(
 ) -> CommandPart:
     ranks = config.multi_node.ranks
 
+    if launcher.kind == "none":
+        bind_launcher_arg = "local" if ranks == 1 else "auto"
+    else:
+        bind_launcher_arg = launcher.kind
+
     opts: CommandPart = (
         str(system.legate_paths.bind_sh_path),
         "--launcher",
-        "local"
-        if launcher.kind == "none" and ranks == 1
-        else str(launcher.kind),
+        bind_launcher_arg,
     )
 
     ranks_per_node = config.multi_node.ranks_per_node

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -138,11 +138,13 @@ class Test_cmd_bind:
 
         result = m.cmd_bind(config, system, launcher)
 
+        launcher_arg = "auto" if launch == "none" else launch
+
         bind_sh = str(system.legate_paths.bind_sh_path)
         assert result == (
             bind_sh,
             "--launcher",
-            launch,
+            launcher_arg,
             f"--{kind}s",
             "1/2",
             "--",

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -67,7 +67,8 @@ class Test_cmd_bind:
 
         result = m.cmd_bind(config, system, launcher)
 
-        assert result == ()
+        bind_sh = str(system.legate_paths.bind_sh_path)
+        assert result == (bind_sh, "--launcher", "local", "--")
 
     @pytest.mark.parametrize("kind", ("cpu", "gpu", "mem", "nic"))
     def test_basic_local(self, genobjs: GenObjs, kind: str) -> None:
@@ -76,7 +77,14 @@ class Test_cmd_bind:
         result = m.cmd_bind(config, system, launcher)
 
         bind_sh = str(system.legate_paths.bind_sh_path)
-        assert result == (bind_sh, "local", f"--{kind}s", "1")
+        assert result == (
+            bind_sh,
+            "--launcher",
+            "local",
+            f"--{kind}s",
+            "1",
+            "--",
+        )
 
     @pytest.mark.parametrize("launch", ("none", "mpirun", "jsrun", "srun"))
     def test_combo_local(
@@ -101,13 +109,16 @@ class Test_cmd_bind:
         result = m.cmd_bind(config, system, launcher)
 
         bind_sh = str(system.legate_paths.bind_sh_path)
-        assert result[:2] == (
+        assert result[:3] == (
             bind_sh,
+            "--launcher",
             "local" if launch == "none" else launch,
         )
-        x = iter(result[2:])
+        x = iter(result[3:])
         for name, binding in zip(x, x):  # pairwise
             assert f"{name} {binding}" in "--cpus 1 --gpus 1 --nics 1 --mems 1"
+
+        assert result[-1] == "--"
 
     @pytest.mark.parametrize("launch", ("none", "mpirun", "jsrun", "srun"))
     @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
@@ -128,7 +139,14 @@ class Test_cmd_bind:
         result = m.cmd_bind(config, system, launcher)
 
         bind_sh = str(system.legate_paths.bind_sh_path)
-        assert result == (bind_sh, launch, f"--{kind}s", "1/2")
+        assert result == (
+            bind_sh,
+            "--launcher",
+            launch,
+            f"--{kind}s",
+            "1/2",
+            "--",
+        )
 
     @pytest.mark.parametrize("binding", ("1", "1/2/3"))
     @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)


### PR DESCRIPTION
This PR changes the driver invocation to always add `bind.sh` unconditionally. This is so that a computed `LEGATE_RANK` environment variable can be set consistently, regardless of launch presence or kind. This will support a future PR that adds an option for per-rank Python cprofile output.

The new usage for `bind.sh` is:
```
bind.sh --launcher <launcher> [--cpus <spec>] [--gpus <spec>] [--mems <spec>] [--nics <spec>] -- <app> ...
```
The main differences are:
* `--launcher` required before the launcher value (`local`, `mpirun`, `srun`, or `jsrun`)
* delimeter `--` required before remaining "app" portion

These changes make the reported invocation less confusing and more robust, and should be fine since `bind.sh` is only invoked by the driver, and the driver has complete control over the args passed.  The necessary changes have been made to the driver (and related unit tests)