### PR TITLE
Add support for LEGATE_CONFIG

### DIFF
--- a/legate/driver/__init__.py
+++ b/legate/driver/__init__.py
@@ -20,8 +20,18 @@ from .launcher import Launcher
 
 
 def main() -> int:
-    import sys
+    import os, shlex, sys
 
     from .main import legate_main as _main
 
-    return _main(sys.argv)
+    # A little explanation. We want to encourage configuration options be
+    # passed via LEGATE_CONFIG, in order to be considerate to user scripts.
+    # But we still need to accept actual command line args for comaptibility,
+    # and those should also take precedences. Here we splice the options from
+    # LEGATE_CONFIG in before sys.argv, and take advantage of the fact that if
+    # there are any options repeated in both places, argparse will use the
+    # latter (i.e. the actual command line provided ones).
+    env_args = shlex.split(os.environ.get("LEGATE_CONFIG", ""))
+    argv = sys.argv[:1] + env_args + sys.argv[1:]
+
+    return _main(argv)

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -176,8 +176,18 @@ class Config:
     """
 
     def __init__(self, argv: ArgList) -> None:
-        self.argv = argv
+        user_script = next((x for x in argv if x.endswith(".py")), None)
+        if user_script:
+            user_script_index = argv.index(user_script)
+            legate_argv = argv[:user_script_index]
+            user_argv = argv[user_script_index:][1:]
+        else:
+            legate_argv = argv
+            user_argv = []
 
+        self.argv = legate_argv
+
+        # extra might contain legion command line options for now
         args, extra = parser.parse_known_args(self.argv[1:])
 
         colors.ENABLED = args.color
@@ -185,12 +195,10 @@ class Config:
         # only saving this for help with testing
         self._args = args
 
-        self.user_script = next((x for x in extra if x.endswith(".py")), None)
+        self.user_script = user_script
 
-        user_opts = list(extra)
-        if self.user_script in user_opts:
-            user_opts.remove(self.user_script)
-        self.user_opts = tuple(user_opts)
+        # extra here might be legion or realm command line options
+        self.user_opts = tuple(user_argv) + tuple(extra)
 
         # these may modify the args, so apply before dataclass conversions
         self._fixup_nocr(args)


### PR DESCRIPTION
This PR adds initial support for a `LEGATE_CONFIG` environment variable to pass options to the legate runtime (either with the `legate` driver or with standard python invocation). This PR also explicitly changes arg parsing to consider options *before* a `script.py` to be "legate config" and options *after* a `script.py` to be "user options".

Some specific invocations and their results are given below for comparison

### Standard python invocation

#### with env var
#### 
```bash
LEGATE_CONFIG="--fbmem 2048 --gpus 1 --gpu-bind 1 --verbose --color" python cholesky.py

#  cholesky.py -lg:local 0 -ll:cpu 4 -ll:gpu 1 -cuda:skipbusy -ll:util 2 -ll:csize 4000 -ll:fsize 2048 -ll:zsize 32 -ll:networks none -level openmp=5,gpu=5 -lg:eager_alloc_percentage 50 -ucx:tls_host '^dc,ud'
```

#### with command line args

See "Gotchas" below

### Driver invocation

#### with env var
```bash
LEGATE_CONFIG="--fbmem 2048 --gpus 1 --gpu-bind 1 --verbose --color" legate cholesky.py

# bind.sh --launcher local --gpus 1 -- legion_python -ll:py 1 -lg:local 0 -ll:cpu 4 -ll:gpu 1 -cuda:skipbusy -ll:util 2 -ll:csize 4000 -ll:fsize 2048 -ll:zsize 32 -ll:networks none -level openmp=5,gpu=5 -lg:eager_alloc_percentage 50 -ucx:tls_host '^dc,ud' cholesky.py
```

#### with command line args
```bash
legate --fbmem 2048 --gpus 1 --gpu-bind 1 --verbose --color cholesky.py
 
# bind.sh --launcher local --gpus 1 -- legion_python -ll:py 1 -lg:local 0 -ll:cpu 4 -ll:gpu 1 -cuda:skipbusy -ll:util 2 -ll:csize 4000 -ll:fsize 2048 -ll:zsize 32 -ll:networks none -level openmp=5,gpu=5 -lg:eager_alloc_percentage 50 -ucx:tls_host '^dc,ud' cholesky.py
```

## Gotchas

The splitting on user script results in this behvior, which is just to be aware of:
```bash
legate --fbmem 2048 --gpus 1 --gpu-bind 1 cholesky.py  # legate sees --fbmem, etc

legate cholesky.py --fbmem 2048 --gpus 1 --gpu-bind 1  # legate does NOT see --fbmem, etc
```
This is definitely cleaner from a "stay out of the user script's way" POV but will need to be communicated widely. 

Another gotcha from splitting on user script. This does *not* work:
```
python cholesky.py --fbmem 2048 --gpus 1 --gpu-bind 1 --verbose --color
```
since all of the args are considered user args. I think this might be worth some consideration. 

## Tests

Note that all existing tests pass with these changes, since the implementation works by inserting values into "argv" early on. Appropriate tests to add would be to ensure that the presence   `LEGATE_CONFIG`  results in the expected modification of the `argv` that is passed to `Config`. I will add tests once the behavior is all agreed on. 

## Future work

Ultimately, it might be nice to have all CLLR configuration options pass via env vars. This would eliminate all possible contention with argument parsing that a user `script.py` would do and also would provide a clearer contract between the different library layers (each looks at its own env var, rather than all trying to gobble up `sys.argv` on their own with no coordination). 

This will require a fair somewhat more work to change the current machinery that builds up a command line to change to building up different env vars instead. 