### PR TITLE
Args and Config

### DIFF
--- a/legate/driver/__init__.py
+++ b/legate/driver/__init__.py
@@ -20,8 +20,18 @@ from .launcher import Launcher
 
 
 def main() -> int:
-    import sys
+    import os, shlex, sys
 
     from .main import legate_main as _main
 
-    return _main(sys.argv)
+    # A little explanation. We want to encourage configuration options be
+    # passed via LEGATE_CONFIG, in order to be considerate to user scripts.
+    # But we still need to accept actual command line args for comaptibility,
+    # and those should also take precedences. Here we splice the options from
+    # LEGATE_CONFIG in before sys.argv, and take advantage of the fact that if
+    # there are any options repeated in both places, argparse will use the
+    # latter (i.e. the actual command line provided ones).
+    env_args = shlex.split(os.environ.get("LEGATE_CONFIG", ""))
+    argv = sys.argv[:1] + env_args + sys.argv[1:]
+
+    return _main(argv)

--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -102,7 +102,7 @@ parser = _LegateArgumentParser(
 parser.add_argument(
     "command",
     nargs=REMAINDER,
-    help="A python script to run, plus any argumentsfor the script. "
+    help="A python script to run, plus any arguments for the script. "
     "Any arguments after the script will be passed to the script, i.e. "
     "NOT used as arguments to legate itself.",
 )

--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -16,7 +16,7 @@
 #
 from __future__ import annotations
 
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from argparse import REMAINDER, ArgumentDefaultsHelpFormatter, ArgumentParser
 from typing import IO, Optional
 
 from ..util.shared_args import (
@@ -99,6 +99,13 @@ parser = _LegateArgumentParser(
     formatter_class=ArgumentDefaultsHelpFormatter,
 )
 
+parser.add_argument(
+    "command",
+    nargs=REMAINDER,
+    help="A python script to run, plus any argumentsfor the script. "
+    "Any arguments after the script will be passed to the script, i.e. "
+    "NOT used as arguments to legate itself.",
+)
 
 multi_node = parser.add_argument_group("Multi-node configuration")
 multi_node.add_argument(NODES.name, **NODES.kwargs)

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -178,19 +178,15 @@ class Config:
     def __init__(self, argv: ArgList) -> None:
         self.argv = argv
 
-        args, extra = parser.parse_known_args(self.argv[1:])
+        args = parser.parse_args(self.argv[1:])
 
         colors.ENABLED = args.color
 
         # only saving this for help with testing
         self._args = args
 
-        self.user_script = next((x for x in extra if x.endswith(".py")), None)
-
-        user_opts = list(extra)
-        if self.user_script in user_opts:
-            user_opts.remove(self.user_script)
-        self.user_opts = tuple(user_opts)
+        self.user_script = args.command[0] if args.command else None
+        self.user_opts = tuple(args.command[1:]) if self.user_script else ()
 
         # these may modify the args, so apply before dataclass conversions
         self._fixup_nocr(args)

--- a/legate/tester/stages/_linux/cpu.py
+++ b/legate/tester/stages/_linux/cpu.py
@@ -48,7 +48,9 @@ class CPU(TestStage):
 
     kind: FeatureType = "cpus"
 
-    args = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)

--- a/legate/tester/stages/_linux/eager.py
+++ b/legate/tester/stages/_linux/eager.py
@@ -43,6 +43,8 @@ class Eager(TestStage):
 
     args: ArgList = []
 
+    _tmp_args: ArgList = []
+
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 

--- a/legate/tester/stages/_linux/gpu.py
+++ b/legate/tester/stages/_linux/gpu.py
@@ -44,7 +44,9 @@ class GPU(TestStage):
 
     kind: FeatureType = "cuda"
 
-    args = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)

--- a/legate/tester/stages/_linux/omp.py
+++ b/legate/tester/stages/_linux/omp.py
@@ -48,7 +48,9 @@ class OMP(TestStage):
 
     kind: FeatureType = "openmp"
 
-    args = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)

--- a/legate/tester/stages/_osx/cpu.py
+++ b/legate/tester/stages/_osx/cpu.py
@@ -47,7 +47,9 @@ class CPU(TestStage):
 
     kind: FeatureType = "cpus"
 
-    args = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)

--- a/legate/tester/stages/_osx/eager.py
+++ b/legate/tester/stages/_osx/eager.py
@@ -43,6 +43,8 @@ class Eager(TestStage):
 
     args: ArgList = []
 
+    _tmp_args = []
+
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 

--- a/legate/tester/stages/_osx/gpu.py
+++ b/legate/tester/stages/_osx/gpu.py
@@ -42,7 +42,9 @@ class GPU(TestStage):
 
     kind: FeatureType = "cuda"
 
-    args: ArgList = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         raise RuntimeError("GPU test are not supported on OSX")

--- a/legate/tester/stages/_osx/omp.py
+++ b/legate/tester/stages/_osx/omp.py
@@ -47,7 +47,9 @@ class OMP(TestStage):
 
     kind: FeatureType = "openmp"
 
