### PR TITLE
Use bind.sh for all rank detection

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -32,6 +32,7 @@ Options:
   --nics=SPEC       Network interface binding specification, used to set
                     all of: UCX_NET_DEVICES, NCCL_IB_HCA, GASNET_NUM_QPS,
                     and GASNET_IBV_PORTS
+  --debug           print out the final computed invocation before exectuting
 
 SPEC specifies the resources to bind each node-local rank to, with ranks
 separated by /, e.g. '0,1/2,3/4,5/6,7' for 4 ranks per node.
@@ -46,15 +47,17 @@ EOM
   exit 2
 }
 
+debug="0"
 launcher=auto
 while :
 do
   case "$1" in
-    --launcher) launcher="$2" ;;
-    --cpus) cpus="$2" ;;
-    --gpus) gpus="$2" ;;
-    --mems) mems="$2" ;;
-    --nics) nics="$2" ;;
+    --launcher) launcher="$2"; shift 2 ;;
+    --cpus) cpus="$2"; shift 2 ;;
+    --gpus) gpus="$2"; shift 2 ;;
+    --mems) mems="$2"; shift 2 ;;
+    --nics) nics="$2"; shift 2 ;;
+    --debug) debug="1"; shift ;;
     --help) help ;;
     --)
       shift;
@@ -65,7 +68,6 @@ do
       help
       ;;
   esac
-  shift 2
 done
 
 case "$launcher" in
@@ -175,5 +177,10 @@ for arg in $@; do
 done
 
 set -- "${updated[@]}"
+
+if [ "$debug" == "1" ]; then
+  echo "bind.sh: $@" 1>&2
+  echo
+fi
 
 exec "$@"

--- a/bind.sh
+++ b/bind.sh
@@ -169,11 +169,9 @@ fi
 
 # arguments may contain the substring %%LEGATE_GLOBAL_RANK%% which needs to be
 # be replaced with the actual computed rank for downstream processes to use
-count=0
 updated=()
-for arg in $@; do
+for arg in "$@"; do
   updated+=("${arg/\%\%LEGATE_GLOBAL_RANK\%\%/$LEGATE_GLOBAL_RANK}")
-  count=$((count+1))
 done
 
 set -- "${updated[@]}"

--- a/bind.sh
+++ b/bind.sh
@@ -177,7 +177,8 @@ done
 set -- "${updated[@]}"
 
 if [ "$debug" == "1" ]; then
-  echo "bind.sh: $@" 1>&2
+  echo -n "bind.sh: $@" 1>&2
+  for TOK in "$@"; do printf " %q" "$TOK" 1>&2; done
   echo
 fi
 

--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -304,6 +304,15 @@ info.add_argument(
 )
 
 
+info.add_argument(
+    "--bind-detail",
+    dest="bind_detail",
+    action="store_true",
+    required=False,
+    help="print out the final invocation run by bind.sh",
+)
+
+
 other = parser.add_argument_group("Other options")
 
 

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
 __all__ = ("CMD_PARTS",)
 
 
