### PR TITLE
Make lgpatch UX consistent with driver

### DIFF
--- a/legate/lgpatch.py
+++ b/legate/lgpatch.py
@@ -15,8 +15,7 @@
 #
 import sys
 import textwrap
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from typing import Any
+from argparse import REMAINDER, ArgumentParser, RawDescriptionHelpFormatter
 
 KNOWN_PATCHES = {"numpy": "cunumeric"}
 
@@ -38,57 +37,66 @@ Any additional command line arguments are passed on to PROG as-is
 """
 
 
-def parse_args() -> Any:
-    parser = ArgumentParser(
-        prog="lgpatch",
-        description=DESCRIPTION,
-        allow_abbrev=False,
-        add_help=False,
-        epilog=EPILOG,
-        formatter_class=RawDescriptionHelpFormatter,
-    )
-    parser.add_argument(
-        "prog", metavar="PROG", help="The legate program to run"
-    )
-    parser.add_argument(
-        "-patch",
-        action="store",
-        nargs="+",
-        help="Patch the specified libraries",
-        default=[],
-    )
+parser = ArgumentParser(
+    prog="lgpatch",
+    description=DESCRIPTION,
+    allow_abbrev=False,
+    add_help=True,
+    epilog=EPILOG,
+    formatter_class=RawDescriptionHelpFormatter,
+)
+parser.add_argument(
+    "prog",
+    metavar="PROG",
+    nargs=REMAINDER,
+    help="The legate program (with any arguments) to run",
+)
+parser.add_argument(
+    "-p",
+    "--patch",
+    action="append",
+    help="Patch the specified libraries. (May be supplied multiple times)",
+    default=[],
+)
+parser.add_argument(
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="print out more verbose information about patching",
+    default=False,
+)
 
-    # legate parser intercepts "-h" and "--help" earlier
-    if "-patch:help" in sys.argv:
-        parser.print_help()
-        sys.exit()
 
-    return parser.parse_known_args()
-
-
-def do_patch(name: str) -> None:
+def do_patch(name: str, verbose: bool = False) -> None:
     if name not in KNOWN_PATCHES:
         raise ValueError(f"No patch available for module {name}")
-    if name in sys.modules:
-        raise RuntimeError(f"Cannot patch {name} -- it is already loaded")
 
     cuname = KNOWN_PATCHES[name]
     try:
         module = __import__(cuname)
         sys.modules[name] = module
+        if verbose:
+            print(f"lgpatch: patched {name} -> {cuname}")
     except ImportError:
         raise RuntimeError(f"Could not import patch module {cuname}")
 
 
 def main() -> None:
-    args, extra = parse_args()
+    args = parser.parse_args()
 
-    for name in args.patch:
-        do_patch(name)
+    if len(args.prog) == 0:
+        parser.print_usage()
+        sys.exit()
 
-    sys.argv[:] = [args.prog] + extra
+    if len(args.patch) == 0:
+        print("WARNING: lgpatch called without any --patch options")
 
-    with open(args.prog) as f:
+    for name in set(args.patch):
+        do_patch(name, args.verbose)
+
+    sys.argv[:] = args.prog
+
+    with open(args.prog[0]) as f:
         exec(f.read(), {"__name__": "__main__"})
 
 


### PR DESCRIPTION
fixes #614

This PR improves the `lgpatch` console UX to make it more consistent with the current `legate` driver. Specifically, all `lgpatch` args should come before the program to execute and any of its argument. 

```python
# foo.py
import sys
import numpy as np

print(np.arange(10))
print(sys.argv)
```

Yields

```
docs310 ❯ lgpatch --help
usage: lgpatch [-h] [-p PATCH] [-v] ...

Patch existing libraries with legate equivalents.

Currently the following patching can be applied:

    numpy -> cunumeric

positional arguments:
  PROG                  The legate program (with any arguments) to run

options:
  -h, --help            show this help message and exit
  -p PATCH, --patch PATCH
                        Patch the specified libraries. (May be supplied multiple times)
  -v, --verbose         print out more verbose information about patching

Any additional command line arguments are passed on to PROG as-is

docs310 ❯ CUNUMERIC_REPORT_COVERAGE=1 lgpatch -v -p numpy foo.py 

lgpatch: patched numpy -> cunumeric
[0 1 2 3 4 5 6 7 8 9]
['/home/bryan/tmp/foo.py', '--bar', '10']
cuNumeric API coverage: 4/4 (100.0%)
```

@manopapad once you give :+1: I will also update the user's guide docs to match. 