### PR TITLE
Add CTK stubs dir to implicit link directories

### DIFF
--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -412,6 +412,13 @@ endif()
 ]=]
 )
 
+if(DEFINED legate_core_cuda_stubs_path)
+  string(JOIN "\n" code_string "${code_string}"
+    "list(APPEND CMAKE_C_IMPLICIT_LINK_DIRECTORIES ${legate_core_cuda_stubs_path})"
+    "list(APPEND CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES ${legate_core_cuda_stubs_path})"
+    "list(APPEND CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES ${legate_core_cuda_stubs_path})")
+endif()
+
 rapids_export(
   INSTALL legate_core
   EXPORT_SET legate-core-exports


### PR DESCRIPTION
This PR adds the CTK stubs path to implicit link directories in legate's package config, so the stubs path doesn't end up in library consumers' RPATHs.