### PR TITLE
CLI help for library options

### DIFF
--- a/legate/__init__.py
+++ b/legate/__init__.py
@@ -17,6 +17,8 @@ from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
 
+from .args import ARGS
+
 from . import _version
 
 __version__ = _version.get_versions()["version"]  # type: ignore[no-untyped-call]

--- a/legate/args.py
+++ b/legate/args.py
@@ -1,0 +1,60 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from .util.args import ArgSpec, Argument
+
+ARGS = [
+    Argument(
+        "consensus",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="consensus",
+            help="Turn on consensus match on single node (for testing).",
+        ),
+    ),
+    Argument(
+        "cycle-check",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="cycle_check",
+            help=(
+                "Check for reference cycles involving RegionField objects on "
+                "script exit (developer option). When such cycles arise "
+                "during execution, they stop used RegionFields from getting "
+                "collected and reused for new Stores, thus increasing memory "
+                "pressure. By default this check will miss any RegionField "
+                "cycles the garbage collector collected during execution; "
+                "run gc.disable() at the beginning of the program to avoid "
+                "this."
+            ),
+        ),
+    ),
+    Argument(
+        "future-leak-check",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="future_leak_check",
+            help=(
+                "Check for reference cycles keeping Future/FutureMap objects "
+                "alive after Legate runtime exit (developer option). Such "
+                "leaks can result in Legion runtime shutdown hangs."
+            ),
+        ),
+    ),
+]

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING, Any, Deque, List, Optional, TypeVar, Union
 
 from legion_top import add_cleanup_item, top_level
 
-from ..util.args import ArgSpec, Argument, parse_library_command_args
+from ..args import ARGS
+from ..util.args import parse_library_command_args
 from . import ffi  # Make sure we only have one ffi instance
 from . import (
     Fence,
@@ -78,49 +79,6 @@ _sizeof_size_t = ffi.sizeof("size_t")
 assert _sizeof_size_t == 4 or _sizeof_size_t == 8
 
 _LEGATE_FIELD_ID_BASE = 1000
-
-ARGS = [
-    Argument(
-        "consensus",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="consensus",
-            help="Turn on consensus match on single node (for testing).",
-        ),
-    ),
-    Argument(
-        "cycle-check",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="cycle_check",
-            help=(
-                "Check for reference cycles involving RegionField objects on "
-                "script exit (developer option). When such cycles arise "
-                "during execution, they stop used RegionFields from getting "
-                "collected and reused for new Stores, thus increasing memory "
-                "pressure. By default this check will miss any RegionField "
-                "cycles the garbage collector collected during execution; "
-                "run gc.disable() at the beginning of the program to avoid "
-                "this."
-            ),
-        ),
-    ),
-    Argument(
-        "future-leak-check",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="future_leak_check",
-            help=(
-                "Check for reference cycles keeping Future/FutureMap objects "
-                "alive after Legate runtime exit (developer option). Such "
-                "leaks can result in Legion runtime shutdown hangs."
-            ),
-        ),
-    ),
-]
 
 
 # A helper class for doing field management with control replication

--- a/legate/rc.py
+++ b/legate/rc.py
@@ -27,13 +27,6 @@ Use "bin/legate --verbose ..." to see some examples of how to call
 legion_python directly.
 """
 
-# TODO (bv) temp transitive imports until cunumeric is updated
-from .util.args import (  # noqa
-    ArgSpec,
-    Argument,
-    parse_library_command_args as parse_command_args,
-)
-
 
 def has_legion_context() -> bool:
     """Determine whether we are running in legion_python.


### PR DESCRIPTION
This PR adds support for displaying help for command line options for downstream legate libraries such as  `cunumeric` (ref: https://github.com/nv-legate/cunumeric/pull/755).  

Known libraries are speculatively imported, and in case the downstream libraries are not "plain-python" importable (as would be the case in the driver) an environment variable is first set that can be used to condition the library's top-level import. This is clunky, but is only utilized in `print_help` which is called only before immediate program exit. 

```
dev310 ❯ legate --help
usage: legate [-h] [--nodes NODES] [--ranks-per-node RANKS_PER_NODE] [--no-replicate] [--launcher {mpirun,jsrun,srun,none}] [--launcher-extra LAUNCHER_EXTRA] [--cpu-bind CPU_BIND] [--mem-bind MEM_BIND]

   <<<<< SNIP >>>>>

Other options:
  --module MODULE       Specify a Python module to load before running (default: None)
  --dry-run             Print the full command line invocation that would be executed, without executing it (default: False)
  --rlwrap              Whether to run with rlwrap to improve readline ability (default: False)
  --color               Whether to use color terminal output (if colorama is installed) (default: False)

Library-specific options
------------------------

legate library options:
  -legate:consensus     Turn on consensus match on single node (for testing).
  -legate:cycle-check   Check for reference cycles involving RegionField objects on script exit (developer option). When such cycles arise during execution, they stop used RegionFields from getting collected
                        and reused for new Stores, thus increasing memory pressure. By default this check will miss any RegionField cycles the garbage collector collected during execution; run gc.disable() at
                        the beginning of the program to avoid this.
  -legate:future-leak-check
                        Check for reference cycles keeping Future/FutureMap objects alive after Legate runtime exit (developer option). Such leaks can result in Legion runtime shutdown hangs.

cunumeric library options:
  -cunumeric:test       Enable test mode. In test mode, all cuNumeric ndarrays are managed by the distributed runtime and the NumPy fallback for small arrays is turned off.
  -cunumeric:preload-cudalibs
                        Preload and initialize handles of all CUDA libraries (cuBLAS, cuSOLVER, etc.) used in cuNumericLoad CUDA libs early
  -cunumeric:warn       Turn on warnings
  -cunumeric:report:coverage
                        Print an overall percentage of cunumeric coverage
  -cunumeric:report:dump-callstack
                        Print an overall percentage of cunumeric coverage with call stack details
  -cunumeric:report:dump-csv [REPORT_DUMP_CSV]
                        Save a coverage report to a specified CSV file
```