### PR TITLE
Fix C++ warnings, virtual destructor bugs, and style issues

### DIFF
--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -65,31 +65,31 @@ class CoreMapper : public Legion::Mapping::NullMapper {
 
  public:  // Task mapping calls
   void select_task_options(const Legion::Mapping::MapperContext ctx,
-                                   const Legion::Task& task,
-                                   TaskOptions& output) override;
+                           const Legion::Task& task,
+                           TaskOptions& output) override;
   void slice_task(const Legion::Mapping::MapperContext ctx,
-                          const Legion::Task& task,
-                          const SliceTaskInput& input,
-                          SliceTaskOutput& output) override;
+                  const Legion::Task& task,
+                  const SliceTaskInput& input,
+                  SliceTaskOutput& output) override;
   void map_task(const Legion::Mapping::MapperContext ctx,
-                        const Legion::Task& task,
-                        const MapTaskInput& input,
-                        MapTaskOutput& output) override;
+                const Legion::Task& task,
+                const MapTaskInput& input,
+                MapTaskOutput& output) override;
   void select_sharding_functor(const Legion::Mapping::MapperContext ctx,
-                                       const Legion::Task& task,
-                                       const SelectShardingFunctorInput& input,
-                                       SelectShardingFunctorOutput& output) override;
+                               const Legion::Task& task,
+                               const SelectShardingFunctorInput& input,
+                               SelectShardingFunctorOutput& output) override;
   void select_steal_targets(const Legion::Mapping::MapperContext ctx,
-                                    const SelectStealingInput& input,
-                                    SelectStealingOutput& output) override;
+                            const SelectStealingInput& input,
+                            SelectStealingOutput& output) override;
   void select_tasks_to_map(const Legion::Mapping::MapperContext ctx,
-                                   const SelectMappingInput& input,
-                                   SelectMappingOutput& output) override;
+                           const SelectMappingInput& input,
+                           SelectMappingOutput& output) override;
 
  public:
   void configure_context(const Legion::Mapping::MapperContext ctx,
-                                 const Legion::Task& task,
-                                 ContextConfigOutput& output) override;
+                         const Legion::Task& task,
+                         ContextConfigOutput& output) override;
   void map_future_map_reduction(const Legion::Mapping::MapperContext ctx,
                                 const FutureMapReductionInput& input,
                                 FutureMapReductionOutput& output) override;

