### PR TITLE
More changes to map futures to zero-copy memory

### DIFF
--- a/src/core/data/store.cc
+++ b/src/core/data/store.cc
@@ -136,13 +136,14 @@ FutureWrapper::FutureWrapper(
 #ifdef DEBUG_LEGATE
     assert(!initialize || future_.get_untyped_size() == field_size);
 #endif
-    auto proc = Processor::get_executing_processor();
+    auto proc     = Processor::get_executing_processor();
+    auto mem_kind = find_memory_kind_for_executing_processor(
 #ifdef LEGATE_NO_FUTURES_ON_FB
-    auto mem_kind = find_memory_kind_for_executing_processor();
+      true
 #else
-    auto mem_kind = proc.kind() == Processor::Kind::TOC_PROC ? Memory::Kind::GPU_FB_MEM
-                                                             : Memory::Kind::SYSTEM_MEM;
+      false
 #endif
+    );
     if (initialize) {
       auto p_init_value = future_.get_buffer(mem_kind);
 #ifdef LEGATE_USE_CUDA

--- a/src/core/data/store.cc
+++ b/src/core/data/store.cc
@@ -136,7 +136,6 @@ FutureWrapper::FutureWrapper(
 #ifdef DEBUG_LEGATE
     assert(!initialize || future_.get_untyped_size() == field_size);
 #endif
-    auto proc     = Processor::get_executing_processor();
     auto mem_kind = find_memory_kind_for_executing_processor(
 #ifdef LEGATE_NO_FUTURES_ON_FB
       true

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -477,16 +477,14 @@ void BaseMapper::map_task(const MapperContext ctx,
   auto default_option            = options.front();
   auto generate_default_mappings = [&](auto& stores, bool exact) {
     for (auto& store : stores) {
+      auto mapping = StoreMapping::default_mapping(store, default_option, exact);
       if (store.is_future()) {
-        auto option  = default_option == StoreTarget::FBMEM ? StoreTarget::ZCMEM : default_option;
-        auto mapping = StoreMapping::default_mapping(store, option, exact);
         auto fut_idx = store.future_index();
         if (mapped_futures.find(fut_idx) != mapped_futures.end()) continue;
         mapped_futures.insert(fut_idx);
         for_futures.push_back(std::move(mapping));
       } else {
-        auto mapping = StoreMapping::default_mapping(store, default_option, exact);
-        auto key     = store.unique_region_field_id();
+        auto key = store.unique_region_field_id();
         if (mapped_regions.find(key) != mapped_regions.end()) continue;
         mapped_regions.insert(key);
         if (store.unbound())


### PR DESCRIPTION
This PR is a companion to #518 to make sure futures are mapped to zero-copy unless requested otherwise.