### PR TITLE
Fix a bug in the new registration callback API

### DIFF
--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -327,6 +327,7 @@ if (legate_core_BUILD_DOCS)
       src/core/data/allocator.h
       # runtime
       src/core/runtime/runtime.h
+      src/core/runtime/runtime.inl
       src/core/runtime/context.h
       # mapping
       src/core/mapping/mapping.h

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -144,28 +144,6 @@ static void extract_scalar_task(
   LEGATE_ABORT;
 }
 
-namespace detail {
-
-struct RegistrationCallbackArgs {
-  Core::RegistrationCallback callback;
-};
-
-void invoke_legate_registration_callback(const Legion::RegistrationCallbackArgs& args)
-{
-  auto p_args = static_cast<RegistrationCallbackArgs*>(args.buffer.get_ptr());
-  p_args->callback();
-};
-
-}  // namespace detail
-
-/*static*/ void Core::perform_registration(RegistrationCallback callback)
-{
-  legate::detail::RegistrationCallbackArgs args{callback};
-  Legion::UntypedBuffer buffer(&args, sizeof(args));
-  Legion::Runtime::perform_registration_callback(
-    detail::invoke_legate_registration_callback, buffer, true /*global*/);
-}
-
 void register_legate_core_tasks(Legion::Machine machine,
                                 Legion::Runtime* runtime,
                                 const LibraryContext& context)

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -52,9 +52,10 @@ struct Core {
    * @brief Performs a registration callback. Libraries must perform
    * registration of tasks and other components through this function.
    *
-   * @param callback Registration callback to perform
+   * @tparam CALLBACK Registration callback to perform
    */
-  static void perform_registration(RegistrationCallback callback);
+  template <RegistrationCallback CALLBACK>
+  static void perform_registration();
 
  public:
   // Configuration settings
@@ -66,3 +67,5 @@ struct Core {
 };
 
 }  // namespace legate
+
+#include "core/runtime/runtime.inl"

--- a/src/core/runtime/runtime.inl
+++ b/src/core/runtime/runtime.inl
@@ -1,0 +1,42 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "core/runtime/runtime.h"
+
+namespace legate {
+
+namespace detail {
+
+template <Core::RegistrationCallback CALLBACK>
+void invoke_legate_registration_callback(Legion::Machine,
+                                         Legion::Runtime*,
+                                         const std::set<Processor>&)
+{
+  CALLBACK();
+};
+
+}  // namespace detail
+
+template <Core::RegistrationCallback CALLBACK>
+/*static*/ void Core::perform_registration()
+{
+  Legion::Runtime::perform_registration_callback(
+    detail::invoke_legate_registration_callback<CALLBACK>, true /*global*/);
+}
+
+}  // namespace legate


### PR DESCRIPTION
The new registration code was using the same callback to perform all Legate registration callbacks, which accidentally got them deduplicated. This PR fixes the bug by using a function template that will map each Legate callback to a unique Legion callback.