### PR TITLE
Add option to have per-file, per-stage test overrides

### DIFF
--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -17,8 +17,10 @@
 """
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 from typing_extensions import Literal, TypeAlias
+
+from ..util.types import ArgList
 
 #: Define the available feature types for tests
 FeatureType: TypeAlias = Union[
@@ -58,14 +60,9 @@ FEATURES: tuple[FeatureType, ...] = (
 )
 
 #: Paths to example files that should be skipped.
-SKIPPED_EXAMPLES = {
-    "examples/ingest.py",
-    "examples/kmeans_sort.py",
-    "examples/lstm_full.py",
-    "examples/wgrad.py",
-}
+#: Client test scripts should udpate this set witht their own customizations
+SKIPPED_EXAMPLES: set[str] = set()
 
 #: Extra arguments to supply when specific examples are executed.
-PER_FILE_ARGS = {
-    "examples/lstm_full.py": ["--file", "resources/lstm_input.txt"],
-}
+#: Client test scripts should udpate this dict witht their own customizations
+PER_FILE_ARGS: dict[str, ArgList] = {}

--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -84,8 +84,4 @@ class CustomTest:
 #: files are run serially, after the sharded, parallelized tests.
 #:
 #: Client test scripts should udpate this set with their own customizations.
-CUSTOM_FILES: list[CustomTest] = [
-    CustomTest(
-        "tests/integration/test_swapaxes.py", "cuda", ["--fbmem", "8192"]
-    )
-]
+CUSTOM_FILES: list[CustomTest] = []

--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -17,7 +17,8 @@
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from dataclasses import dataclass
+from typing import Union
 from typing_extensions import Literal, TypeAlias
 
 from ..util.types import ArgList
@@ -59,10 +60,32 @@ FEATURES: tuple[FeatureType, ...] = (
     "openmp",
 )
 
-#: Paths to example files that should be skipped.
-#: Client test scripts should udpate this set witht their own customizations
+#: Paths to test files that should be skipped entirely in all stages.
+#:
+#: Client test scripts should udpate this set with their own customizations.
 SKIPPED_EXAMPLES: set[str] = set()
 
-#: Extra arguments to supply when specific examples are executed.
-#: Client test scripts should udpate this dict witht their own customizations
+#: Extra arguments to add when specific test files are executed (in any stage).
+#:
+#: Client test scripts should udpate this dict with their own customizations.
 PER_FILE_ARGS: dict[str, ArgList] = {}
+
+
+@dataclass
+class CustomTest:
+    file: str
+    kind: FeatureType
+    args: ArgList
+
+
+#: Customized configurations for specific test files. Each entry will result
+#: in the specified test file being run in the specified stage, with the given
+#: command line arguments appended (overriding default stage arguments). These
+#: files are run serially, after the sharded, parallelized tests.
+#:
+#: Client test scripts should udpate this set with their own customizations.
+CUSTOM_FILES: list[CustomTest] = [
+    CustomTest(
+        "tests/integration/test_swapaxes.py", "cuda", ["--fbmem", "8192"]
+    )
+]

--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -23,7 +23,7 @@ from typing_extensions import Protocol
 from ...util.colors import yellow
 from ...util.types import ArgList, EnvDict
 from ...util.ui import banner, summary
-from .. import PER_FILE_ARGS, FeatureType
+from .. import CUSTOM_FILES, PER_FILE_ARGS, FeatureType
 from ..config import Config
 from ..test_system import ProcessResult, TestSystem
 from .util import Shard, StageResult, StageSpec, log_proc
@@ -224,7 +224,12 @@ class TestStage(Protocol):
         return args
 
     def run(
-        self, test_file: Path, config: Config, system: TestSystem
+        self,
+        test_file: Path,
+        config: Config,
+        system: TestSystem,
+        *,
+        custom_args: ArgList | None = None,
     ) -> ProcessResult:
         """Execute a single test files with appropriate environment and
         command-line options for a feature test stage.
@@ -253,6 +258,9 @@ class TestStage(Protocol):
         file_args = self.file_args(test_file, config)
 
         cmd += stage_args + file_args + config.extra_args
+
+        if custom_args:
+            cmd += custom_args
 
         self.delay(shard, config, system)
 
@@ -286,4 +294,13 @@ class TestStage(Protocol):
         ]
         pool.close()
 
-        return [job.get() for job in jobs]
+        sharded_results = [job.get() for job in jobs]
+
+        custom = (x for x in CUSTOM_FILES if x.kind == self.kind)
+
+        custom_results = [
+            self.run(Path(x.file), config, system, custom_args=x.args)
+            for x in custom
+        ]
+
+        return sharded_results + custom_results


### PR DESCRIPTION
This PR adds a test config 
```
CUSTOM_FILES: list[CustomTest] = [
    CustomTest(
        "tests/integration/test_swapaxes.py", "cuda", ["--fbmem", "8192"]
    )
]
```
That can be used to have customized test invocations (per-stage) that override normally computed shard options. Customized tests (if they are present) are executed in serial after all the normal test stage invocations.

@manopapad can see example custom test in https://github.com/nv-legate/legate.core/pull/469/commits/68a35f385840b0d6523b8c62f6b2ee9c53305a67