--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -49,6 +49,7 @@ class CoreMapper : public Legion::Mapping::NullMapper {
   CoreMapper(Legion::Mapping::MapperRuntime* runtime,
              Legion::Machine machine,
              const LibraryContext& context);
+
   virtual ~CoreMapper();
 
  public:
@@ -58,44 +59,44 @@ class CoreMapper : public Legion::Mapping::NullMapper {
   static const char* create_name(Legion::AddressSpace node);
 
  public:
-  virtual const char* get_mapper_name() const override;
-  virtual Legion::Mapping::Mapper::MapperSyncModel get_mapper_sync_model() const override;
-  virtual bool request_valid_instances() const { return false; }
+  const char* get_mapper_name() const override;
+  Legion::Mapping::Mapper::MapperSyncModel get_mapper_sync_model() const override;
+  bool request_valid_instances() const override { return false; }
 
  public:  // Task mapping calls
-  virtual void select_task_options(const Legion::Mapping::MapperContext ctx,
+  void select_task_options(const Legion::Mapping::MapperContext ctx,
                                    const Legion::Task& task,
-                                   TaskOptions& output);
-  virtual void slice_task(const Legion::Mapping::MapperContext ctx,
+                                   TaskOptions& output) override;
+  void slice_task(const Legion::Mapping::MapperContext ctx,
                           const Legion::Task& task,
                           const SliceTaskInput& input,
-                          SliceTaskOutput& output);
-  virtual void map_task(const Legion::Mapping::MapperContext ctx,
+                          SliceTaskOutput& output) override;
+  void map_task(const Legion::Mapping::MapperContext ctx,
                         const Legion::Task& task,
                         const MapTaskInput& input,
-                        MapTaskOutput& output);
-  virtual void select_sharding_functor(const Legion::Mapping::MapperContext ctx,
+                        MapTaskOutput& output) override;
+  void select_sharding_functor(const Legion::Mapping::MapperContext ctx,
                                        const Legion::Task& task,
                                        const SelectShardingFunctorInput& input,
-                                       SelectShardingFunctorOutput& output);
-  virtual void select_steal_targets(const Legion::Mapping::MapperContext ctx,
+                                       SelectShardingFunctorOutput& output) override;
+  void select_steal_targets(const Legion::Mapping::MapperContext ctx,
                                     const SelectStealingInput& input,
-                                    SelectStealingOutput& output);
-  virtual void select_tasks_to_map(const Legion::Mapping::MapperContext ctx,
+                                    SelectStealingOutput& output) override;
+  void select_tasks_to_map(const Legion::Mapping::MapperContext ctx,
                                    const SelectMappingInput& input,
-                                   SelectMappingOutput& output);
+                                   SelectMappingOutput& output) override;
 
  public:
-  virtual void configure_context(const Legion::Mapping::MapperContext ctx,
+  void configure_context(const Legion::Mapping::MapperContext ctx,
                                  const Legion::Task& task,
-                                 ContextConfigOutput& output);
+                                 ContextConfigOutput& output) override;
   void map_future_map_reduction(const Legion::Mapping::MapperContext ctx,
                                 const FutureMapReductionInput& input,
-                                FutureMapReductionOutput& output);
-  virtual void select_tunable_value(const Legion::Mapping::MapperContext ctx,
-                                    const Legion::Task& task,
-                                    const SelectTunableInput& input,
-                                    SelectTunableOutput& output);
+                                FutureMapReductionOutput& output) override;
+  void select_tunable_value(const Legion::Mapping::MapperContext ctx,
+                            const Legion::Task& task,
+                            const SelectTunableInput& input,
+                            SelectTunableOutput& output) override;
 
  protected:
   template <typename Functor>

--- a/src/core/mapping/mapping.h
+++ b/src/core/mapping/mapping.h
@@ -154,7 +154,7 @@ struct StoreMapping {
 
 class MachineQueryInterface {
  public:
-  virtual ~MachineQueryInterface(){}
+  virtual ~MachineQueryInterface() {}
   virtual const std::vector<Processor>& cpus() const = 0;
   virtual const std::vector<Processor>& gpus() const = 0;
   virtual const std::vector<Processor>& omps() const = 0;
@@ -163,7 +163,7 @@ class MachineQueryInterface {
 
 class LegateMapper {
  public:
-  virtual ~LegateMapper(){}
+  virtual ~LegateMapper() {}
   virtual void set_machine(const MachineQueryInterface* machine)                            = 0;
   virtual TaskTarget task_target(const Task& task, const std::vector<TaskTarget>& options)  = 0;
   virtual std::vector<StoreMapping> store_mappings(const Task& task,

--- a/src/core/mapping/mapping.h
+++ b/src/core/mapping/mapping.h
@@ -152,14 +152,18 @@ struct StoreMapping {
   static StoreMapping default_mapping(const Store& store, StoreTarget target, bool exact = false);
 };
 
-struct MachineQueryInterface {
+class MachineQueryInterface {
+ public:
+  virtual ~MachineQueryInterface(){}
   virtual const std::vector<Processor>& cpus() const = 0;
   virtual const std::vector<Processor>& gpus() const = 0;
   virtual const std::vector<Processor>& omps() const = 0;
   virtual uint32_t total_nodes() const               = 0;
 };
 
-struct LegateMapper {
+class LegateMapper {
+ public:
+  virtual ~LegateMapper(){}
   virtual void set_machine(const MachineQueryInterface* machine)                            = 0;
   virtual TaskTarget task_target(const Task& task, const std::vector<TaskTarget>& options)  = 0;
   virtual std::vector<StoreMapping> store_mappings(const Task& task,


### PR DESCRIPTION
Several fixes.

Correctness:
1. Destructors of top-level class need to be marked virtual

Performance/Best practice
1. Add override to all virtual function implementations
2. Do not mark functions `virtual` that are not intended to have overrides in subclasses, e.g. `CoreMapper`

Style/consistency issues
1. Don't mix `struct` and `class` declarations in a class hierarchy. Subclasses/parent classes should be consistently called `struct` or `class`.  It's better to avoid using `struct` as a way to have methods default public. `struct` often suggests a simply C-style struct while `class` stylistically suggests a non-trivial container with methods. 