### PR TITLE
Fixes for running cuNumeric CI multi-node

### DIFF
--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -178,10 +178,9 @@ class RegionField:
                 mapper=context.mapper_id,
                 provenance=context.provenance,
             )
-            # If we're not sharing then there is no need to map or restrict the
-            # attachment
+            attach.set_restricted(False)
+            # If we're not sharing then there is no need to map the attachment
             if not share:
-                attach.set_restricted(False)
                 attach.set_mapped(False)
             else:
                 self.physical_region_mapped = True
@@ -231,9 +230,7 @@ class RegionField:
                 provenance=context.provenance,
             )
             index_attach.set_deduplicate_across_shards(True)
-            # If we're not sharing there is no need to restrict the attachment
-            if not share:
-                index_attach.set_restricted(False)
+            index_attach.set_restricted(False)
             external_resources = runtime.dispatch(index_attach)
             # We don't need to flush the contents back to the attached memory
             # if this is an internal temporary allocation.

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -150,7 +150,7 @@ struct RegistrationCallbackArgs {
   Core::RegistrationCallback callback;
 };
 
-static void invoke_legate_registration_callback(const Legion::RegistrationCallbackArgs& args)
+void invoke_legate_registration_callback(const Legion::RegistrationCallbackArgs& args)
 {
   auto p_args = static_cast<RegistrationCallbackArgs*>(args.buffer.get_ptr());
   p_args->callback();


### PR DESCRIPTION
Global callbacks cannot be labeled static, otherwise the symbol does not get external linkage, and multi-node global `perform_registration_callback` fails with:

```
   [1 - 7fbd53fff700]    1.634645 {4}{codetrans}: pointer 0x7fbd361bd7fb in middle of symbol '
   [1 - 7fbd53fff700]    1.634738 {6}{runtime}: [fatal 2014] LEGION FATAL: Global registration callback function pointer 0x7fbd361bd7fb is not portable. All registration callbacks requesting to be performed 'globally' must be able to be recognized by a call to 'dladdr'. This requires that they come from a shared object or the binary is linked with the '-rdynamic' flag. (from file /gpfs/fs1/mpapadakis/legion/runtime/legion/runtime.cc:17405)
```

Attaching to NumPy arrays was being done with restricted attachment, which causes errors like:

```
[1 - 7fdcecd9d700]    2.814690 {5}{runtime}: [error 604] LEGION ERROR: Attach operations in control replication context legion_python_main (UID 1) requested a restriction. Restrictions are only permitted for attach operations in non-control-replicated contexts currently. (from file /gpfs/fs1/mpapadakis/legion/runtime/legion/legion_context.cc:19038)
```

Thankfully, restricted attachment is unnecessary. The real reason why something like this works:

```
x = np.ones((3,))
y = cn.asarray(x)
y *= 2
print(x)  # prints [2, 2, 2]
``` 

is that passing the attached region to a task triggers an unmap, then a remap that will block until the task completes.