### PR TITLE
Use bind.sh for all rank_id handling

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -165,4 +165,15 @@ if [[ -n "${cpus+x}" || -n "${mems+x}" ]]; then
   fi
 fi
 
+# arguments may contain the substring %%LEGATE_GLOBAL_RANK%% which needs to be
+# be replaced with the actual computed rank for downstream processes to use
+count=0
+updated=()
+for arg in $@; do
+  updated+=("${arg/\%\%LEGATE_GLOBAL_RANK\%\%/$LEGATE_GLOBAL_RANK}")
+  count=$((count++))
+done
+
+set -- "${updated[@]}"
+
 exec "$@"

--- a/bind.sh
+++ b/bind.sh
@@ -69,27 +69,48 @@ do
 done
 
 case "$launcher" in
-  mpirun) rank="${OMPI_COMM_WORLD_LOCAL_RANK:-unknown}" ;;
-  jsrun ) rank="${OMPI_COMM_WORLD_LOCAL_RANK:-unknown}" ;;
-  srun  ) rank="${SLURM_LOCALID:-unknown}" ;;
-  auto  ) rank="${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-unknown}}}" ;;
-  local ) rank="0" ;;
+  mpirun)
+    local_rank="${OMPI_COMM_WORLD_LOCAL_RANK:-unknown}"
+    global_rank="${OMPI_COMM_WORLD_RANK:-unknown}"
+    ;;
+  jsrun )
+    local_rank="${OMPI_COMM_WORLD_LOCAL_RANK:-unknown}"
+    gloabl_rank="${OMPI_COMM_WORLD_RANK:-unknown}"
+    ;;
+  srun  )
+    local_rank="${SLURM_LOCALID:-unknown}"
+    global_rank="${SLURM_PROCID:-unknown}"
+    ;;
+  auto  )
+    local_rank="${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-unknown}}}"
+    global_rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${MV2_COMM_WORLD_RANK:-${SLURM_PROCID:-unknown}}}}"
+    ;;
+  local )
+    local_rank="0"
+    global_rank="0"
+    ;;
   *)
     echo "Unexpected launcher value: $launcher" 1>&2
     help
     ;;
 esac
 
-if [[ "$rank" == "unknown" ]]; then
+if [[ "$local_rank" == "unknown" ]]; then
     echo "Error: Could not determine node-local rank" 1>&2
     exit 1
 fi
 
