### PR TITLE
Optimize scalar extraction

### DIFF
--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1046,6 +1046,15 @@ class Runtime:
         return self._num_gpus
 
     @property
+    def core_task_variant_id(self) -> int:
+        if self.num_gpus > 0:
+            return self.core_library.LEGATE_GPU_VARIANT
+        elif self.num_omps > 0:
+            return self.core_library.LEGATE_OMP_VARIANT
+        else:
+            return self.core_library.LEGATE_CPU_VARIANT
+
+    @property
     def attachment_manager(self) -> AttachmentManager:
         return self._attachment_manager
 
@@ -1468,7 +1477,7 @@ class Runtime:
         launcher = TaskLauncher(
             self.core_context,
             self.core_library.LEGATE_CORE_EXTRACT_SCALAR_TASK_ID,
-            tag=self.core_library.LEGATE_CPU_VARIANT,
+            tag=self.core_task_variant_id,
         )
         launcher.add_future(future)
         launcher.add_scalar_arg(idx, ty.int32)
@@ -1482,7 +1491,7 @@ class Runtime:
         launcher = TaskLauncher(
             self.core_context,
             self.core_library.LEGATE_CORE_EXTRACT_SCALAR_TASK_ID,
-            tag=self.core_library.LEGATE_CPU_VARIANT,
+            tag=self.core_task_variant_id,
         )
         launcher.add_future_map(future)
         launcher.add_scalar_arg(idx, ty.int32)

