### PR TITLE
Pin Legion to specific commit sha by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - Download and initialize RAPIDS CMake helpers -----------------------------
 
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.02/RAPIDS.cmake
        ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 endif()
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
@@ -72,7 +72,7 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
-set(legate_core_version 22.12.00)
+set(legate_core_version 23.03.00)
 
 # For now we want the optimization flags to match on both normal make and cmake
 # builds so we override the cmake defaults here for release, this changes

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright 2022 NVIDIA Corporation
+# Copyright 2022-2023 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,14 @@ function(find_or_configure_legion)
   include("${rapids-cmake-dir}/export/detail/parse_version.cmake")
   rapids_export_parse_version(${PKG_VERSION} Legion PKG_VERSION)
 
+  string(REGEX REPLACE "^0([0-9]+)?$" "\\1" Legion_major_version "${Legion_major_version}")
+  string(REGEX REPLACE "^0([0-9]+)?$" "\\1" Legion_minor_version "${Legion_minor_version}")
+  string(REGEX REPLACE "^0([0-9]+)?$" "\\1" Legion_patch_version "${Legion_patch_version}")
+
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(Legion version git_repo git_branch shallow exclude_from_all)
 
-  set(version ${PKG_VERSION})
+  set(version "${Legion_major_version}.${Legion_minor_version}.${Legion_patch_version}")
   set(exclude_from_all ${PKG_EXCLUDE_FROM_ALL})
   if(PKG_BRANCH)
     set(git_branch "${PKG_BRANCH}")
@@ -180,6 +184,14 @@ function(find_or_configure_legion)
                                  "Legion_REDOP_COMPLEX ON"
                                  "Legion_GPU_REDUCTIONS OFF"
                                  "Legion_BUILD_RUST_PROFILER ON"
+                                 "Legion_SPY ${Legion_SPY}"
+                                 "Legion_USE_LLVM ${Legion_USE_LLVM}"
+                                 "Legion_USE_HDF5 ${Legion_USE_HDF5}"
+                                 "Legion_USE_CUDA ${Legion_USE_CUDA}"
+                                 "Legion_NETWORKS ${Legion_NETWORKS}"
+                                 "Legion_USE_OpenMP ${Legion_USE_OpenMP}"
+                                 "Legion_USE_Python ${Legion_USE_Python}"
+                                 "Legion_BOUNDS_CHECKS ${Legion_BOUNDS_CHECKS}"
     )
   endif()
 
