### PR TITLE
Mappers should skip collective views with no suitable instance

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -980,8 +980,10 @@ void BaseMapper::legate_select_sources(const MapperContext ctx,
   for (uint32_t idx = 0; idx < collective_sources.size(); idx++) {
     std::vector<PhysicalInstance> col_instances;
     collective_sources[idx].find_instances_nearest_memory(destination_memory, col_instances);
-    // if we can't find any nearest instance in this collective view, we move on to the next one
-    if (col_instances.empty()) continue;
+#ifdef DEBUG_LEGATE
+    // there must exist at least one instance in the collective view
+    assert(!col_instances.empty());
+#endif
     // we need only first instance if there are several
     const PhysicalInstance& instance = col_instances[0];
     add_instance_to_band_ranking(

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -980,6 +980,8 @@ void BaseMapper::legate_select_sources(const MapperContext ctx,
   for (uint32_t idx = 0; idx < collective_sources.size(); idx++) {
     std::vector<PhysicalInstance> col_instances;
     collective_sources[idx].find_instances_nearest_memory(destination_memory, col_instances);
+    // if we can't find any nearest instance in this collective view, we move on to the next one
+    if (col_instances.empty()) continue;
     // we need only first instance if there are several
     const PhysicalInstance& instance = col_instances[0];
     add_instance_to_band_ranking(


### PR DESCRIPTION
This PR fixes an intermittent segfault in `legate_select_sources`.