### PR TITLE
legate/core: guard deletion in reset_{store,storage}_key_partition

### DIFF
--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -877,7 +877,8 @@ class PartitionManager:
         self._store_key_partitions[store_id] = key_partition
 
     def reset_store_key_partition(self, store_id: int) -> None:
-        del self._store_key_partitions[store_id]
+        if store_id in self._store_key_partitions:
+            del self._store_key_partitions[store_id]
 
     def find_storage_key_partition(
         self, storage_id: int, restrictions: tuple[Restriction, ...]
@@ -895,7 +896,8 @@ class PartitionManager:
         self._storage_key_partitions[storage_id] = key_partition
 
     def reset_storage_key_partition(self, storage_id: int) -> None:
-        del self._storage_key_partitions[storage_id]
+        if storage_id in self._storage_key_partitions:
+            del self._storage_key_partitions[storage_id]
 
     def find_legion_partition(
         self, storage_id: int, functor: PartitionBase


### PR DESCRIPTION
This allows for users of `reset_key_partition()` not need to query if there is a key partition already -- slightly more ergonomic use.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>