### PR TITLE
Add nvml dependency in the conda build script to get the headers for realm

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -112,6 +112,7 @@ requirements:
     - cuda-nvtx ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}
     - cuda-cudart ={{ cuda_version }}
+    - cuda-nvml-dev ={{ cuda_version }}
     - cuda-driver-dev ={{ cuda_version }}
     - cuda-cudart-dev ={{ cuda_version }}
 {% endif %}


### PR DESCRIPTION
While trying to debug the CI, my local build hit the following from legion/realm compilation:
```
[35/197] Building CXX object _deps/legion-build/runtime/CMakeFiles/RealmRuntime.dir/realm/cuda/cuda_module.cc.o
FAILED: _deps/legion-build/runtime/CMakeFiles/RealmRuntime.dir/realm/cuda/cuda_module.cc.o
$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DRealmRuntime_EXPORTS -I$PREFIX/include -I$SRC_DIR/build/_deps/legion-src/runtime -I$SRC_DIR/build/_deps/legion-build/runtime -UNDEBUG -march=haswell -O2 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Woverloaded-virtual -std=gnu++17 -MD -MT _deps/legion-build/runtime/CMakeFiles/RealmRuntime.dir/realm/cuda/cuda_module.cc.o -MF _deps/legion-build/runtime/CMakeFiles/RealmRuntime.dir/realm/cuda/cuda_module.cc.o.d -o _deps/legion-build/runtime/CMakeFiles/RealmRuntime.dir/realm/cuda/cuda_module.cc.o -c $SRC_DIR/build/_deps/legion-src/runtime/realm/cuda/cuda_module.cc
In file included from $SRC_DIR/build/_deps/legion-src/runtime/realm/cuda/cuda_module.cc:17:
$SRC_DIR/build/_deps/legion-src/runtime/realm/cuda/cuda_internal.h:23:10: fatal error: nvml.h: No such file or directory
   23 | #include <nvml.h>
      |          ^~~~~~~~
compilation terminated.
```
I'm not sure when realm began depending on nvml.  Adding the necessary dependency linkage resulted in a successful build locally.