-    args = [CUNUMERIC_TEST_ARG]
+    args: ArgList = []
+
+    _tmp_args = [CUNUMERIC_TEST_ARG]
 
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)

--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -258,13 +258,13 @@ class TestStage(Protocol):
 
         cov_args = self.cov_args(config)
 
-        cmd = [str(config.legate_path)] + cov_args
-
         stage_args = self.args + self.shard_args(shard, config)
         file_args = self.file_args(test_file, config)
 
-        cmd += (
-            stage_args
+        cmd = (
+            [str(config.legate_path)]
+            + stage_args
+            + cov_args
             + [str(test_path)]
             + file_args
             + config.extra_args

--- a/tests/unit/legate/tester/stages/_linux/test_cpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_cpu.py
@@ -31,7 +31,8 @@ def test_default() -> None:
     s = FakeSystem(cpus=12)
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
@@ -44,7 +45,8 @@ def test_cpu_pin_strict() -> None:
     s = FakeSystem(cpus=12)
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
@@ -57,7 +59,8 @@ def test_cpu_pin_none() -> None:
     s = FakeSystem(cpus=12)
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 

--- a/tests/unit/legate/tester/stages/_linux/test_gpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_gpu.py
@@ -30,7 +30,8 @@ def test_default() -> None:
     s = FakeSystem()
     stage = m.GPU(c, s)
     assert stage.kind == "cuda"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 

--- a/tests/unit/legate/tester/stages/_linux/test_omp.py
+++ b/tests/unit/legate/tester/stages/_linux/test_omp.py
@@ -31,7 +31,8 @@ def test_default() -> None:
     s = FakeSystem(cpus=12)
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
@@ -44,7 +45,8 @@ def test_cpu_pin_strict() -> None:
     s = FakeSystem(cpus=12)
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
@@ -57,7 +59,8 @@ def test_cpu_pin_none() -> None:
     s = FakeSystem(cpus=12)
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
-    assert stage.args == ["-cunumeric:test"]
+    assert stage.args == []
+    assert stage._tmp_args == ["-cunumeric:test"]
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 

--- a/tests/unit/legate/tester/stages/test_test_stage.py
+++ b/tests/unit/legate/tester/stages/test_test_stage.py
@@ -40,6 +40,8 @@ class MockTestStage(m.TestStage):
 
     args = ["-foo", "-bar"]
 
+    _tmp_args = []
+
     def __init__(self, config: Config, system: _TestSystem) -> None:
         self._init(config, system)
 


### PR DESCRIPTION
This PR adds support for `LEGATE_CONFIG` as a mechanism for supplying legate or legion configuration options. Other points:

* The `legate` driver now recognizes a script and its arguments more generally by using all of the "remaining" args, rather than assuming a `.py` file extension somewhere.
* The `legate` driver still supports passing ***Legate*** (only) command line options before a script to run. The driver is an application, and it is reasonable for an application to process its own arguments since it can control when that processing happens. 

Broadly speaking, these two usages are what is now possible:

```
LEGATE_CONFIG="legate or legion opts" legate <legate opts only> <script> <script or legion opts>

LEGATE_CONFIG="legate or legion opts" python <script> <script opts>
```

## Notes

### Legion command line config args

Technically, this will also "work":
```
python script.py -ll:cpu 2
```
The reason to discourage this (why it was not listed above) is that we have no control whether `script.py` attempts its own arg-parsing before or after `legate.core` is imported. If the script tries to parse args first, then it could abort due to "unkown" args

### Coverage 

The relative position of `cov_bin` was moved, to ensure legate args came before it. This seems the correct thing to do. The following also seems to work for me:
```
test.py --use=cpus,eager,cuda --cpus 2  --gpus 1 --debug ---cov-bin /opt/envs/dev310/bin/coverage
```
and results in an invocation like:
```
LEGATE_TEST=1 REALM_SYNTHETIC_CORE_MAP= legate --cpus 2 --cpu-bind 3,4,5,9,10,11 /opt/envs/dev310/bin/coverage run -a --branch /home/bryan/work/cunumeric/tests/integration/test_0d_store.py -cunumeric:test

```
@robinw0928 can you confirm whether this meets your expectations?

### Cunumeric args

The handling of `-cunumerc:test` was a but tricky. It cannot be included with the legate-only args (as it was previously) so it has been moved after the script in a fairly clunky way for now. @manopapad has proposed to remove all cunumeric command line processing and replace with env vars of some sort, and I *strongly* agree with this.  There are just too many combinations of import orders, command invocations, invocation methods, etc to contend with, and we can't even exert control over all of them if we wanted to try. The complexity added by having downstream libraries try to rummage through `sys.argv`, in addition to the upstream ones, is basically unmanageable. The good news is that there are only a handful of cunumeric args at present. 

### Legion env var config args

I have left out any conversions around `LEGION_DEFAULT_ARGS` and `REALM_DEFAULT_ARGS` from this PR. I actually think the current PR goes far enough to get things into a better place before a beta release. I would definitely like to include these env vars in documentation I intend to write, but I would like to stop there for now, and not introduce more changes and complexity to the driver before the beta release. 