### PR TITLE
Restrict gcc versions to match nvcc compatibility

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -52,6 +52,7 @@ class SectionConfig(Protocol):
 class CUDAConfig(SectionConfig):
     ctk_version: str
     compilers: bool
+    os: OSType
 
     header = "cuda"
 
@@ -68,7 +69,11 @@ class CUDAConfig(SectionConfig):
         )
 
         # gcc 11.3 is incompatible with nvcc <= 11.5.
-        if self.compilers and (V(self.ctk_version) <= V("11.5")):
+        if (
+            self.compilers
+            and self.os == "linux"
+            and (V(self.ctk_version) <= V("11.5"))
+        ):
             deps += (
                 "gcc_linux-64<=11.2",
                 "gxx_linux-64<=11.2",
@@ -207,7 +212,7 @@ class EnvConfig:
 
     @property
     def cuda(self) -> CUDAConfig:
-        return CUDAConfig(self.ctk, self.compilers)
+        return CUDAConfig(self.ctk, self.compilers, self.os)
 
     @property
     def build(self) -> BuildConfig:


### PR DESCRIPTION
This PR adds gcc/gxx constraints when compilers are requested and CTK <= 11.5

In the current form, the gcc/gxx constraints are added to the "cuda" block in the environment file:

```
  # cuda
  - cudatoolkit=11.5
  - cutensor>=1.3.3
  - nccl
  - pynvml
  - gcc_linux-64<=11.2
  - gxx_linux-64<=11.2
```

The comment headings are only informational, and the constraint is derived from the cuda config, so this seems OK. 