+# this will be replaced by bind.sh with the actual computed rank at runtime
+LEGATE_GLOBAL_RANK_SUBSTITUTION = "%%LEGATE_GLOBAL_RANK%%"
+
+
 def cmd_bind(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
@@ -100,7 +104,10 @@ def cmd_nvprof(
     if not config.profiling.nvprof:
         return ()
 
-    log_path = str(config.logging.logdir / f"legate_{launcher.rank_id}.nvvp")
+    log_path = str(
+        config.logging.logdir
+        / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
+    )
 
     return ("nvprof", "-o", log_path)
 
@@ -111,7 +118,9 @@ def cmd_nsys(
     if not config.profiling.nsys:
         return ()
 
-    log_path = str(config.logging.logdir / f"legate_{launcher.rank_id}")
+    log_path = str(
+        config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+    )
     targets = config.profiling.nsys_targets
     extra = config.profiling.nsys_extra
 

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -62,6 +62,9 @@ def cmd_bind(
             check_bind_ranks(name, binding)
             opts += (f"--{name}s", binding)
 
+    if config.info.bind_detail:
+        opts += ("--debug",)
+
     return opts + ("--",)
 
 

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -134,6 +134,7 @@ class Info(DataclassMixin):
     progress: bool
     mem_usage: bool
     verbose: bool
+    bind_detail: bool
 
 
 @dataclass(frozen=True)

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -93,7 +93,10 @@ class Driver:
         """
         if self.config.info.verbose:
             # we only want to print verbose output on a "head" node
-            if self.launcher.kind != "none" or self.launcher.rank_id == "0":
+            if (
+                self.launcher.kind != "none"
+                or self.launcher.detected_rank_id == "0"
+            ):
                 print_verbose(self.system, self)
 
         self._darwin_gdb_warn()

--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -54,8 +54,8 @@ LAUNCHER_VAR_PREFIXES = (
 class Launcher:
     """A base class for custom launch handlers for Legate.
 
-    Subclasses should set ``kind``, ``rank_id``, and ``cmd`` properties during
-    their initialization.
+    Subclasses should set ``kind`` and ``cmd`` properties during their
+    initialization.
 
     Parameters
     ----------
@@ -66,8 +66,6 @@ class Launcher:
     """
 
     kind: LauncherType
-
-    rank_id: str
 
     cmd: Command
 

--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -50,9 +50,6 @@ LAUNCHER_VAR_PREFIXES = (
     "NVIDIA_",
 )
 
-# this will be replaced by bind.sh with the actual computed rank at runtime
-LEGATE_GLOBAL_RANK_SUBSTITUTION = "%%LEGATE_GLOBAL_RANK%%"
-
 
 class Launcher:
     """A base class for custom launch handlers for Legate.
@@ -103,7 +100,6 @@ class Launcher:
         return (
             isinstance(other, type(self))
             and self.kind == other.kind
-            and self.rank_id == other.rank_id
             and self.cmd == other.cmd
             and self.env == other.env
         )
@@ -308,11 +304,9 @@ class SimpleLauncher(Launcher):
     def __init__(self, config: ConfigProtocol, system: System) -> None:
         super().__init__(config, system)
 
-        # we still want to let bind.sh handle this, even in the simple
-        # case, just for consistency. But we do still check the known
+        # bind.sh handles computing local and global rank id, even in the
+        # simple case, just for consistency. But we do still check the known
         # rank env vars below in order to issue RANK_ERR_MSG if needed
-        self.rank_id = LEGATE_GLOBAL_RANK_SUBSTITUTION
-
         if config.multi_node.ranks > 1 and self.detected_rank_id is None:
             raise RuntimeError(RANK_ERR_MSG)
 
@@ -330,8 +324,6 @@ class MPILauncher(Launcher):
 
     def __init__(self, config: ConfigProtocol, system: System) -> None:
         super().__init__(config, system)
-
-        self.rank_id = LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         ranks = config.multi_node.ranks
         ranks_per_node = config.multi_node.ranks_per_node
@@ -361,8 +353,6 @@ class JSRunLauncher(Launcher):
     def __init__(self, config: ConfigProtocol, system: System) -> None:
         super().__init__(config, system)
 
-        self.rank_id = LEGATE_GLOBAL_RANK_SUBSTITUTION
-
         ranks = config.multi_node.ranks
         ranks_per_node = config.multi_node.ranks_per_node
 
@@ -388,8 +378,6 @@ class SRunLauncher(Launcher):
 
     def __init__(self, config: ConfigProtocol, system: System) -> None:
         super().__init__(config, system)
-
-        self.rank_id = LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         ranks = config.multi_node.ranks
         ranks_per_node = config.multi_node.ranks_per_node

--- a/legate/driver/logs.py
+++ b/legate/driver/logs.py
@@ -185,7 +185,7 @@ def process_logs(
 
     handlers: list[LogHandler] = []
 
-    if launcher.kind != "none" or launcher.rank_id == "0":
+    if launcher.kind != "none" or launcher.detected_rank_id == "0":
         if config.profiling.profile:
             handlers.append(ProfilingHandler(config, system))
 

--- a/legate/jupyter/config.py
+++ b/legate/jupyter/config.py
@@ -86,5 +86,5 @@ class Config:
         self.debugging = Debugging(
             False, False, False, False, False, False, False
         )
-        self.info = Info(False, False, self.verbose > 0)
+        self.info = Info(False, False, self.verbose > 0, False)
         self.other = Other(None, False, False)

--- a/tests/unit/legate/driver/test_args.py
+++ b/tests/unit/legate/driver/test_args.py
@@ -166,6 +166,9 @@ class TestParserDefaults:
     def test_verbose(self) -> None:
         assert m.parser.get_default("verbose") is False
 
+    def test_bind_detail(self) -> None:
+        assert m.parser.get_default("bind_detail") is False
+
     # other
 
     def test_module(self) -> None:

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -73,6 +73,14 @@ class Test_cmd_bind:
         bind_sh = str(system.legate_paths.bind_sh_path)
         assert result == (bind_sh, "--launcher", "local", "--")
 
+    def test_bind_detail(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(["--bind-detail"])
+
+        result = m.cmd_bind(config, system, launcher)
+
+        bind_sh = str(system.legate_paths.bind_sh_path)
+        assert result == (bind_sh, "--launcher", "local", "--debug", "--")
+
     @pytest.mark.parametrize("kind", ("cpu", "gpu", "mem", "nic"))
     def test_basic_local(self, genobjs: GenObjs, kind: str) -> None:
         config, system, launcher = genobjs([f"--{kind}-bind", "1"])

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -20,7 +20,10 @@ from pathlib import Path
 import pytest
 
 import legate.driver.command as m
-from legate.driver.launcher import RANK_ENV_VARS
+from legate.driver.launcher import (
+    LEGATE_GLOBAL_RANK_SUBSTITUTION,
+    RANK_ENV_VARS,
+)
 from legate.util.colors import scrub
 from legate.util.types import LauncherType
 
@@ -261,7 +264,10 @@ class Test_cmd_nvprof:
 
         result = m.cmd_nvprof(config, system, launcher)
 
-        log_path = str(config.logging.logdir / "legate_0.nvvp")
+        log_path = str(
+            config.logging.logdir
+            / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
+        )
         assert result == ("nvprof", "-o", log_path)
 
     @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
@@ -277,7 +283,10 @@ class Test_cmd_nvprof:
 
         result = m.cmd_nvprof(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{rank}.nvvp")
+        log_path = str(
+            config.logging.logdir
+            / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
+        )
         assert result == ("nvprof", "-o", log_path)
 
     @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
@@ -320,7 +329,9 @@ class Test_cmd_nsys:
 
         result = m.cmd_nsys(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{rank}")
+        log_path = str(
+            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+        )
         assert result == (
             "nsys",
             "profile",
@@ -376,7 +387,9 @@ class Test_cmd_nsys:
 
         result = m.cmd_nsys(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{rank}")
+        log_path = str(
+            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+        )
         assert result == (
             "nsys",
             "profile",
@@ -414,7 +427,9 @@ class Test_cmd_nsys:
 
         result = m.cmd_nsys(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{rank}")
+        log_path = str(
+            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+        )
         assert result == (
             "nsys",
             "profile",
@@ -447,7 +462,9 @@ class Test_cmd_nsys:
 
         result = m.cmd_nsys(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{rank}")
+        log_path = str(
+            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+        )
         assert result == (
             "nsys",
             "profile",

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -20,10 +20,7 @@ from pathlib import Path
 import pytest
 
 import legate.driver.command as m
-from legate.driver.launcher import (
-    LEGATE_GLOBAL_RANK_SUBSTITUTION,
-    RANK_ENV_VARS,
-)
+from legate.driver.launcher import RANK_ENV_VARS
 from legate.util.colors import scrub
 from legate.util.types import LauncherType
 
@@ -33,6 +30,10 @@ from .util import GenObjs
 
 def test___all__() -> None:
     assert m.__all__ == ("CMD_PARTS",)
+
+
+def test_LEGATE_GLOBAL_RANK_SUBSTITUTION() -> None:
+    assert m.LEGATE_GLOBAL_RANK_SUBSTITUTION == "%%LEGATE_GLOBAL_RANK%%"
 
 
 def test_CMD_PARTS() -> None:
@@ -274,7 +275,7 @@ class Test_cmd_nvprof:
 
         log_path = str(
             config.logging.logdir
-            / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
         )
         assert result == ("nvprof", "-o", log_path)
 
@@ -293,7 +294,7 @@ class Test_cmd_nvprof:
 
         log_path = str(
             config.logging.logdir
-            / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
         )
         assert result == ("nvprof", "-o", log_path)
 
@@ -311,7 +312,8 @@ class Test_cmd_nvprof:
         result = m.cmd_nvprof(config, system, launcher)
 
         log_path = str(
-            config.logging.logdir / f"legate_{launcher.rank_id}.nvvp"
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}.nvvp"
         )
         assert result == ("nvprof", "-o", log_path)
 
@@ -338,7 +340,8 @@ class Test_cmd_nsys:
         result = m.cmd_nsys(config, system, launcher)
 
         log_path = str(
-            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}"
         )
         assert result == (
             "nsys",
@@ -362,7 +365,10 @@ class Test_cmd_nsys:
 
         result = m.cmd_nsys(config, system, launcher)
 
-        log_path = str(config.logging.logdir / f"legate_{launcher.rank_id}")
+        log_path = str(
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+        )
         assert result == (
             "nsys",
             "profile",
@@ -396,7 +402,8 @@ class Test_cmd_nsys:
         result = m.cmd_nsys(config, system, launcher)
 
         log_path = str(
-            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}"
         )
         assert result == (
             "nsys",
@@ -436,7 +443,8 @@ class Test_cmd_nsys:
         result = m.cmd_nsys(config, system, launcher)
 
         log_path = str(
-            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}"
         )
         assert result == (
             "nsys",
@@ -471,7 +479,8 @@ class Test_cmd_nsys:
         result = m.cmd_nsys(config, system, launcher)
 
         log_path = str(
-            config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}"
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}"
         )
         assert result == (
             "nsys",

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -247,6 +247,7 @@ class TestInfo:
             "progress",
             "mem_usage",
             "verbose",
+            "bind_detail",
         }
 
     def test_mixin(self) -> None:
@@ -331,7 +332,9 @@ class TestConfig:
             event=False,
         )
 
-        assert c.info == m.Info(progress=False, mem_usage=False, verbose=False)
+        assert c.info == m.Info(
+            progress=False, mem_usage=False, verbose=False, bind_detail=False
+        )
 
         assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
 

--- a/tests/unit/legate/driver/test_launcher.py
+++ b/tests/unit/legate/driver/test_launcher.py
@@ -363,6 +363,7 @@ class TestSimpleLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ()
 
     def test_single_rank_launcher_extra_ignored(
@@ -375,6 +376,7 @@ class TestSimpleLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ()
 
     @pytest.mark.parametrize("rank_var", m.RANK_ENV_VARS)
@@ -393,6 +395,7 @@ class TestSimpleLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ()
 
     def test_multi_rank_bad(self, genconfig: GenConfig) -> None:
@@ -421,6 +424,7 @@ class TestSimpleLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ()
 
 
@@ -470,6 +474,7 @@ class TestMPILauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -495,8 +500,9 @@ class TestMPILauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
 
-        # TODO (bv) -x env args currnetly too fragile to test
+        # TODO (bv) -x env args currently too fragile to test
         assert launcher.cmd[:10] == (
             ("mpirun",)
             + ("-n", "1", "--npernode", "1", "--bind-to", "none")
@@ -522,6 +528,7 @@ class TestMPILauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -560,6 +567,7 @@ class TestMPILauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -580,6 +588,7 @@ class TestJSRunLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "1", "-r", "1", "-a", "1")
@@ -601,6 +610,7 @@ class TestJSRunLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "1", "-r", "1", "-a", "1")
@@ -624,6 +634,7 @@ class TestJSRunLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "100", "-r", "1", "-a", "2")
@@ -657,6 +668,7 @@ class TestJSRunLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "100", "-r", "1", "-a", "2")
@@ -672,6 +684,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ("srun", "-n", "1", "--ntasks-per-node", "1")
 
     def test_single_rank_launcher_extra(self, genconfig: GenConfig) -> None:
@@ -689,6 +702,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -710,6 +724,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, SYSTEM)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -735,6 +750,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ("srun", "-n", "200", "--ntasks-per-node", "2")
 
     @pytest.mark.parametrize("rank_var", m.RANK_ENV_VARS)
@@ -763,6 +779,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -795,6 +812,7 @@ class TestSRunLauncher:
         launcher = m.Launcher.create(config, system)
 
         assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
+        assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             "srun",
             "-n",

--- a/tests/unit/legate/driver/test_launcher.py
+++ b/tests/unit/legate/driver/test_launcher.py
@@ -54,10 +54,6 @@ def test_LAUNCHER_VAR_PREFIXES() -> None:
     )
 
 
-def test_LEGATE_GLOBAL_RANK_SUBSTITUTION() -> None:
-    assert m.LEGATE_GLOBAL_RANK_SUBSTITUTION == "%%LEGATE_GLOBAL_RANK%%"
-
-
 class TestLauncher:
     @pytest.mark.parametrize("prefix", m.LAUNCHER_VAR_PREFIXES)
     def test_is_launcher_var_good_prefix(self, prefix: str) -> None:
@@ -130,7 +126,7 @@ class TestLauncher__eq__:
 
         assert launcher1 == launcher2
         assert launcher1.kind == launcher2.kind
-        assert launcher1.rank_id == launcher2.rank_id
+        assert launcher1.detected_rank_id == launcher2.detected_rank_id
         assert launcher1.cmd == launcher2.cmd
         assert launcher1.env == launcher2.env
 
@@ -362,7 +358,6 @@ class TestSimpleLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ()
 
@@ -375,7 +370,6 @@ class TestSimpleLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ()
 
@@ -394,7 +388,6 @@ class TestSimpleLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ()
 
@@ -423,7 +416,6 @@ class TestSimpleLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ()
 
@@ -473,7 +465,6 @@ class TestMPILauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
 
         # TODO (bv) -x env args currnetly too fragile to test
@@ -499,7 +490,6 @@ class TestMPILauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
 
         # TODO (bv) -x env args currently too fragile to test
@@ -527,7 +517,6 @@ class TestMPILauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
 
         # TODO (bv) -x env args currnetly too fragile to test
@@ -566,7 +555,6 @@ class TestMPILauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
 
         # TODO (bv) -x env args currnetly too fragile to test
@@ -587,7 +575,6 @@ class TestJSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             ("jsrun",)
@@ -609,7 +596,6 @@ class TestJSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             ("jsrun",)
@@ -633,7 +619,6 @@ class TestJSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             ("jsrun",)
@@ -667,7 +652,6 @@ class TestJSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             ("jsrun",)
@@ -683,7 +667,6 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == ("srun", "-n", "1", "--ntasks-per-node", "1")
 
@@ -701,7 +684,6 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             "srun",
@@ -723,7 +705,6 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "0"
         assert launcher.cmd == (
             "srun",
@@ -749,7 +730,6 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == ("srun", "-n", "200", "--ntasks-per-node", "2")
 
@@ -778,7 +758,6 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             "srun",
@@ -811,7 +790,6 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.detected_rank_id == "123"
         assert launcher.cmd == (
             "srun",

--- a/tests/unit/legate/driver/test_launcher.py
+++ b/tests/unit/legate/driver/test_launcher.py
@@ -54,6 +54,10 @@ def test_LAUNCHER_VAR_PREFIXES() -> None:
     )
 
 
+def test_LEGATE_GLOBAL_RANK_SUBSTITUTION() -> None:
+    assert m.LEGATE_GLOBAL_RANK_SUBSTITUTION == "%%LEGATE_GLOBAL_RANK%%"
+
+
 class TestLauncher:
     @pytest.mark.parametrize("prefix", m.LAUNCHER_VAR_PREFIXES)
     def test_is_launcher_var_good_prefix(self, prefix: str) -> None:
@@ -358,7 +362,7 @@ class TestSimpleLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "0"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ()
 
     def test_single_rank_launcher_extra_ignored(
@@ -370,7 +374,7 @@ class TestSimpleLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "0"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ()
 
     @pytest.mark.parametrize("rank_var", m.RANK_ENV_VARS)
@@ -388,7 +392,7 @@ class TestSimpleLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "123"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ()
 
     def test_multi_rank_bad(self, genconfig: GenConfig) -> None:
@@ -416,7 +420,7 @@ class TestSimpleLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "123"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ()
 
 
@@ -465,7 +469,7 @@ class TestMPILauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -490,7 +494,7 @@ class TestMPILauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -517,7 +521,7 @@ class TestMPILauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -555,7 +559,7 @@ class TestMPILauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
 
         # TODO (bv) -x env args currnetly too fragile to test
         assert launcher.cmd[:10] == (
@@ -575,7 +579,7 @@ class TestJSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "1", "-r", "1", "-a", "1")
@@ -596,7 +600,7 @@ class TestJSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "1", "-r", "1", "-a", "1")
@@ -619,7 +623,7 @@ class TestJSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "100", "-r", "1", "-a", "2")
@@ -652,7 +656,7 @@ class TestJSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{OMPI_COMM_WORLD_RANK}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             ("jsrun",)
             + ("-n", "100", "-r", "1", "-a", "2")
@@ -667,7 +671,7 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ("srun", "-n", "1", "--ntasks-per-node", "1")
 
     def test_single_rank_launcher_extra(self, genconfig: GenConfig) -> None:
@@ -684,7 +688,7 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -705,7 +709,7 @@ class TestSRunLauncher:
 
         launcher = m.Launcher.create(config, SYSTEM)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -730,7 +734,7 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == ("srun", "-n", "200", "--ntasks-per-node", "2")
 
     @pytest.mark.parametrize("rank_var", m.RANK_ENV_VARS)
@@ -758,7 +762,7 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             "srun",
             "-n",
@@ -790,7 +794,7 @@ class TestSRunLauncher:
         system = System()
         launcher = m.Launcher.create(config, system)
 
-        assert launcher.rank_id == "%q{SLURM_PROCID}"
+        assert launcher.rank_id == m.LEGATE_GLOBAL_RANK_SUBSTITUTION
         assert launcher.cmd == (
             "srun",
             "-n",

--- a/tests/unit/legate/jupyter/test_config.py
+++ b/tests/unit/legate/jupyter/test_config.py
@@ -107,7 +107,9 @@ class TestConfig:
             event=False,
         )
 
-        assert c.info == m.Info(progress=False, mem_usage=False, verbose=False)
+        assert c.info == m.Info(
+            progress=False, mem_usage=False, verbose=False, bind_detail=False
+        )
 
         assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
 


### PR DESCRIPTION
This PR updates the driver to do all rank detection in `bind.sh`. This affects the current `nvprof` and `nsys` options. Once the PR is tested on a real cluster and merged, I will make a follow-on PR to add `cprofile` option that uses the same. 

This PR also adds a driver option `--bind-detail` to the option (and corresponding `--debug` option to `bind.sh`) that will show exactly what invocation `bind.sh` ends up calling. It can be used with `--verbose` and tests, to see what ultimately gets executed, e.g. 

```
+LEGATE_TEST=1 CUNUMERIC_MIN_CPU_CHUNK=2000000000 CUNUMERIC_MIN_OMP_CHUNK=2000000000 CUNUMERIC_MIN_GPU_CHUNK=2000000000 legate /home/bryan/work/cunumeric/tests/integration/test_2d_reduction.py --cpus 1 --cpu-bind 3,9 -v --bind-detail
[PASS] (Eager) tests/integration/test_2d_reduction.py
   bind.sh: numactl --physcpubind 3,9 /home/bryan/work/legate.core/_skbuild/linux-x86_64-3.10/cmake-build/_deps/legion-build/bin/legion_python -ll:py 1 -lg:local 0 -ll:util 2 -ll:csize 4000 -level openmp=5 -lg:eager_alloc_percentage 50 /home/bryan/work/cunumeric/tests/integration/test_2d_reduction.py -v
```