@@ -211,7 +223,7 @@ foreach(_var IN ITEMS "legate_core_LEGION_VERSION"
 endforeach()
 
 if(NOT DEFINED legate_core_LEGION_VERSION)
-  set(legate_core_LEGION_VERSION "${legate_core_VERSION_MAJOR}.${legate_core_VERSION_MINOR}.0")
+  set(legate_core_LEGION_VERSION "${legate_core_VERSION}")
 endif()
 
 find_or_configure_legion(VERSION          ${legate_core_LEGION_VERSION}

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -14,6 +14,8 @@
 # limitations under the License.
 #=============================================================================
 
+include_guard(GLOBAL)
+
 function(find_or_configure_legion)
   set(oneValueArgs VERSION REPOSITORY BRANCH EXCLUDE_FROM_ALL)
   cmake_parse_arguments(PKG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -175,9 +177,21 @@ function(find_or_configure_legion)
 
 endfunction()
 
+# This will be defined if provided via the command-line.
+# It will never be cached (see below)
 if(NOT DEFINED legate_core_LEGION_BRANCH)
-  set(legate_core_LEGION_BRANCH control_replication)
+  set(legate_core_LEGION_BRANCH 7b5835255fecf2edf300cb565e7bd3b0af8d03ad)
 endif()
+
+# Create a legate_core_LEGION_BRANCH variable in the current scope either from
+# the existing current-scope variable, or the cache variable.
+set(legate_core_LEGION_BRANCH "${legate_core_LEGION_BRANCH}")
+
+# Remove legate_core_LEGION_BRANCH from the CMakeCache.txt. This ensures
+# reconfiguring the same build dir without passing
+# `-Dlegate_core_LEGION_BRANCH=` reverts to the hash above instead of reusing
+# the previous `-Dlegate_core_LEGION_BRANCH=` value.
+unset(legate_core_LEGION_BRANCH CACHE)
 
 if(NOT DEFINED legate_core_LEGION_REPOSITORY)
   set(legate_core_LEGION_REPOSITORY https://gitlab.com/StanfordLegion/legion.git)

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -204,8 +204,8 @@ foreach(_var IN ITEMS "legate_core_LEGION_VERSION"
     # current-scope variable, or the cache variable.
     set(${_var} "${${_var}}")
     # Remove legate_core_LEGION_BRANCH from the CMakeCache.txt. This ensures reconfiguring the same
-    # build dir without passing `-Dlegate_core_LEGION_BRANCH=` reverts to the hash above instead of
-    # reusing the previous `-Dlegate_core_LEGION_BRANCH=` value.
+    # build dir without passing `-Dlegate_core_LEGION_BRANCH=` reverts to the value in versions.json
+    # instead of reusing the previous `-Dlegate_core_LEGION_BRANCH=` value.
     unset(${_var} CACHE)
   endif()
 endforeach()

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -197,6 +197,9 @@ if(NOT DEFINED legate_core_LEGION_REPOSITORY)
   set(legate_core_LEGION_REPOSITORY https://gitlab.com/StanfordLegion/legion.git)
 endif()
 
+set(legate_core_LEGION_REPOSITORY "${legate_core_LEGION_REPOSITORY}")
+unset(legate_core_LEGION_REPOSITORY CACHE)
+
 if(NOT DEFINED legate_core_LEGION_VERSION)
   set(legate_core_LEGION_VERSION "${legate_core_VERSION_MAJOR}.${legate_core_VERSION_MINOR}.0")
 endif()

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "e628d3674730d9c1807af45c272e5fccb56062d9"
+      "git_tag" : "e1f1ef61e29c3160419d0cd528950b2d565c2a0d"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -6,7 +6,6 @@
       "git_tag" : "1.17.0"
     },
     "Legion": {
-      "version": "{version}",
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
       "git_tag" : "e628d3674730d9c1807af45c272e5fccb56062d9"
     }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,9 +1,14 @@
 {
   "packages" : {
-      "Thrust" : {
-        "version" : "1.17.0.0",
-        "git_url" : "https://github.com/NVIDIA/thrust.git",
-        "git_tag" : "1.17.0"
+    "Thrust" : {
+      "version" : "1.17.0.0",
+      "git_url" : "https://github.com/NVIDIA/thrust.git",
+      "git_tag" : "1.17.0"
+    },
+    "Legion": {
+      "version": "{version}",
+      "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
+      "git_tag" : "e628d3674730d9c1807af45c272e5fccb56062d9"
     }
   }
 }

--- a/install.py
+++ b/install.py
@@ -738,7 +738,7 @@ def driver():
         "--legion-url",
         dest="legion_url",
         required=False,
-        default="https://gitlab.com/StanfordLegion/legion.git",
+        default=None,
         help="Legion git URL to build Legate with.",
     )
     parser.add_argument(

--- a/install.py
+++ b/install.py
@@ -451,7 +451,7 @@ def install(
     if conduit:
         cmake_flags += [f"-DGASNet_CONDUIT={conduit}"]
     if cuda_dir:
-        cmake_flags += [f"-DCUDA_TOOLKIT_ROOT_DIR={cuda_dir}"]
+        cmake_flags += [f"-DCUDAToolkit_ROOT={cuda_dir}"]
     if thrust_dir:
         cmake_flags += [f"-DThrust_ROOT={thrust_dir}"]
     if legion_dir:
@@ -745,7 +745,7 @@ def driver():
         "--legion-branch",
         dest="legion_branch",
         required=False,
-        default="control_replication",
+        default=None,
         help="Legion branch to build Legate with.",
     )
     args, unknown = parser.parse_known_args()


### PR DESCRIPTION
This PR pins the Legion repo URL and git revision that's built if Legion is not found via `find_package()`.

It explicitly ignores values stored in the `CMakeCache.txt`, so subsequent rebuilds that don't set the `--legion-{url,branch}` args revert to the defaults:

```bash
$ install.py --editable --legion-branch "feature_branch"

# Reverts to building the default pinned Legion sha, not "feature_branch"
$ install.py --editable
```