### PR TITLE
Don't nocr for single node

### DIFF
--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -206,7 +206,7 @@ class Config:
         return not any(opt.endswith(".py") for opt in self.user_opts)
 
     def _fixup_nocr(self, args: Namespace) -> None:
-        if self.console and not args.not_control_replicable:
+        if self.console and not args.not_control_replicable and args.nodes > 1:
             print(warn("Disabling control replication for interactive run"))
             args.not_control_replicable = True
 

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -206,7 +206,11 @@ class Config:
         return not any(opt.endswith(".py") for opt in self.user_opts)
 
     def _fixup_nocr(self, args: Namespace) -> None:
-        if self.console and not args.not_control_replicable and args.nodes > 1:
+        # this is slightly duplicative of MultiNode.ranks property, but fixup
+        # checks happen before sub-configs are initialized from args
+        ranks = int(args.nodes) * int(args.ranks_per_node)
+
+        if self.console and not args.not_control_replicable and ranks > 1:
             print(warn("Disabling control replication for interactive run"))
             args.not_control_replicable = True
 

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -519,8 +519,24 @@ class Test_cmd_nocr:
 
         assert result == ()
 
-    def test_console(self, genobjs: GenObjs) -> None:
+    def test_console_single_node(self, genobjs: GenObjs) -> None:
         config, system, launcher = genobjs([], fake_module=None)
+
+        result = m.cmd_nocr(config, system, launcher)
+
+        assert result == ()
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    def test_console_multi_node(
+        self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--nodes", "2"],
+            multi_rank=(2, 2),
+            rank_env={rank_var: rank},
+            fake_module=None,
+        )
 
         result = m.cmd_nocr(config, system, launcher)
 

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -532,9 +532,28 @@ class Test_cmd_nocr:
         self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
     ) -> None:
         config, system, launcher = genobjs(
+            # passing --nodes is not usually necessary for genobjs but we
+            # are probing a "fixup" check that inspect args directly
             ["--nodes", "2"],
-            multi_rank=(2, 2),
+            multi_rank=(2, 1),
             rank_env={rank_var: rank},
+            fake_module=None,
+        )
+
+        result = m.cmd_nocr(config, system, launcher)
+
+        assert result == ("--nocr",)
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    def test_console_multi_rank(
+        self, genobjs: GenObjs, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            # passing --ranks-per-node is not usually necessary for genobjs
+            # but we are probing a "fixup" check that inspect args directly
+            ["--ranks-per-node", "2"],
+            multi_rank=(1, 2),
+            rank_env={rank_var: "0"},
             fake_module=None,
         )
 

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -284,7 +284,7 @@ class TestConfig:
         assert c.multi_node == m.MultiNode(
             nodes=defaults.LEGATE_NODES,
             ranks_per_node=defaults.LEGATE_RANKS_PER_NODE,
-            not_control_replicable=True,
+            not_control_replicable=False,
             launcher="none",
             launcher_extra=[],
         )
@@ -373,8 +373,17 @@ class TestConfig:
             ]
         )
 
-    def test_nocr_fixup(self, capsys: Capsys) -> None:
+    def test_nocr_fixup_default_single_node(self, capsys: Capsys) -> None:
         c = m.Config(["legate"])
+
+        assert c.console
+        assert not c.multi_node.not_control_replicable
+
+        out, _ = capsys.readouterr()
+        assert scrub(out).strip() == ""
+
+    def test_nocr_fixup_multi_node(self, capsys: Capsys) -> None:
+        c = m.Config(["legate", "--nodes", "2"])
 
         assert c.console
         assert c.multi_node.not_control_replicable

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -394,6 +394,18 @@ class TestConfig:
             == "WARNING: Disabling control replication for interactive run"
         )
 
+    def test_nocr_fixup_multi_rank(self, capsys: Capsys) -> None:
+        c = m.Config(["legate", "--ranks-per-node", "2"])
+
+        assert c.console
+        assert c.multi_node.not_control_replicable
+
+        out, _ = capsys.readouterr()
+        assert (
+            scrub(out).strip()
+            == "WARNING: Disabling control replication for interactive run"
+        )
+
     @pytest.mark.parametrize(
         "args", powerset_nonempty(("--event", "--dataflow"))
     )


### PR DESCRIPTION
In the interest of making future example in docs as clean and unconfusing as possible, this PR removes the "nocr fixup" for single node console usage, where it is not needed, so that users are not confronted by a WARNING that does not apply and that they may not understand. 