### PR TITLE
Pass a sufficiently high default value for gasnet's ibv-max-hcas

### DIFF
--- a/install.py
+++ b/install.py
@@ -439,6 +439,7 @@ def install(
 -DLegion_REDOP_HALF=ON
 -DLegion_BUILD_BINDINGS=ON
 -DLegion_BUILD_JUPYTER=ON
+-DLegion_EMBED_GASNet_CONFIGURE_ARGS="--with-ibv-max-hcas=8"
 """.splitlines()
 
     if nccl_dir:


### PR DESCRIPTION
Previously we would pass this setting through an envvar in quickstart build.sh, but Legion's cmake workflow overrides this value, so we need to pass it as a cmake flag.