### PR TITLE
Revert "Update the architectures built in conda package (#545) (#546)"

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -16,7 +16,7 @@ CMAKE_ARGS+="
 if [ -z "$CPU_ONLY" ]; then
   CMAKE_ARGS+="
 -DLegion_USE_CUDA=ON
--DCMAKE_CUDA_ARCHITECTURES:LIST=60-real;70-real;75-real;80-real;90
+-DCMAKE_CUDA_ARCHITECTURES:LIST=60-real;70-real;75-real;80-real;86
 "
 fi
 


### PR DESCRIPTION
This reverts commit 6c718de3c7a986a8a5003d0964dfcc810756bc6b. We will support Hopper in the next release.