### PR TITLE
Erase cached reduction instances that cannot be acquired

### DIFF
--- a/src/core/mapping/instance_manager.h
+++ b/src/core/mapping/instance_manager.h
@@ -129,6 +129,9 @@ class ReductionInstanceSet {
                        Instance& instance,
                        const InstanceMappingPolicy& policy);
 
+ public:
+  bool erase(Instance inst);
+
  private:
   std::map<Region, ReductionInstanceSpec> instances_;
 };
@@ -226,6 +229,9 @@ class ReductionInstanceManager : public BaseInstanceManager {
                        FieldID field_id,
                        Instance instance,
                        const InstanceMappingPolicy& policy = {});
+
+ public:
+  void erase(Instance inst);
 
  public:
   static ReductionInstanceManager* get_instance_manager();


### PR DESCRIPTION
Currently, the instance manager never removes its cached instances even when they cannot be acquired. This makes the base mapper forever attempt to reuse instances that cannot be acquired. This PR fixes the problem.