### PR TITLE
Map futures to zero-copy memory on GPUs

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -476,14 +476,16 @@ void BaseMapper::map_task(const MapperContext ctx,
   auto default_option            = options.front();
   auto generate_default_mappings = [&](auto& stores, bool exact) {
     for (auto& store : stores) {
-      auto mapping = StoreMapping::default_mapping(store, default_option, exact);
       if (store.is_future()) {
+        auto option  = default_option == StoreTarget::FBMEM ? StoreTarget::ZCMEM : default_option;
+        auto mapping = StoreMapping::default_mapping(store, option, exact);
         auto fut_idx = store.future_index();
         if (mapped_futures.find(fut_idx) != mapped_futures.end()) continue;
         mapped_futures.insert(fut_idx);
         for_futures.push_back(std::move(mapping));
       } else {
-        auto key = store.unique_region_field_id();
+        auto mapping = StoreMapping::default_mapping(store, default_option, exact);
+        auto key     = store.unique_region_field_id();
         if (mapped_regions.find(key) != mapped_regions.end()) continue;
         mapped_regions.insert(key);
         if (store.unbound())

--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -350,19 +350,10 @@ void CoreMapper::map_future_map_reduction(const MapperContext ctx,
 {
   output.serdez_upper_bound = LEGATE_MAX_SIZE_SCALAR_RETURN;
 
-#ifdef LEGATE_MAP_FUTURE_MAP_REDUCTIONS_TO_GPU
-  // TODO: It's been reported that blindly mapping target instances of future map reductions
-  // to framebuffers hurts performance. Until we find a better mapping policy, we guard
-  // the current policy with a macro.
-
-  // If this was joining exceptions, we don't want to put instances anywhere
-  // other than the system memory because they need serdez
-  if (input.tag == LEGATE_CORE_JOIN_EXCEPTION_TAG) return;
   if (!local_gpus.empty())
-    for (auto& pair : local_frame_buffers) output.destination_memories.push_back(pair.second);
+    output.destination_memories.push_back(local_zerocopy_memory);
   else if (has_socket_mem)
     for (auto& pair : local_numa_domains) output.destination_memories.push_back(pair.second);
-#endif
 }
 
 void CoreMapper::select_tunable_value(const MapperContext ctx,


### PR DESCRIPTION
@rohany reported that mapping futures to zero-copy memory all the time when tasks run on GPUs can avoid the driver overhead from tiny host-to-device copies. This PR changes the default mapping policy to enforce that.