### PR TITLE
Add --cprofile driver option

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -177,8 +177,8 @@ done
 set -- "${updated[@]}"
 
 if [ "$debug" == "1" ]; then
-  echo -n "bind.sh: $@" 1>&2
-  for TOK in "$@"; do printf " %q" "$TOK" 1>&2; done
+  echo -n "bind.sh: $@"
+  for TOK in "$@"; do printf " %q" "$TOK"; done
   echo
 fi
 

--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -130,6 +130,15 @@ profiling.add_argument(
 
 
 profiling.add_argument(
+    "--cprofile",
+    dest="cprofile",
+    action="store_true",
+    required=False,
+    help="profile Python execution with the cprofile module",
+)
+
+
+profiling.add_argument(
     "--nvprof",
     dest="nvprof",
     action="store_true",

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -152,8 +152,22 @@ def cmd_module(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
     module = config.other.module
+    cprofile = config.profiling.cprofile
 
-    return () if module is None else ("-m", module)
+    if cprofile and module is not None:
+        raise ValueError("Only one of --module or --cprofile may be used")
+
+    if module is not None:
+        return ("-m", module)
+
+    if cprofile:
+        log_path = str(
+            config.logging.logdir
+            / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.cprof"
+        )
+        return ("-m", "cProfile", "-o", log_path)
+
+    return ()
 
 
 def cmd_rlwrap(

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -90,6 +90,7 @@ class Memory(DataclassMixin):
 @dataclass(frozen=True)
 class Profiling(DataclassMixin):
     profile: bool
+    cprofile: bool
     nvprof: bool
     nsys: bool
     nsys_targets: str  # TODO: multi-choice

--- a/legate/jupyter/config.py
+++ b/legate/jupyter/config.py
@@ -81,7 +81,7 @@ class Config:
         # turn everything else off
         self.user_opts: tuple[str, ...] = ()
         self.binding = Binding(None, None, None, None)
-        self.profiling = Profiling(False, False, False, "", [])
+        self.profiling = Profiling(False, False, False, False, "", [])
         self.logging = Logging(None, Path(), False, False)
         self.debugging = Debugging(
             False, False, False, False, False, False, False

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -548,6 +548,24 @@ class Test_cmd_module:
 
         assert result == ("-m", "foo")
 
+    def test_with_cprofile(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(["--cprofile"])
+
+        result = m.cmd_module(config, system, launcher)
+
+        log_path = str(
+            config.logging.logdir
+            / f"legate_{m.LEGATE_GLOBAL_RANK_SUBSTITUTION}.cprof"
+        )
+        assert result == ("-m", "cProfile", "-o", log_path)
+
+    def test_module_and_cprofile_error(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(["--module", "foo", "--cprofile"])
+
+        err = "Only one of --module or --cprofile may be used"
+        with pytest.raises(ValueError, match=err):
+            m.cmd_module(config, system, launcher)
+
 
 class Test_cmd_rlwrap:
     def test_default(self, genobjs: GenObjs) -> None:

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -152,6 +152,7 @@ class TestProfiling:
     def test_fields(self) -> None:
         assert set(m.Profiling.__dataclass_fields__) == {
             "profile",
+            "cprofile",
             "nvprof",
             "nsys",
             "nsys_targets",
@@ -168,6 +169,7 @@ class TestProfiling:
     def test_nsys_extra_fixup_basic(self, extra: list[str]) -> None:
         p = m.Profiling(
             profile=True,
+            cprofile=True,
             nvprof=True,
             nsys=True,
             nsys_targets="foo,bar",
@@ -178,6 +180,7 @@ class TestProfiling:
     def test_nsys_extra_fixup_complex(self) -> None:
         p = m.Profiling(
             profile=True,
+            cprofile=True,
             nvprof=True,
             nsys=True,
             nsys_targets="foo,bar",
@@ -199,6 +202,7 @@ class TestProfiling:
     def test_nsys_extra_fixup_quoted(self) -> None:
         p = m.Profiling(
             profile=True,
+            cprofile=True,
             nvprof=True,
             nsys=True,
             nsys_targets="foo,bar",
@@ -309,6 +313,7 @@ class TestConfig:
 
         c.profiling == m.Profiling(
             profile=False,
+            cprofile=False,
             nvprof=False,
             nsys=False,
             nsys_targets="",
@@ -414,6 +419,7 @@ class TestConfig:
                 "--gdb",
                 "--keep-logs",
                 "--profile",
+                "--cprofile",
             )
         ),
     )

--- a/tests/unit/legate/jupyter/test_config.py
+++ b/tests/unit/legate/jupyter/test_config.py
@@ -84,6 +84,7 @@ class TestConfig:
 
         c.profiling == m.Profiling(
             profile=False,
+            cprofile=False,
             nvprof=False,
             nsys=False,
             nsys_targets="",


### PR DESCRIPTION
This PR adds a new option `--cprofile` to the driver that enables the Python stdlib `cProfile` module. 

The `cProfile` module must be loaded with that  `-m` python (legate) command line option. This PR handles things in `cmd_module` function that normally handles `--module`, in order to make an explicit exception if `--cprofile` is used together with `--module` (i.e. they are incompatible)

The cprofile output is stored at
```
config.logging.logdir / f"legate_{LEGATE_GLOBAL_RANK_SUBSTITUTION}.cprof"
```
so that multi-rank profiling is possible. 