### PR TITLE
Fix uninstall instructions for jupyter extension

### DIFF
--- a/legate/jupyter/kernel.py
+++ b/legate/jupyter/kernel.py
@@ -90,9 +90,11 @@ def install_kernel_spec(spec: KernelSpec, config: Config) -> None:
     except NoSuchKernel:
         pass
     else:
+        # inexplicably, install_kernel_spec calls lower on the supplied kernel
+        # name before using, so we need to call lower for this advice to work
         msg = error(
             f"kernel spec {spec_name!r} already exists. Remove it by "
-            f"running 'jupyter kernelspec uninstall {spec_name!r}, "
+            f"running: 'jupyter kernelspec uninstall {spec_name.lower()}', "
             "or choose a new kernel name."
         )
         print(msg)


### PR DESCRIPTION
This small PR fixes the uninstall instructions when a duplicate kernel name is attempted to install.  `KernelSpecManager` calls `lower` on kernel names before saving them out, so the command is, e.g 
```
jupyter kernelspec uninstall legate_sm_gpu           
``` 
and not
```
jupyter kernelspec uninstall 'Legate_SM_GPU'
```
even if the original kernel name was "Legate_SM_GPU".