### PR TITLE
Updates for cmd opts -> env vars

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from argparse import REMAINDER, ArgumentDefaultsHelpFormatter, ArgumentParser
-from typing import IO, Optional
 
 from ..util.shared_args import (
     CPUS,
@@ -41,58 +40,7 @@ from . import defaults
 __all__ = ("parser",)
 
 
-# We want to provide information about library-specific command line options
-# for legate and cunumeric, etc. if they are installed. But we want to avoid
-# importing those packages under normal circumstances. This argument parser
-# subclass overrides the standard print_help method to attempt to import
-# specified packages *only* when printing help output. Additionally:
-#
-# - names of downstream packages must be configured on the packages class attr
-# - downstream packages must expose a <pkg_name>.ARGS attr with argparse args
-# - <pkg_name>.ARGS must be plain-python importable if the environment variable
-#   _LEGATE_PROJECT_HELP_ARGS_ is set to "1"
-#
-# All of this is somewhat clunky but the best option to provide a good UX.
-class _LegateArgumentParser(ArgumentParser):
-    packages = ("legate", "cunumeric")
-
-    def print_help(self, file: Optional[IO[str]] = None) -> None:
-        import importlib
-        import os
-        from argparse import SUPPRESS
-
-        os.environ["_LEGATE_PROJECT_HELP_ARGS_"] = "1"
-
-        super().print_help(file)
-
-        helps = []
-
-        for pkg_name in self.packages:
-            try:
-                ARGS = importlib.import_module(pkg_name).ARGS
-                parser = ArgumentParser(
-                    prog=pkg_name,
-                    add_help=False,
-                    allow_abbrev=False,
-                    usage=SUPPRESS,
-                )
-
-                for arg in ARGS:
-                    argname = f"-{pkg_name}:{arg.name}"
-                    parser.add_argument(argname, **arg.kwargs)
-
-                helps.append((pkg_name, parser.format_help()))
-
-            except Exception:
-                pass
-
-        if helps:
-            print("\nLibrary-specific options\n------------------------\n")
-            for pkg_name, help in helps:
-                print(f"{pkg_name} library {help}")
-
-
-parser = _LegateArgumentParser(
+parser = ArgumentParser(
     description="Legate Driver",
     allow_abbrev=False,
     formatter_class=ArgumentDefaultsHelpFormatter,

--- a/legate/settings.py
+++ b/legate/settings.py
@@ -20,7 +20,6 @@ __all__ = ("settings",)
 
 
 class LegateRuntimeSettings(Settings):
-
     consensus: PrioritizedSetting[bool] = PrioritizedSetting(
         "consensus",
         "LEGATE_CONSENSUS",

--- a/legate/tester/stages/_linux/cpu.py
+++ b/legate/tester/stages/_linux/cpu.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
 from ..util import (
-    CUNUMERIC_TEST_ARG,
+    CUNUMERIC_TEST_ENV,
     UNPIN_ENV,
     Shard,
     StageSpec,
@@ -50,13 +50,13 @@ class CPU(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
+        env = {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
+        env.update(CUNUMERIC_TEST_ENV)
+        return env
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         args = [

--- a/legate/tester/stages/_linux/eager.py
+++ b/legate/tester/stages/_linux/eager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import Shard, StageSpec, adjust_workers
+from ..util import EAGER_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -43,18 +43,11 @@ class Eager(TestStage):
 
     args: ArgList = []
 
-    _tmp_args: ArgList = []
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        # Raise min chunk sizes for deferred codepaths to force eager execution
-        env = {
-            "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
-            "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
-            "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",
-        }
+        env = dict(EAGER_ENV)
         return env
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:

--- a/legate/tester/stages/_linux/gpu.py
+++ b/legate/tester/stages/_linux/gpu.py
@@ -18,7 +18,7 @@ import time
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import CUNUMERIC_TEST_ARG, Shard, StageSpec, adjust_workers
+from ..util import CUNUMERIC_TEST_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -46,13 +46,11 @@ class GPU(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return {}
+        return dict(CUNUMERIC_TEST_ENV)
 
     def delay(self, shard: Shard, config: Config, system: TestSystem) -> None:
         time.sleep(config.gpu_delay / 1000)

--- a/legate/tester/stages/_linux/omp.py
+++ b/legate/tester/stages/_linux/omp.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
 from ..util import (
-    CUNUMERIC_TEST_ARG,
+    CUNUMERIC_TEST_ENV,
     UNPIN_ENV,
     Shard,
     StageSpec,
@@ -50,13 +50,13 @@ class OMP(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
+        env = {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
+        env.update(CUNUMERIC_TEST_ENV)
+        return env
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         args = [

--- a/legate/tester/stages/_osx/cpu.py
+++ b/legate/tester/stages/_osx/cpu.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
 from ..util import (
-    CUNUMERIC_TEST_ARG,
+    CUNUMERIC_TEST_ENV,
     UNPIN_ENV,
     Shard,
     StageSpec,
@@ -49,13 +49,13 @@ class CPU(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return UNPIN_ENV
+        env = dict(UNPIN_ENV)
+        env.update(CUNUMERIC_TEST_ENV)
+        return env
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         return ["--cpus", str(config.cpus)]

--- a/legate/tester/stages/_osx/eager.py
+++ b/legate/tester/stages/_osx/eager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import UNPIN_ENV, Shard, StageSpec, adjust_workers
+from ..util import EAGER_ENV, UNPIN_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -43,18 +43,11 @@ class Eager(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = []
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        # Raise min chunk sizes for deferred codepaths to force eager execution
-        env = {
-            "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
-            "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
-            "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",
-        }
+        env = dict(EAGER_ENV)
         env.update(UNPIN_ENV)
         return env
 

--- a/legate/tester/stages/_osx/gpu.py
+++ b/legate/tester/stages/_osx/gpu.py
@@ -18,7 +18,7 @@ import time
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import CUNUMERIC_TEST_ARG, UNPIN_ENV, Shard
+from ..util import CUNUMERIC_TEST_ENV, UNPIN_ENV, Shard
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -44,13 +44,13 @@ class GPU(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         raise RuntimeError("GPU test are not supported on OSX")
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return UNPIN_ENV
+        env = dict(UNPIN_ENV)
+        env.update(CUNUMERIC_TEST_ENV)
+        return env
 
     def delay(self, shard: Shard, config: Config, system: TestSystem) -> None:
         time.sleep(config.gpu_delay / 1000)

--- a/legate/tester/stages/_osx/omp.py
+++ b/legate/tester/stages/_osx/omp.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
 from ..util import (
-    CUNUMERIC_TEST_ARG,
+    CUNUMERIC_TEST_ENV,
     UNPIN_ENV,
     Shard,
     StageSpec,
@@ -49,13 +49,13 @@ class OMP(TestStage):
 
     args: ArgList = []
 
-    _tmp_args = [CUNUMERIC_TEST_ARG]
-
     def __init__(self, config: Config, system: TestSystem) -> None:
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return UNPIN_ENV
+        env = dict(UNPIN_ENV)
+        env.update(CUNUMERIC_TEST_ENV)
+        return env
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         return [

--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -57,12 +57,6 @@ class TestStage(Protocol):
     #: Any fixed stage-specific command-line args to pass
     args: ArgList
 
-    # This can go away when/if "-cunumeric:test" is replaced by an env var.
-    # The issue is that currently the args above are all otherwise legate
-    # args that must appear before the script path, but "-cunumeric:test" is
-    # not a legate arg, so it cannot go there.
-    _tmp_args: ArgList
-
     # --- Protocol methods
 
     def __init__(self, config: Config, system: TestSystem) -> None:
@@ -268,7 +262,6 @@ class TestStage(Protocol):
             + [str(test_path)]
             + file_args
             + config.extra_args
-            + self._tmp_args
         )
 
         if custom_args:

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -25,9 +25,17 @@ from ..config import Config
 from ..logger import LOG
 from ..test_system import ProcessResult
 
-CUNUMERIC_TEST_ARG = "-cunumeric:test"
-
 UNPIN_ENV = {"REALM_SYNTHETIC_CORE_MAP": ""}
+
+CUNUMERIC_TEST_ENV = {"CUNUMERIC_TEST": "1"}
+
+# Raise min chunk sizes for deferred codepaths to force eager execution
+EAGER_ENV = {
+    "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
+    "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
+    "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",
+}
+
 
 Shard: TypeAlias = Tuple[int, ...]
 

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -31,6 +31,7 @@ CUNUMERIC_TEST_ENV = {"CUNUMERIC_TEST": "1"}
 
 # Raise min chunk sizes for deferred codepaths to force eager execution
 EAGER_ENV = {
+    "CUNUMERIC_TEST": "0",
     "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
     "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
     "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/legate/util/args.py
+++ b/legate/util/args.py
@@ -14,9 +14,6 @@
 #
 from __future__ import annotations
 
-import re
-import sys
-import warnings
 from argparse import Action, ArgumentParser, Namespace
 from dataclasses import dataclass, fields
 from typing import (
@@ -144,67 +141,3 @@ class ExtendAction(Action, Generic[T]):
             items.append(values)
         # removing any duplicates before storing
         setattr(namespace, self.dest, list(set(items)))
-
-
-def parse_library_command_args(
-    libname: str, args: Iterable[Argument]
-) -> Namespace:
-    """ """
-    if not libname.isidentifier():
-        raise ValueError(
-            f"Invalid library {libname!r} for command line arguments"
-        )
-
-    parser = ArgumentParser(
-        prog=f"<{libname} program>", add_help=False, allow_abbrev=False
-    )
-
-    # Some explanation is in order. Argparse treats arguments with a single
-    # dash differently, e.g. "-xyz" is interpreted as "-x -y -z". This can
-    # cause confusion and clashes when there are multiple single-dash args
-    # with identical prefixes. TLDR; we want "-legate:foo" to behave just
-    # as if it was "--legate:foo". In order to do this, we configure a parser
-    # for "long argumens" and then munge the values in sys.argv to update
-    # any "short prefix" arguments to be "long prefix" arguments first, before
-    # parsing. We also take care to update any output. The alternative here
-    # would be to abandon argparse entirely, and parse sys.argv manually.
-    #
-    # ref: https://github.com/nv-legate/legate.core/issues/415
-
-    short_prefix = f"-{libname}:"
-    long_prefix = f"-{short_prefix}"
-
-    argnames = [arg.name for arg in args]
-
-    for arg in args:
-        argname = f"{long_prefix}{arg.name}"
-        parser.add_argument(argname, **arg.kwargs)
-
-    has_custom_help = "help" in argnames
-
-    if f"{short_prefix}help" in sys.argv and not has_custom_help:
-        help_string = parser.format_help()
-
-        # this is a little sloppy but should suffice in practice
-        print(help_string.replace(long_prefix, short_prefix))
-
-        sys.exit()
-
-    # convert any short-prefix args to be long-prefix
-    sys.argv = [re.sub(f"^{short_prefix}", long_prefix, x) for x in sys.argv]
-
-    args, extra = parser.parse_known_args()
-
-    # put any unconsumed args back they way they were
-    extra = [re.sub(f"^{long_prefix}", short_prefix, x) for x in extra]
-
-    for item in extra:
-        if item.startswith(short_prefix):
-            warnings.warn(
-                f"Unrecognized argument {item!r} for {libname} (passed on as-is)"  # noqa: E501
-            )
-            break
-
-    sys.argv = sys.argv[:1] + extra
-
-    return args

--- a/tests/unit/legate/tester/stages/_linux/test_cpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_cpu.py
@@ -21,9 +21,12 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import cpu as m
-from legate.tester.stages.util import UNPIN_ENV
+from legate.tester.stages.util import CUNUMERIC_TEST_ENV, UNPIN_ENV
 
 from .. import FakeSystem
+
+unpin_and_test = dict(UNPIN_ENV)
+unpin_and_test.update(CUNUMERIC_TEST_ENV)
 
 
 def test_default() -> None:
@@ -32,8 +35,7 @@ def test_default() -> None:
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.env(c, s) == unpin_and_test
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)
@@ -46,8 +48,7 @@ def test_cpu_pin_strict() -> None:
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == {}
+    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)
@@ -60,8 +61,7 @@ def test_cpu_pin_none() -> None:
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.env(c, s) == unpin_and_test
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)

--- a/tests/unit/legate/tester/stages/_linux/test_eager.py
+++ b/tests/unit/legate/tester/stages/_linux/test_eager.py
@@ -32,6 +32,7 @@ def test_default() -> None:
     assert stage.kind == "eager"
     assert stage.args == []
     assert stage.env(c, s) == {
+        "CUNUMERIC_TEST": "0",
         "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
         "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
         "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/tests/unit/legate/tester/stages/_linux/test_gpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_gpu.py
@@ -21,6 +21,7 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import gpu as m
+from legate.tester.stages.util import CUNUMERIC_TEST_ENV
 
 from .. import FakeSystem
 
@@ -31,8 +32,7 @@ def test_default() -> None:
     stage = m.GPU(c, s)
     assert stage.kind == "cuda"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == {}
+    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
     assert stage.spec.workers > 0
 
 

--- a/tests/unit/legate/tester/stages/_linux/test_omp.py
+++ b/tests/unit/legate/tester/stages/_linux/test_omp.py
@@ -21,9 +21,12 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import omp as m
-from legate.tester.stages.util import UNPIN_ENV
+from legate.tester.stages.util import CUNUMERIC_TEST_ENV, UNPIN_ENV
 
 from .. import FakeSystem
+
+unpin_and_test = dict(UNPIN_ENV)
+unpin_and_test.update(CUNUMERIC_TEST_ENV)
 
 
 def test_default() -> None:
@@ -32,8 +35,7 @@ def test_default() -> None:
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.env(c, s) == unpin_and_test
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)
@@ -46,8 +48,7 @@ def test_cpu_pin_strict() -> None:
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == {}
+    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)
@@ -60,8 +61,7 @@ def test_cpu_pin_none() -> None:
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
     assert stage.args == []
-    assert stage._tmp_args == ["-cunumeric:test"]
-    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.env(c, s) == unpin_and_test
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)

--- a/tests/unit/legate/tester/stages/test_test_stage.py
+++ b/tests/unit/legate/tester/stages/test_test_stage.py
@@ -39,8 +39,6 @@ class MockTestStage(m.TestStage):
 
     args = ["-foo", "-bar"]
 
-    _tmp_args = []
-
     def __init__(self, config: Config, system: _TestSystem) -> None:
         self._init(config, system)
 


### PR DESCRIPTION
 This PR closes the loop with #567 and https://github.com/nv-legate/cunumeric/pull/799 

* Updates tester to set `CUNUMERC_TEST=1` instead of passing `-cunumeic:test`
* Removes argparse feature for help with library command line args (and also removes janky conditional imports)