--- a/src/core/task/return.cc
+++ b/src/core/task/return.cc
@@ -197,6 +197,17 @@ size_t ReturnValues::legion_buffer_size() const { return buffer_size_; }
 
 void ReturnValues::legion_serialize(void* buffer) const
 {
+  // We pack N return values into the buffer in the following format:
+  //
+  // +--------+-----------+-----+------------+-------+-------+-------+-----
+  // |   #    | offset to |     | offset to  | total | value | value | ...
+  // | values | scalar 1  | ... | scalar N-1 | value |   1   |   2   |
+  // |        |           |     |            | size  |       |       |
+  // +--------+-----------+-----+------------+-------+-------+-------+-----
+  //           <============ offsets ===============> <==== values =======>
+  //
+  // the size of value i is computed by offsets[i] - (i == 0 ? 0 : offsets[i-1])
+
 #ifdef LEGATE_USE_CUDA
   auto stream = cuda::StreamPool::get_stream_pool().get_stream();
 #endif

--- a/src/core/task/return.cc
+++ b/src/core/task/return.cc
@@ -35,6 +35,40 @@ using namespace Legion;
 
 namespace legate {
 
+ReturnValue::ReturnValue(Legion::UntypedDeferredValue value, size_t size)
+  : value_(value), size_(size)
+{
+  is_device_value_ = value.get_instance().get_location().kind() == Memory::Kind::GPU_FB_MEM;
+}
+
+/*static*/ ReturnValue ReturnValue::unpack(const void* ptr, size_t size, Memory::Kind memory_kind)
+{
+  ReturnValue result(UntypedDeferredValue(size, memory_kind), size);
+#ifdef DEBUG_LEGATE
+  assert(!result.is_device_value());
+#endif
+  memcpy(result.ptr(), ptr, size);
+
+  return result;
+}
+
+void ReturnValue::finalize(Legion::Context legion_context) const
+{
+  value_.finalize(legion_context);
+}
+
+void* ReturnValue::ptr()
+{
+  AccessorWO<int8_t, 1> acc(value_, size_, false);
+  return acc.ptr(0);
+}
+
+const void* ReturnValue::ptr() const
+{
+  AccessorRO<int8_t, 1> acc(value_, size_, false);
+  return acc.ptr(0);
+}
+
 struct JoinReturnedException {
   using LHS = ReturnedException;
   using RHS = LHS;
@@ -145,53 +179,6 @@ ReturnValue ReturnedException::pack() const
   return ReturnValue(buffer, buffer_size);
 }
 
-namespace {
-
-template <bool PACK_SIZE>
-int8_t* pack_return_value(int8_t* target, const ReturnValue& value)
-{
-  if constexpr (PACK_SIZE) {
-    *reinterpret_cast<uint32_t*>(target) = value.second;
-    target += sizeof(uint32_t);
-  }
-
-  AccessorRO<int8_t, 1> acc(value.first, value.second, false);
-  memcpy(target, acc.ptr(0), value.second);
-  return target + value.second;
-}
-
-#ifdef LEGATE_USE_CUDA
-
-template <bool PACK_SIZE>
-int8_t* pack_return_value(int8_t* target, const ReturnValue& value, cuda::StreamView& stream)
-{
-  if constexpr (PACK_SIZE) {
-    *reinterpret_cast<uint32_t*>(target) = value.second;
-    target += sizeof(uint32_t);
-  }
-
-  AccessorRO<int8_t, 1> acc(value.first, value.second, false);
-  CHECK_CUDA(cudaMemcpyAsync(target, acc.ptr(0), value.second, cudaMemcpyDeviceToHost, stream));
-  return target + value.second;
-}
-
-#endif
-
-ReturnValue unpack_return_value(const int8_t*& ptr, Memory::Kind memory_kind)
-{
-  auto size = *reinterpret_cast<const uint32_t*>(ptr);
-  ptr += sizeof(uint32_t);
-
-  UntypedDeferredValue value(size, memory_kind);
-  AccessorWO<int8_t, 1> acc(value, size, false);
-  memcpy(acc.ptr(0), ptr, size);
-  ptr += size;
-
-  return ReturnValue(value, size);
-}
-
-}  // namespace
-
 ReturnValues::ReturnValues() {}
 
 ReturnValues::ReturnValues(std::vector<ReturnValue>&& return_values)
@@ -199,9 +186,9 @@ ReturnValues::ReturnValues(std::vector<ReturnValue>&& return_values)
 {
   if (return_values_.size() > 1) {
     buffer_size_ += sizeof(uint32_t);
-    for (auto& ret : return_values_) buffer_size_ += sizeof(uint32_t) + ret.second;
+    for (auto& ret : return_values_) buffer_size_ += sizeof(uint32_t) + ret.size();
   } else if (return_values_.size() > 0)
-    buffer_size_ = return_values_[0].second;
+    buffer_size_ = return_values_[0].size();
 }
 
 ReturnValue ReturnValues::operator[](int32_t idx) const { return return_values_[idx]; }
@@ -214,27 +201,36 @@ void ReturnValues::legion_serialize(void* buffer) const
   auto stream = cuda::StreamPool::get_stream_pool().get_stream();
 #endif
 
-  auto ptr = static_cast<int8_t*>(buffer);
   if (return_values_.size() == 1) {
     auto& ret = return_values_.front();
 #ifdef LEGATE_USE_CUDA
-    if (ret.first.get_instance().get_location().kind() == Memory::Kind::GPU_FB_MEM)
-      ptr = pack_return_value<false>(ptr, ret, stream);
+    if (ret.is_device_value())
+      CHECK_CUDA(cudaMemcpyAsync(buffer, ret.ptr(), ret.size(), cudaMemcpyDeviceToHost, stream));
     else
 #endif
-      ptr = pack_return_value<false>(ptr, ret);
-  } else {
-    *reinterpret_cast<uint32_t*>(ptr) = return_values_.size();
-    ptr += sizeof(uint32_t);
+      memcpy(buffer, ret.ptr(), ret.size());
+    return;
+  }
 
-    for (auto& ret : return_values_) {
+  *static_cast<uint32_t*>(buffer) = return_values_.size();
+  auto ptr                        = static_cast<int8_t*>(buffer) + sizeof(uint32_t);
+
+  uint32_t offset = 0;
+  for (auto ret : return_values_) {
+    offset += ret.size();
+    *reinterpret_cast<uint32_t*>(ptr) = offset;
+    ptr                               = ptr + sizeof(uint32_t);
+  }
+
+  for (auto ret : return_values_) {
+    uint32_t size = ret.size();
 #ifdef LEGATE_USE_CUDA
-      if (ret.first.get_instance().get_location().kind() == Memory::Kind::GPU_FB_MEM)
-        ptr = pack_return_value<true>(ptr, ret, stream);
-      else
+    if (ret.is_device_value())
+      CHECK_CUDA(cudaMemcpyAsync(ptr, ret.ptr(), size, cudaMemcpyDeviceToHost, stream));
+    else
 #endif
-        ptr = pack_return_value<true>(ptr, ret);
-    }
+      memcpy(ptr, ret.ptr(), size);
+    ptr += size;
   }
 }
 
@@ -244,11 +240,35 @@ void ReturnValues::legion_deserialize(const void* buffer)
 
   auto ptr        = static_cast<const int8_t*>(buffer);
   auto num_values = *reinterpret_cast<const uint32_t*>(ptr);
-  ptr += sizeof(uint32_t);
-  return_values_.resize(num_values);
 
-  for (auto& ret : return_values_) ret = unpack_return_value(ptr, mem_kind);
-  buffer_size_ = ptr - static_cast<const int8_t*>(buffer);
+  auto offsets = reinterpret_cast<const uint32_t*>(ptr + sizeof(uint32_t));
+  auto values  = ptr + sizeof(uint32_t) + sizeof(uint32_t) * num_values;
+
+  uint32_t offset = 0;
+  for (uint32_t idx = 0; idx < num_values; ++idx) {
+    uint32_t next_offset = offsets[idx];
+    uint32_t size        = next_offset - offset;
+    return_values_.push_back(ReturnValue::unpack(values + offset, size, mem_kind));
+    offset = next_offset;
+  }
+}
+
+/*static*/ ReturnValue ReturnValues::extract(Legion::Future future, uint32_t to_extract)
+{
+  auto kind          = find_memory_kind_for_executing_processor();
+  const auto* buffer = future.get_buffer(kind);
+
+  auto ptr        = static_cast<const int8_t*>(buffer);
+  auto num_values = *reinterpret_cast<const uint32_t*>(ptr);
+
+  auto offsets = reinterpret_cast<const uint32_t*>(ptr + sizeof(uint32_t));
+  auto values  = ptr + sizeof(uint32_t) + sizeof(uint32_t) * num_values;
+
+  uint32_t next_offset = offsets[to_extract];
+  uint32_t offset      = to_extract == 0 ? 0 : offsets[to_extract - 1];
+  uint32_t size        = next_offset - offset;
+
+  return ReturnValue::unpack(values + offset, size, kind);
 }
 
 void ReturnValues::finalize(Context legion_context) const
