### PR TITLE
legate/core: fix FutureMap leak in communicator shutdown

### DIFF
--- a/legate/core/communicator.py
+++ b/legate/core/communicator.py
@@ -61,6 +61,10 @@ class Communicator(ABC):
     def destroy(self) -> None:
         for volume, handle in self._handles.items():
             self._finalize(volume, handle)
+        # Drop the references to the handles dict after
+        # all handles have been finalized to ensure that
+        # no references to FutureMaps are kept.
+        self._handles = {}
 
     @abstractproperty
     def needs_barrier(self) -> bool:


### PR DESCRIPTION
This commit fixes the following leak, leading to shutdown hangs.

```
found cycle!
  tail:
    0x200092ca1e10: <class 'legate.core._legion.future.FutureMap'>
     ^
    0x200058dd65c0: <class 'dict'>
     ^ ["_handles"]
    0x2000588dff80: <class 'dict'>
     ^ .__dict__
    0x2000889b11b0: <class 'legate.core.communicator.NCCLCommunicator'>
     ^ ["_nccl"]
    0x2000588dd540: <class 'dict'>
     ^ .__dict__
    0x2000887b8430: <class 'legate.core.runtime.CommunicatorManager'>
     ^ ["_comm_manager"]
    0x2000889f7d00: <class 'dict'>
     ^ .__dict__
    0x2000887b9f90: <class 'legate.core.runtime.Runtime'>
     ^ ["runtime"]
    0x200173d7b180: <class 'dict'>
  cycle:
    0x200173d7b180: <class 'dict'>
     ^ .__dict__
    0x200173d84370: <class 'legate.core.runtime.ConsensusMatchingFieldManager'>
     ^ ["manager"]
    0x200173e30cc0: <class 'dict'>
     ^ .__dict__
    0x200173db2e00: <class 'legate.core.runtime.FreeFieldInfo'>
     ^ [85]
    0x200173df0f80: <class 'list'>
     ^ ["_freed_fields"]
    0x2000588ddb40: <class 'dict'>
     ^ .__dict__
    0x2000889b0fa0: <class 'legate.core.runtime.FieldMatchManager'>
     ^ ["_field_match_manager"]
    0x200173d7b180: <class 'dict'>
```

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>