### PR TITLE
Revert "Report version info in --verbose outupt"

### DIFF
--- a/install.py
+++ b/install.py
@@ -413,7 +413,7 @@ def install(
     cmake_flags = cmd_env.get("CMAKE_ARGS", "").split(" ")
 
     if debug or verbose:
-        cmake_flags += [f"--log-level={'DEBUG' if debug else 'VERBOSE'}"]
+        cmake_flags += ["--log-level=%s" % ("DEBUG" if debug else "VERBOSE")]
 
     cmake_flags += f"""\
 -DCMAKE_BUILD_TYPE={(
@@ -441,27 +441,27 @@ def install(
 """.splitlines()
 
     if nccl_dir:
-        cmake_flags += [f"-DNCCL_DIR={nccl_dir}"]
+        cmake_flags += ["-DNCCL_DIR=%s" % nccl_dir]
     if gasnet_dir:
-        cmake_flags += [f"-DGASNet_ROOT_DIR={gasnet_dir}"]
+        cmake_flags += ["-DGASNet_ROOT_DIR=%s" % gasnet_dir]
     if ucx_dir:
-        cmake_flags += [f"-DUCX_ROOT={ucx_dir}"]
+        cmake_flags += ["-DUCX_ROOT=%s" % ucx_dir]
     if conduit:
-        cmake_flags += [f"-DGASNet_CONDUIT={conduit}"]
+        cmake_flags += ["-DGASNet_CONDUIT=%s" % conduit]
     if cuda_dir:
-        cmake_flags += [f"-DCUDA_TOOLKIT_ROOT_DIR={cuda_dir}"]
+        cmake_flags += ["-DCUDA_TOOLKIT_ROOT_DIR=%s" % cuda_dir]
     if thrust_dir:
-        cmake_flags += [f"-DThrust_ROOT={thrust_dir}"]
+        cmake_flags += ["-DThrust_ROOT=%s" % thrust_dir]
     if legion_dir:
-        cmake_flags += [f"-DLegion_ROOT={legion_dir}"]
+        cmake_flags += ["-DLegion_ROOT=%s" % legion_dir]
     elif legion_src_dir:
-        cmake_flags += [f"-DCPM_Legion_SOURCE={legion_src_dir}"]
+        cmake_flags += ["-DCPM_Legion_SOURCE=%s" % legion_src_dir]
     else:
         cmake_flags += ["-DCPM_DOWNLOAD_Legion=ON"]
     if legion_url:
-        cmake_flags += [f"-Dlegate_core_LEGION_REPOSITORY={legion_url}"]
+        cmake_flags += ["-Dlegate_core_LEGION_REPOSITORY=%s" % legion_url]
     if legion_branch:
-        cmake_flags += [f"-Dlegate_core_LEGION_BRANCH={legion_branch}"]
+        cmake_flags += ["-Dlegate_core_LEGION_BRANCH=%s" % legion_branch]
 
     cmake_flags += extra_flags
     build_flags = [f"-j{str(thread_count)}"]
@@ -761,7 +761,7 @@ def driver():
         )
         print("to specify the CMake executable if it is not on PATH.")
         print()
-        print(f"Attempted to execute: {args.cmake_exe}")
+        print("Attempted to execute: %s" % args.cmake_exe)
         sys.exit(1)
 
     install(unknown=unknown, **vars(args))

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -14,15 +14,12 @@
 #
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
 from shlex import quote
 from subprocess import run
 from textwrap import indent
 from typing import TYPE_CHECKING
 
 from ..util.system import System
-from ..util.types import DataclassMixin
 from ..util.ui import kvtable, rule, section, value, warn
 from .command import CMD_PARTS_CANONICAL, CMD_PARTS_LEGION
 from .config import ConfigProtocol
@@ -42,14 +39,6 @@ reasons:
 (lldb) process launch -v LIB_PATH={libpath} -v PYTHONPATH={pythonpath}
 
 """
-
-
-@dataclass(frozen=True)
-class LegateVersions(DataclassMixin):
-    """Collect package versions relevant to Legate."""
-
-    legate_version: str
-    cunumeric_version: str | None
 
 
 class LegateDriver:
@@ -184,23 +173,6 @@ class CanonicalDriver(LegateDriver):
         assert False, "This function should not be invoked."
 
 
-def get_versions() -> LegateVersions:
-    from legate import __version__ as lg_version
-
-    os.environ["_LEGATE_PROJECT_HELP_ARGS_"] = "1"
-    try:
-        import cunumeric  # type: ignore [import]
-
-        cn_version = cunumeric.__version__
-    except ModuleNotFoundError:
-        cn_version = None
-    del os.environ["_LEGATE_PROJECT_HELP_ARGS_"]
-
-    return LegateVersions(
-        legate_version=lg_version, cunumeric_version=cn_version
-    )
-
-
 def print_verbose(
     system: System,
     driver: LegateDriver | None = None,
@@ -229,9 +201,6 @@ def print_verbose(
 
     print(section("\nLegion paths:"))
     print(indent(str(system.legion_paths), prefix="  "))
-
-    print(section("\nVersions:"))
-    print(indent(str(get_versions()), prefix="  "))
 
     if driver:
         print(section("\nCommand:"))


### PR DESCRIPTION
Reverts nv-legate/legate.core#549

cc @manopapad This seems to be causing cunumeric tests to fail (in CI, working for me locally :shrug:) , reverting until I can sort it out. 

```
  File "/opt/conda/envs/legate/lib/python3.9/site-packages/legate/driver/driver.py", line 112, in dry_run
    print_verbose(self.system, self)
  File "/opt/conda/envs/legate/lib/python3.9/site-packages/legate/driver/driver.py", line 234, in print_verbose
    print(indent(str(get_versions()), prefix="  "))
  File "/opt/conda/envs/legate/lib/python3.9/site-packages/legate/driver/driver.py", line 194, in get_versions
    cn_version = cunumeric.__version__
AttributeError: partially initialized module 'cunumeric' has no attribute '__version__' (most likely due to a circular import)
```