### PR TITLE
Revert "NVTX: Use RangePush and Domain (#293)"

### DIFF
--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -45,11 +45,6 @@ static const char* const core_library_name = "legate.core";
 
 /*static*/ bool Core::has_socket_mem = false;
 
-#ifdef LEGATE_USE_CUDA
-/*static*/ const char* const nvtx::Range::domainName = "Legate";
-/*static*/ nvtxDomainHandle_t nvtx::Range::domain;
-#endif
-
 /*static*/ void Core::parse_config(void)
 {
 #ifndef LEGATE_USE_CUDA
@@ -88,10 +83,6 @@ static const char* const core_library_name = "legate.core";
   parse_variable("LEGATE_EMPTY_TASK", use_empty_task);
   parse_variable("LEGATE_SYNC_STREAM_VIEW", synchronize_stream_view);
   parse_variable("LEGATE_LOG_MAPPING", log_mapping_decisions);
-
-#ifdef LEGATE_USE_CUDA
-  nvtx::Range::initialize();
-#endif
 }
 
 static void extract_scalar_task(
@@ -116,9 +107,7 @@ static void extract_scalar_task(
 
 /*static*/ void Core::shutdown(void)
 {
-#ifdef LEGATE_USE_CUDA
-  nvtx::Range::shutdown();
-#endif
+  // Nothing to do here yet...
 }
 
 /*static*/ void Core::show_progress(const Legion::Task* task,

--- a/src/core/utilities/nvtx_help.h
+++ b/src/core/utilities/nvtx_help.h
@@ -27,23 +27,11 @@ namespace nvtx {
 
 class Range {
  public:
-  Range(const char* message)
-  {
-    nvtxEventAttributes_t eventAttrib = {0};
-    eventAttrib.version               = NVTX_VERSION;
-    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
-    eventAttrib.message.ascii         = message;
-    nvtxDomainRangePushEx(domain, &eventAttrib);
-  }
-  ~Range() { nvtxDomainRangePop(domain); }
-
-  static void initialize() { domain = nvtxDomainCreateA(domainName); }
-  static void shutdown() { nvtxDomainDestroy(domain); }
+  Range(const char* message) { range_ = nvtxRangeStartA(message); }
+  ~Range() { nvtxRangeEnd(range_); }
 
  private:
-  static const char* const domainName;
-  static nvtxDomainHandle_t domain;
+  nvtxRangeId_t range_;
 };
 
 }  // namespace nvtx


### PR DESCRIPTION
One side-effect of #293 is that NVTX ranges are now associated with physical thread ids in Nsight. This is undesirable at the moment, as each GPU processor is currently rendered as multiple threads in Nsight (an issue that @manopapad and I are still investigating) and thus the ranges now spread across those threads. Even worse is that since each thread only has ~20 boxes to show, rendering is suppressed for them, as I guess they are seemingly uninteresting. Until we fix this behavior, we will fall back to the old code for NVTX ranges, which at least shows all the ranges on a single line.

cc @evanramos-nvidia @manopapad 