### PR TITLE
More robust nsys --sample flag with --nsys-extra

### DIFF
--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -127,7 +127,15 @@ def cmd_nsys(
 
     opts: CommandPart = ("nsys", "profile", "-t", targets, "-o", log_path)
     opts += tuple(extra)
-    if "-s" not in extra:
+
+    has_sample_flag = False
+    for option in extra:
+        flag = option.split("=")[0]
+        if flag == "-s" or flag == "--sample":
+            has_sample_flag = True
+            break
+
+    if not has_sample_flag:
         opts += ("-s", "none")
 
     return opts

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -14,6 +14,7 @@
 #
 from __future__ import annotations
 
+import argparse
 from typing import TYPE_CHECKING
 
 from .. import install_info
@@ -125,17 +126,20 @@ def cmd_nsys(
     targets = config.profiling.nsys_targets
     extra = config.profiling.nsys_extra
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--sample")
+    parser.add_argument("-t", "--targets")
+    nsys_parsed_args, unparsed = parser.parse_known_args(extra)
+
+    if nsys_parsed_args.targets:
+        raise RuntimeError(
+            "please pass targets as arguments to --nsys"
+            "rather than using --nsys-extra"
+        )
+
     opts: CommandPart = ("nsys", "profile", "-t", targets, "-o", log_path)
     opts += tuple(extra)
-
-    has_sample_flag = False
-    for option in extra:
-        flag = option.split("=")[0]
-        if flag == "-s" or flag == "--sample":
-            has_sample_flag = True
-            break
-
-    if not has_sample_flag:
+    if not nsys_parsed_args.sample:
         opts += ("-s", "none")
 
     return opts

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -362,8 +362,6 @@ class Test_cmd_nsys:
             "none",
         )
 
-    # spaces are necessary before arguments to work around
-    # argparse inability to consume arguments with -- correctly
     @pytest.mark.parametrize(
         "nsys_extra",
         (

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -362,15 +362,15 @@ class Test_cmd_nsys:
             "none",
         )
 
-    # spaces are necessary before the arguments to work around
+    # spaces are necessary before arguments to work around
     # argparse inability to consume arguments with -- correctly
     @pytest.mark.parametrize(
         "nsys_extra",
         (
             " --sample=cpu",
-            " --backtrace=lbr -s cpu",
-            " --sample cpu",
-            " -s=cpu",
+            "--backtrace=lbr -s cpu",
+            "--sample cpu",
+            "-s cpu",
         ),
     )
     def test_explicit_sample(self, genobjs: GenObjs, nsys_extra: str) -> None:

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -367,14 +367,17 @@ class Test_cmd_nsys:
     @pytest.mark.parametrize(
         "nsys_extra",
         (
-            " --sample=cpu",
-            "--backtrace=lbr -s cpu",
-            "--sample cpu",
-            "-s cpu",
+            ["--nsys-extra=--sample=cpu"],
+            ["--nsys-extra", "--backtrace=lbr -s cpu"],
+            ["--nsys-extra", "--sample cpu"],
+            ["--nsys-extra", "-s cpu"],
+            ["--nsys-extra=--sample", "--nsys-extra", "cpu"],
         ),
     )
-    def test_explicit_sample(self, genobjs: GenObjs, nsys_extra: str) -> None:
-        args = ["--nsys", "--nsys-extra", nsys_extra]
+    def test_explicit_sample(
+        self, genobjs: GenObjs, nsys_extra: list[str]
+    ) -> None:
+        args = ["--nsys"] + nsys_extra
         config, system, launcher = genobjs(args)
         result = m.cmd_nsys(config, system, launcher)
 


### PR DESCRIPTION
The current nsys flag only checks for `-s` to deduplicate. The user might pass any of the following:

1. --sample <>
1. --sample=<>
1. -s <>
1. -s=<>

The user will get a cryptic error about --sample being passed twice unless they use `-s <>`