### PR TITLE
Don't check for collective behavior when we have WRITE privilege

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -211,6 +211,7 @@ void BaseMapper::select_task_options(const MapperContext ctx,
 #ifdef LEGATE_USE_COLLECTIVE
   for (uint32_t idx = 0; idx < task.regions.size(); ++idx) {
     auto& req = task.regions[idx];
+    if (req.privilege & LEGION_WRITE_PRIV) continue;
     if ((req.handle_type == LEGION_SINGULAR_PROJECTION) ||
         (find_legate_projection_functor(req.projection)->is_collective())) {
       output.check_collective_regions.insert(idx);


### PR DESCRIPTION
Otherwise a program like this:

```
M1 = cn.ones((30,30))
M2 = cn.ones((30,30))
M3 = M1.dot(M2)
```

produces this warning:

```
Ignoring request by mapper cunumeric on Node 0 to check for collective usage for region requirement 2 of task cunumeric::MatMulTask (UID 159) because region requirement has writing privileges
```