### PR TITLE
Add `--numamem` to the tester

### DIFF
--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -46,6 +46,9 @@ DEFAULT_OMPS_PER_NODE = 1
 #: Value to use if --ompthreads is not specified.
 DEFAULT_OMPTHREADS = 4
 
+#: Value to use if --numamem is not specified.
+DEFAULT_NUMAMEM = 0
+
 #: Default values to apply to normalize the testing environment.
 DEFAULT_PROCESS_ENV = {
     "LEGATE_TEST": "1",

--- a/legate/tester/args.py
+++ b/legate/tester/args.py
@@ -28,6 +28,7 @@ from . import (
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
+    DEFAULT_NUMAMEM,
     DEFAULT_OMPS_PER_NODE,
     DEFAULT_OMPTHREADS,
     FEATURES,
@@ -158,6 +159,15 @@ feature_opts.add_argument(
     type=int,
     default=DEFAULT_OMPTHREADS,
     help="Number of threads per OpenMP processor",
+)
+
+
+feature_opts.add_argument(
+    "--numamem",
+    dest="numamem",
+    type=int,
+    default=DEFAULT_NUMAMEM,
+    help="NUMA memory for OpenMP processors (MB)",
 )
 
 

--- a/legate/tester/config.py
+++ b/legate/tester/config.py
@@ -63,6 +63,7 @@ class Config:
         self.fbmem = args.fbmem
         self.gpu_delay = args.gpu_delay
         self.ompthreads = args.ompthreads
+        self.numamem = args.numamem
 
         # test run configuration
         self.debug = args.debug

--- a/legate/tester/stages/_linux/omp.py
+++ b/legate/tester/stages/_linux/omp.py
@@ -64,6 +64,8 @@ class OMP(TestStage):
             str(config.omps),
             "--ompthreads",
             str(config.ompthreads),
+            "--numamem",
+            str(config.numamem),
         ]
         if config.cpu_pin != "none":
             args += [

--- a/tests/unit/legate/tester/stages/_linux/test_omp.py
+++ b/tests/unit/legate/tester/stages/_linux/test_omp.py
@@ -79,6 +79,8 @@ def test_shard_args(shard: tuple[int, ...], expected: str) -> None:
         f"{c.omps}",
         "--ompthreads",
         f"{c.ompthreads}",
+        "--numamem",
+        f"{c.numamem}",
         "--cpu-bind",
         expected,
     ]

--- a/tests/unit/legate/tester/test___init__.py
+++ b/tests/unit/legate/tester/test___init__.py
@@ -22,6 +22,7 @@ from legate.tester import (
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
+    DEFAULT_NUMAMEM,
     DEFAULT_OMPS_PER_NODE,
     DEFAULT_OMPTHREADS,
     DEFAULT_PROCESS_ENV,
@@ -49,6 +50,9 @@ class TestConsts:
 
     def test_DEFAULT_OMPTHREADS(self) -> None:
         assert DEFAULT_OMPTHREADS == 4
+
+    def test_DEFAULT_NUMAMEM(self) -> None:
+        assert DEFAULT_NUMAMEM == 0
 
     def test_DEFAULT_PROCESS_ENV(self) -> None:
         assert DEFAULT_PROCESS_ENV == {

--- a/tests/unit/legate/tester/test_args.py
+++ b/tests/unit/legate/tester/test_args.py
@@ -22,6 +22,7 @@ from legate.tester import (
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
+    DEFAULT_NUMAMEM,
     DEFAULT_OMPS_PER_NODE,
     DEFAULT_OMPTHREADS,
     args as m,
@@ -58,6 +59,9 @@ class TestParserDefaults:
 
     def test_ompthreads(self) -> None:
         assert m.parser.get_default("ompthreads") == DEFAULT_OMPTHREADS
+
+    def test_numamem(self) -> None:
+        assert m.parser.get_default("numamem") == DEFAULT_NUMAMEM
 
     def test_legate_dir(self) -> None:
         assert m.parser.get_default("legate_dir") is None


### PR DESCRIPTION
This PR adds `--numamem` to the tester so we can run tests with numa memory as before. (See the test driver failure: https://github.com/nv-legate/cunumeric/actions/runs/4191696755/jobs/7268552774)