### PR TITLE
Pin `scikit-build` to `v0.16.4`

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -102,7 +102,7 @@ requirements:
     - zlib
     - python
     - llvm-openmp
-    - scikit-build
+    - scikit-build >=0.13.1,<0.16.5
     - numpy {{ numpy_version }}
 {% if gpu_enabled_bool %}
     - nccl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "wheel",
     "ninja",
     "setuptools",
-    "scikit-build>=0.13.1",
+    "scikit-build>=0.13.1,<0.16.5",
     "cmake>=3.22.1,!=3.23.0,!=3.25.0",
 ]
 

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -86,7 +86,7 @@ class BuildConfig(SectionConfig):
             "git",
             "make",
             "ninja",
-            "scikit-build>=0.13.1",
+            "scikit-build>=0.13.1,<0.16.5",
             "setuptools>=60",
             "zlib",
         )


### PR DESCRIPTION
Pin `scikit-build` to `v0.16.4` to workaround https://github.com/scikit-build/scikit-build/issues/845.

Related cunumeric PR: https://github.com/nv-legate/cunumeric/pull/758