### PR TITLE
Update Build.md to add the missing dependency, rust

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -189,6 +189,7 @@ in the environment file:
 - `git`
 - `make`
 - `ninja` (this is optional, but produces more informative build output)
+- `rust`
 - `scikit-build`
 
 ### OpenBLAS


### PR DESCRIPTION
Rust was added to the build tools in PR #535, but BUILD.md has not been updated yet.

Signed-off-by: OTABI Tomoya <tomoya.otabi@gmail.com>