### PR TITLE
Change the default Legion branch to collective

### DIFF
--- a/install.py
+++ b/install.py
@@ -724,7 +724,7 @@ def driver():
         "--legion-branch",
         dest="legion_branch",
         required=False,
-        default="control_replication",
+        default="collective",
         help="Legion branch to build Legate with.",
     )
     args, unknown = parser.parse_known_args()


### PR DESCRIPTION
Will need to revert this PR once `collective` is merged with `control_replication`.