### PR TITLE
Fix is_complete_for check

### DIFF
--- a/legate/core/partition.py
+++ b/legate/core/partition.py
@@ -227,7 +227,9 @@ class Tiling(PartitionBase):
         my_lo = self._offset
         my_hi = self._offset + self.tile_shape * self._color_shape
 
-        return my_lo <= offsets and offsets + extents <= my_hi
+        return all(a <= b for (a, b) in zip(my_lo, offsets)) and all(
+            a <= b for (a, b) in zip(offsets + extents, my_hi)
+        )
 
     def is_disjoint_for(self, launch_domain: Optional[Rect]) -> bool:
         return (

--- a/legate/core/partition.py
+++ b/legate/core/partition.py
@@ -238,7 +238,9 @@ class Tiling(PartitionBase):
         )
 
     def has_color(self, color: Shape) -> bool:
-        return color >= 0 and color < self._color_shape
+        return all(a >= 0 for a in color) and all(
+            a < b for (a, b) in zip(color, self._color_shape)
+        )
 
     @lru_cache
     def get_subregion_size(self, extents: Shape, color: Shape) -> Shape:

--- a/legate/core/partition.py
+++ b/legate/core/partition.py
@@ -227,9 +227,7 @@ class Tiling(PartitionBase):
         my_lo = self._offset
         my_hi = self._offset + self.tile_shape * self._color_shape
 
-        return all(a <= b for (a, b) in zip(my_lo, offsets)) and all(
-            a <= b for (a, b) in zip(offsets + extents, my_hi)
-        )
+        return all(my_lo <= offsets) and all(offsets + extents <= my_hi)
 
     def is_disjoint_for(self, launch_domain: Optional[Rect]) -> bool:
         return (
@@ -238,9 +236,7 @@ class Tiling(PartitionBase):
         )
 
     def has_color(self, color: Shape) -> bool:
-        return all(a >= 0 for a in color) and all(
-            a < b for (a, b) in zip(color, self._color_shape)
-        )
+        return all(color >= 0) and all(color < self._color_shape)
 
     @lru_cache
     def get_subregion_size(self, extents: Shape, color: Shape) -> Shape:
@@ -400,7 +396,7 @@ class Weighted(PartitionBase):
         return True
 
     def has_color(self, color: Shape) -> bool:
-        return color >= 0 and color < self._color_shape
+        return all(color >= 0) and all(color < self._color_shape)
 
     def translate(self, offset: Shape) -> None:
         raise NotImplementedError("This method shouldn't be invoked")

--- a/legate/core/shape.py
+++ b/legate/core/shape.py
@@ -32,6 +32,11 @@ def _cast_tuple(value: int | Iterable[int], ndim: int) -> tuple[int, ...]:
     return tuple(value)
 
 
+class _ShapeComparisonResult(tuple[bool, ...]):
+    def __bool__(self) -> bool:
+        assert False, "use any() or all()"
+
+
 class Shape:
     _extents: Union[tuple[int, ...], None]
     _ispace: Union[IndexSpace, None]
@@ -154,41 +159,45 @@ class Shape:
         else:
             return False
 
-    def __le__(self, other: ExtentLike) -> bool:
+    def __le__(self, other: ExtentLike) -> _ShapeComparisonResult:
         lh = self.extents
         rh = (
             other.extents
             if isinstance(other, Shape)
             else _cast_tuple(other, self.ndim)
         )
-        return len(lh) == len(rh) and lh <= rh
+        assert len(lh) == len(rh)
+        return _ShapeComparisonResult(l <= r for (l, r) in zip(lh, rh))
 
-    def __lt__(self, other: ExtentLike) -> bool:
+    def __lt__(self, other: ExtentLike) -> _ShapeComparisonResult:
         lh = self.extents
         rh = (
             other.extents
             if isinstance(other, Shape)
             else _cast_tuple(other, self.ndim)
         )
-        return len(lh) == len(rh) and lh < rh
+        assert len(lh) == len(rh)
+        return _ShapeComparisonResult(l < r for (l, r) in zip(lh, rh))
 
-    def __ge__(self, other: ExtentLike) -> bool:
+    def __ge__(self, other: ExtentLike) -> _ShapeComparisonResult:
         lh = self.extents
         rh = (
             other.extents
             if isinstance(other, Shape)
             else _cast_tuple(other, self.ndim)
         )
-        return len(lh) == len(rh) and lh >= rh
+        assert len(lh) == len(rh)
+        return _ShapeComparisonResult(l >= r for (l, r) in zip(lh, rh))
 
-    def __gt__(self, other: ExtentLike) -> bool:
+    def __gt__(self, other: ExtentLike) -> _ShapeComparisonResult:
         lh = self.extents
         rh = (
             other.extents
             if isinstance(other, Shape)
             else _cast_tuple(other, self.ndim)
         )
-        return len(lh) == len(rh) and lh > rh
+        assert len(lh) == len(rh)
+        return _ShapeComparisonResult(l > r for (l, r) in zip(lh, rh))
 
     def __add__(self, other: ExtentLike) -> Shape:
         lh = self.extents


### PR DESCRIPTION
This is the underlying issue behind https://github.com/nv-legate/cunumeric/pull/721#issuecomment-1370307289. Thanks to @aschaffer for doing most of the work to uncover this.

The error in the original logic can be seen when running the following example:

```
import cunumeric as num
a = num.ones((8, 10, 8))
v = num.ones((3, 5, 3))
num.convolve(a, v, mode="same")
```

with `LEGATE_TEST=1 CUNUMERIC_TEST=1 legate --cpus 3 --event --dataflow`, in which case legion spy verification fails with:

```
ERROR: Index Partition: 15 was labelled complete but there are missing points. This is definitely an application bug and invalidates all of Legion's dependence analysis. You must fix this before Legion Spy can continue.
```

The call to `is_complete_for` for the offending partition is misjudging it as complete. Here are the values in that call:

```
self._tile_shape = Shape((8, 4, 8))
self._color_shape = Shape((1, 3, 1))
self._offset = Shape((0, 0, -2))
extents = Shape((8, 10, 8))
offsets = Shape((0, 0, 0))
my_lo = Shape((0, 0, -2))
my_hi = Shape((8, 12, 6)))
```

@magnatelee please also take a look at the following potential related issues:
* The task creation code in `deferred.py:convolve` is setting `PartSym.complete = False`, but this information is not honored when creating the partitions. Instead `is_complete_for` is consulted like normal.
* Here a (lexicographic) comparison operator on `Shape` was used where an elementwise comparison was intended. It would be good to check any other uses of these operators, to confirm that this mixup isn't happening there too.