-export LEGATE_RANK="$rank"
+if [[ "$global_rank" == "unknown" ]]; then
+    echo "Error: Could not determine global rank" 1>&2
+    exit 1
+fi
+
+export LEGATE_LOCAL_RANK="$local_rank"
+export LEGATE_GLOBAL_RANK="$global_rank"
 
 if [ -n "${cpus+x}" ]; then
   cpus=(${cpus//\// })
-  if [[ "$rank" -ge "${#cpus[@]}" ]]; then
+  if [[ "$local_rank" -ge "${#cpus[@]}" ]]; then
       echo "Error: Incomplete CPU binding specification" 1>&2
       exit 1
   fi
@@ -97,16 +118,16 @@ fi
 
 if [ -n "${gpus+x}" ]; then
   gpus=(${gpus//\// })
-  if [[ "$rank" -ge "${#gpus[@]}" ]]; then
+  if [[ "$local_rank" -ge "${#gpus[@]}" ]]; then
       echo "Error: Incomplete GPU binding specification" 1>&2
       exit 1
   fi
-  export CUDA_VISIBLE_DEVICES="${gpus[$rank]}"
+  export CUDA_VISIBLE_DEVICES="${gpus[$local_rank]}"
 fi
 
 if [ -n "${mems+x}" ]; then
   mems=(${mems//\// })
-  if [[ "$rank" -ge "${#mems[@]}" ]]; then
+  if [[ "$local_rank" -ge "${#mems[@]}" ]]; then
       echo "Error: Incomplete MEM binding specification" 1>&2
       exit 1
   fi
@@ -114,14 +135,14 @@ fi
 
 if [ -n "${nics+x}" ]; then
   nics=(${nics//\// })
-  if [[ "$rank" -ge "${#nics[@]}" ]]; then
+  if [[ "$local_rank" -ge "${#nics[@]}" ]]; then
       echo "Error: Incomplete NIC binding specification" 1>&2
       exit 1
   fi
 
   # set all potentially relevant variables (hopefully they are ignored if we
   # are not using the corresponding network)
-  nic="${nics[$rank]}"
+  nic="${nics[$local_rank]}"
   nic_array=(${nic//,/ })
   export UCX_NET_DEVICES="${nic//,/:1,}":1
   export NCCL_IB_HCA="$nic"
@@ -133,10 +154,10 @@ fi
 if [[ -n "${cpus+x}" || -n "${mems+x}" ]]; then
   if command -v numactl &> /dev/null; then
       if [[ -n "${cpus+x}" ]]; then
-          set -- --physcpubind "${cpus[$rank]}" "$@"
+          set -- --physcpubind "${cpus[$local_rank]}" "$@"
       fi
       if [[ -n "${mems+x}" ]]; then
-          set -- --membind "${mems[$rank]}" "$@"
+          set -- --membind "${mems[$local_rank]}" "$@"
       fi
       set -- numactl "$@"
   else

--- a/bind.sh
+++ b/bind.sh
@@ -171,9 +171,11 @@ count=0
 updated=()
 for arg in $@; do
   updated+=("${arg/\%\%LEGATE_GLOBAL_RANK\%\%/$LEGATE_GLOBAL_RANK}")
-  count=$((count++))
+  count=$((count+1))
 done
 
 set -- "${updated[@]}"
+
+echo "bind.sh: $@" 1>&2
 
 exec "$@"

--- a/bind.sh
+++ b/bind.sh
@@ -176,6 +176,6 @@ done
 
 set -- "${updated[@]}"
 
-echo "bind.sh: $@" 1>&2
+# echo "bind.sh: $@" 1>&2
 
 exec "$@"

--- a/tests/unit/legate/driver/conftest.py
+++ b/tests/unit/legate/driver/conftest.py
@@ -84,12 +84,9 @@ def genconfig() -> Any:
 
 @pytest.fixture
 def gensystem(monkeypatch: pytest.MonkeyPatch) -> Any:
-    def _system(
-        rank_env: dict[str, str] | None = None, os: str | None = None
-    ) -> System:
-        if rank_env:
-            for k, v in rank_env.items():
-                monkeypatch.setenv(k, v)
+    def _system(rank_id: str | None = None, os: str | None = None) -> System:
+        if rank_id:
+            monkeypatch.setenv("LEGATE_RANK", rank_id)
         system = System()
         if os:
             monkeypatch.setattr(system, "os", os)
@@ -107,13 +104,13 @@ def genobjs(
         *,
         fake_module: str | None = "foo.py",
         multi_rank: tuple[int, int] | None = None,
-        rank_env: dict[str, str] | None = None,
+        rank_id: str | None = None,
         os: str | None = None,
     ) -> tuple[Config, System, Launcher]:
         config = genconfig(
             args, fake_module=fake_module, multi_rank=multi_rank
         )
-        system = gensystem(rank_env, os)
+        system = gensystem(rank_id, os)
         launcher = Launcher.create(config, system)
         return config, system, launcher
 

--- a/tests/unit/legate/driver/test_driver.py
+++ b/tests/unit/legate/driver/test_driver.py
@@ -23,7 +23,7 @@ from pytest_mock import MockerFixture
 import legate.driver.driver as m
 from legate.driver.command import CMD_PARTS
 from legate.driver.config import Config
-from legate.driver.launcher import RANK_ENV_VARS, Launcher
+from legate.driver.launcher import Launcher
 from legate.util.colors import scrub
 from legate.util.shared_args import LAUNCHERS
 from legate.util.system import System
@@ -132,17 +132,14 @@ class TestDriver:
 
         assert pv_out in run_out
 
-    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
     def test_verbose_nonero_rank_id(
         self,
         monkeypatch: pytest.MonkeyPatch,
         capsys: Capsys,
         genconfig: GenConfig,
-        rank_var: str,
     ) -> None:
-        for name in RANK_ENV_VARS:
-            monkeypatch.delenv(name, raising=False)
-        monkeypatch.setenv(name, "1")
+        monkeypatch.delenv("LEGATE_RANK", raising=False)
+        monkeypatch.setenv("LEGATE_RANK", "1")
 
         # set --dry-run to avoid needing to mock anything
         config = genconfig(


### PR DESCRIPTION
This PR updates the driver to use the `LEGATE_RANK` env var that is now always set by `bind.sh`, in order to set the launcher `rank_id`. This affects the current `nvprof` and `nsys` options. Once the PR is tested on a real cluster and merged, I will make a follow-on PR to add `cprofile` option that uses the same. 