### PR TITLE
Report version info in --verbose outupt

### DIFF
--- a/install.py
+++ b/install.py
@@ -413,7 +413,7 @@ def install(
     cmake_flags = cmd_env.get("CMAKE_ARGS", "").split(" ")
 
     if debug or verbose:
-        cmake_flags += ["--log-level=%s" % ("DEBUG" if debug else "VERBOSE")]
+        cmake_flags += [f"--log-level={'DEBUG' if debug else 'VERBOSE'}"]
 
     cmake_flags += f"""\
 -DCMAKE_BUILD_TYPE={(
@@ -441,27 +441,27 @@ def install(
 """.splitlines()
 
     if nccl_dir:
-        cmake_flags += ["-DNCCL_DIR=%s" % nccl_dir]
+        cmake_flags += [f"-DNCCL_DIR={nccl_dir}"]
     if gasnet_dir:
-        cmake_flags += ["-DGASNet_ROOT_DIR=%s" % gasnet_dir]
+        cmake_flags += [f"-DGASNet_ROOT_DIR={gasnet_dir}"]
     if ucx_dir:
-        cmake_flags += ["-DUCX_ROOT=%s" % ucx_dir]
+        cmake_flags += [f"-DUCX_ROOT={ucx_dir}"]
     if conduit:
-        cmake_flags += ["-DGASNet_CONDUIT=%s" % conduit]
+        cmake_flags += [f"-DGASNet_CONDUIT={conduit}"]
     if cuda_dir:
-        cmake_flags += ["-DCUDA_TOOLKIT_ROOT_DIR=%s" % cuda_dir]
+        cmake_flags += [f"-DCUDA_TOOLKIT_ROOT_DIR={cuda_dir}"]
     if thrust_dir:
-        cmake_flags += ["-DThrust_ROOT=%s" % thrust_dir]
+        cmake_flags += [f"-DThrust_ROOT={thrust_dir}"]
     if legion_dir:
-        cmake_flags += ["-DLegion_ROOT=%s" % legion_dir]
+        cmake_flags += [f"-DLegion_ROOT={legion_dir}"]
     elif legion_src_dir:
-        cmake_flags += ["-DCPM_Legion_SOURCE=%s" % legion_src_dir]
+        cmake_flags += [f"-DCPM_Legion_SOURCE={legion_src_dir}"]
     else:
         cmake_flags += ["-DCPM_DOWNLOAD_Legion=ON"]
     if legion_url:
-        cmake_flags += ["-Dlegate_core_LEGION_REPOSITORY=%s" % legion_url]
+        cmake_flags += [f"-Dlegate_core_LEGION_REPOSITORY={legion_url}"]
     if legion_branch:
-        cmake_flags += ["-Dlegate_core_LEGION_BRANCH=%s" % legion_branch]
+        cmake_flags += [f"-Dlegate_core_LEGION_BRANCH={legion_branch}"]
 
     cmake_flags += extra_flags
     build_flags = [f"-j{str(thread_count)}"]
@@ -761,7 +761,7 @@ def driver():
         )
         print("to specify the CMake executable if it is not on PATH.")
         print()
-        print("Attempted to execute: %s" % args.cmake_exe)
+        print(f"Attempted to execute: {args.cmake_exe}")
         sys.exit(1)
 
     install(unknown=unknown, **vars(args))

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -185,7 +185,7 @@ class CanonicalDriver(LegateDriver):
 
 
 def get_versions() -> LegateVersions:
-    from legate import __version__
+    from legate import __version__ as lg_version
 
     os.environ["_LEGATE_PROJECT_HELP_ARGS_"] = "1"
     try:
@@ -197,7 +197,7 @@ def get_versions() -> LegateVersions:
     del os.environ["_LEGATE_PROJECT_HELP_ARGS_"]
 
     return LegateVersions(
-        legate_version=__version__, cunumeric_version=cn_version
+        legate_version=lg_version, cunumeric_version=cn_version
     )
 
 

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -14,12 +14,15 @@
 #
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass
 from shlex import quote
 from subprocess import run
 from textwrap import indent
 from typing import TYPE_CHECKING
 
 from ..util.system import System
+from ..util.types import DataclassMixin
 from ..util.ui import kvtable, rule, section, value, warn
 from .command import CMD_PARTS_CANONICAL, CMD_PARTS_LEGION
 from .config import ConfigProtocol
@@ -39,6 +42,14 @@ reasons:
 (lldb) process launch -v LIB_PATH={libpath} -v PYTHONPATH={pythonpath}
 
 """
+
+
+@dataclass(frozen=True)
+class LegateVersions(DataclassMixin):
+    """Collect package versions relevant to Legate."""
+
+    legate_version: str
+    cunumeric_version: str | None
 
 
 class LegateDriver:
@@ -173,6 +184,23 @@ class CanonicalDriver(LegateDriver):
         assert False, "This function should not be invoked."
 
 
+def get_versions() -> LegateVersions:
+    from legate import __version__
+
+    os.environ["_LEGATE_PROJECT_HELP_ARGS_"] = "1"
+    try:
+        import cunumeric  # type: ignore [import]
+
+        cn_version = cunumeric.__version__
+    except ModuleNotFoundError:
+        cn_version = None
+    del os.environ["_LEGATE_PROJECT_HELP_ARGS_"]
+
+    return LegateVersions(
+        legate_version=__version__, cunumeric_version=cn_version
+    )
+
+
 def print_verbose(
     system: System,
     driver: LegateDriver | None = None,
@@ -201,6 +229,9 @@ def print_verbose(
 
     print(section("\nLegion paths:"))
     print(indent(str(system.legion_paths), prefix="  "))
+
+    print(section("\nVersions:"))
+    print(indent(str(get_versions()), prefix="  "))
 
     if driver:
         print(section("\nCommand:"))


### PR DESCRIPTION
This PR adds a `Versions:` section to the `-legate -verbose` output, that reports `legate` and (if found) `cunumeric` version information. Future work will add `legion` version information. 

This PR uses the recent work to make `cunumeric` top-level importable for purposes of scraping metadata from the package.

![image](https://user-images.githubusercontent.com/1078448/215595520-4e0cebf7-d1e4-4e9d-a696-fd5e7cfcaa8d.png)
