### PR TITLE
Runtime network detection and UCX options

### DIFF
--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -271,7 +271,7 @@ def cmd_bgwork(
     # message handler threads equal to our number of utility
     # processors in order to prevent head-of-line blocking
     if ranks > 1:
-        opts += ("-ll:bgwork", str(utility))
+        opts += ("-ll:bgwork", str(max(utility, 2)))
 
     if ranks > 1 and "ucx" in install_info.networks:
         opts += ("-ll:bgworkpin", "1")

--- a/legate/install_info.py.in
+++ b/legate/install_info.py.in
@@ -42,3 +42,5 @@ def get_libpath():
 
 libpath: str = get_libpath()
 header: str = """@header@"""
+
+networks: list[str] = "@Legion_NETWORKS@".split()

--- a/legate_core_python.cmake
+++ b/legate_core_python.cmake
@@ -45,10 +45,10 @@ endif()
 
 add_custom_target("generate_install_info_py" ALL
   COMMAND ${CMAKE_COMMAND}
+          -DLegion_NETWORKS="${Legion_NETWORKS}"
           -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
           -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_install_info_py.cmake"
   COMMENT "Generate install_info.py"
-  VERBATIM
 )
 
 add_library(legate_core_python INTERFACE)

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 import legate.driver.command as m
+from legate import install_info
 from legate.driver.launcher import RANK_ENV_VARS
 from legate.util.colors import scrub
 from legate.util.types import LauncherType
@@ -880,6 +881,200 @@ class Test_cmd_utility:
         result = m.cmd_utility(config, system, launcher)
 
         assert result == ("-ll:util", value)
+
+
+class Test_cmd_bgwork:
+    def test_default_single_rank(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs([])
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ()
+
+    def test_utility_1_single_rank(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(["--utility", "1"])
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ()
+
+    def test_utility_1_single_rank_and_ucx(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(["--utility", "1"])
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ()
+
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utiltity_n_single_rank(
+        self, genobjs: GenObjs, value: str
+    ) -> None:
+        config, system, launcher = genobjs(["--utility", value])
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ()
+
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utiltity_n_single_rank_and_ucx(
+        self, genobjs: GenObjs, value: str
+    ) -> None:
+        config, system, launcher = genobjs(["--utility", value])
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ()
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    def test_default_multi_rank(
+        self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            [], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ("-ll:bgwork", "2")
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    def test_default_multi_rank_and_ucx(
+        self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            [], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ("-ll:bgwork", "2", "-ll:bgworkpin", "1")
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    def test_utility_1_multi_rank_no_launcher(
+        self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", "1"], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ("-ll:bgwork", "2")
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    def test_utility_1_multi_rank_no_launcher_and_ucx(
+        self, genobjs: GenObjs, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", "1"], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ("-ll:bgwork", "2", "-ll:bgworkpin", "1")
+
+    @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
+    def test_utility_1_multi_rank_with_launcher(
+        self, genobjs: GenObjs, launch: str
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", "1", "--launcher", launch], multi_rank=(2, 2)
+        )
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ("-ll:bgwork", "2")
+
+    @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
+    def test_utility_1_multi_rank_with_launcher_and_ucx(
+        self, genobjs: GenObjs, launch: str
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", "1", "--launcher", launch], multi_rank=(2, 2)
+        )
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ("-ll:bgwork", "2", "-ll:bgworkpin", "1")
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utility_n_multi_rank_no_launcher(
+        self, genobjs: GenObjs, value: str, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", value], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ("-ll:bgwork", value)
+
+    @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
+    @pytest.mark.parametrize("rank", ("0", "1", "2"))
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utility_n_multi_rank_no_launcher_and_ucx(
+        self, genobjs: GenObjs, value: str, rank: str, rank_var: dict[str, str]
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", value], multi_rank=(2, 2), rank_env={rank_var: rank}
+        )
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ("-ll:bgwork", value, "-ll:bgworkpin", "1")
+
+    @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utility_n_multi_rank_with_launcher(
+        self, genobjs: GenObjs, value: str, launch: str
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", value, "--launcher", launch], multi_rank=(2, 2)
+        )
+
+        result = m.cmd_bgwork(config, system, launcher)
+
+        assert result == ("-ll:bgwork", value)
+
+    @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
+    @pytest.mark.parametrize("value", ("2", "3", "10"))
+    def test_utility_n_multi_rank_with_launcher_and_ucx(
+        self, genobjs: GenObjs, value: str, launch: str
+    ) -> None:
+        config, system, launcher = genobjs(
+            ["--utility", value, "--launcher", launch], multi_rank=(2, 2)
+        )
+
+        networks_orig = list(install_info.networks)
+        install_info.networks.append("ucx")
+        result = m.cmd_bgwork(config, system, launcher)
+        install_info.networks[:] = networks_orig[:]
+
+        assert result == ("-ll:bgwork", value, "-ll:bgworkpin", "1")
 
 
 class Test_cmd_sysmem:

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -58,6 +58,7 @@ def test_CMD_PARTS() -> None:
         m.cmd_gpus,
         m.cmd_openmp,
         m.cmd_utility,
+        m.cmd_bgwork,
         m.cmd_mem,
         m.cmd_numamem,
         m.cmd_fbmem,
@@ -826,7 +827,7 @@ class Test_cmd_utility:
 
         result = m.cmd_utility(config, system, launcher)
 
-        assert result == ("-ll:util", "2", "-ll:bgwork", "2")
+        assert result == ("-ll:util", "2")
 
     @pytest.mark.parametrize("rank_var", RANK_ENV_VARS)
     @pytest.mark.parametrize("rank", ("0", "1", "2"))
@@ -865,7 +866,7 @@ class Test_cmd_utility:
 
         result = m.cmd_utility(config, system, launcher)
 
-        assert result == ("-ll:util", value, "-ll:bgwork", value)
+        assert result == ("-ll:util", value)
 
     @pytest.mark.parametrize("launch", ("mpirun", "jsrun", "srun"))
     @pytest.mark.parametrize("value", ("2", "3", "10"))
@@ -878,7 +879,7 @@ class Test_cmd_utility:
 
         result = m.cmd_utility(config, system, launcher)
 
-        assert result == ("-ll:util", value, "-ll:bgwork", value)
+        assert result == ("-ll:util", value)
 
 
 class Test_cmd_sysmem:


### PR DESCRIPTION
This PR adds runtime detection of the Realm network (thanks to @trxcllnt for pointing me in a simpler direction than I was originally looking), exposed as a list `install_info.networks` 

Additionally, the options for `bgwork` and `bgworkpin` have been factored into their own `cmd_bgwork`

@manopapad before I add unit tests, one slight difference to clarify: previously, `-ll:bgwork` was *not* added if `utility == 1`. In the current PR, `cmd_bgwork` adds it unconditionally (even if `utility == 1`) Is this correct, or should `cmd_bgwork` retain that same condition?