@@ -257,7 +277,7 @@ void ReturnValues::finalize(Context legion_context) const
     Runtime::legion_task_postamble(legion_context);
     return;
   } else if (return_values_.size() == 1) {
-    return_values_.front().first.finalize(legion_context);
+    return_values_.front().finalize(legion_context);
     return;
   }
 

--- a/src/core/task/return.cc
+++ b/src/core/task/return.cc
@@ -59,7 +59,7 @@ void ReturnValue::finalize(Legion::Context legion_context) const
 
 void* ReturnValue::ptr()
 {
-  AccessorWO<int8_t, 1> acc(value_, size_, false);
+  AccessorRW<int8_t, 1> acc(value_, size_, false);
   return acc.ptr(0);
 }
 

--- a/src/core/task/return.h
+++ b/src/core/task/return.h
@@ -20,7 +20,32 @@
 
 namespace legate {
 
-using ReturnValue = std::pair<Legion::UntypedDeferredValue, size_t>;
+struct ReturnValue {
+ public:
+  ReturnValue(Legion::UntypedDeferredValue value, size_t size);
+
+ public:
+  ReturnValue(const ReturnValue&)            = default;
+  ReturnValue& operator=(const ReturnValue&) = default;
+
+ public:
+  static ReturnValue unpack(const void* ptr, size_t size, Legion::Memory::Kind memory_kind);
+
+ public:
+  void* ptr();
+  const void* ptr() const;
+  const size_t size() const { return size_; }
+  const bool is_device_value() const { return is_device_value_; }
+
+ public:
+  // Calls the Legion postamble with an instance
+  void finalize(Legion::Context legion_context) const;
+
+ private:
+  Legion::UntypedDeferredValue value_{};
+  size_t size_{0};
+  bool is_device_value_{false};
+};
 
 struct ReturnedException {
  public:
@@ -64,6 +89,9 @@ struct ReturnValues {
   size_t legion_buffer_size() const;
   void legion_serialize(void* buffer) const;
   void legion_deserialize(const void* buffer);
+
+ public:
+  static ReturnValue extract(Legion::Future future, uint32_t to_extract);
 
  public:
   // Calls the Legion postamble with an instance that packs all return values

--- a/src/core/task/task.h
+++ b/src/core/task/task.h
@@ -62,6 +62,11 @@ struct VariantOptions {
     concurrent = _concurrent;
     return *this;
   }
+  VariantOptions& with_return_size(size_t _return_size)
+  {
+    return_size = _return_size;
+    return *this;
+  }
 };
 
 using LegateVariantImpl = void (*)(TaskContext&);


### PR DESCRIPTION
The `extract_scalar` task was deserializing the packed scalar buffer into individual scalars when it needed to extract one of them. This PR optimizes the operation to be constant-time.