### PR TITLE
Fix ucx:tls_host default value

### DIFF
--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -370,7 +370,7 @@ def cmd_eager_alloc(
 def cmd_ucx(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
-    return ("-ucx:tls_host", "^dc,ud")
+    return ("-ucx:tls_host", "rc,tcp,cuda_copy,cuda_ipc,sm,self")
 
 
 def cmd_user_script(


### PR DESCRIPTION
"^dc,ud" will NOT work properly in UCX until 1.14.1 is released. So, for now we need to do it by listing all transports we except dc and ud.