### PR TITLE
remove generic create_task

### DIFF
--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -370,8 +370,8 @@ class Context:
     def create_manual_task(
         self,
         task_id: int,
+        launch_domain: Rect,
         mapper_id: int = 0,
-        launch_domain: Optional[Rect] = None,
     ) -> ManualTask:
         """
         Creates a manual task.

--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -23,7 +23,6 @@ from typing import (
     Protocol,
     TypeVar,
     Union,
-    cast,
 )
 
 import numpy as np
@@ -368,16 +367,14 @@ class Context:
 
         return wrapper
 
-    def create_task(
+    def create_manual_task(
         self,
         task_id: int,
         mapper_id: int = 0,
-        manual: bool = False,
         launch_domain: Optional[Rect] = None,
-    ) -> Union[AutoTask, ManualTask]:
+    ) -> ManualTask:
         """
-        Creates a task. The type of the returned task is determined by the
-        value of ``manual``.
+        Creates a manual task.
 
         Parameters
         ----------
@@ -390,10 +387,6 @@ class Context:
             Id of the mapper that should determine mapping policies for the
             task. Used only when the library has more than one mapper.
 
-        manual : bool
-            Indicates whether the task should be manually parallelized;
-            if ``True``, the task is parallelized manually by the caller.
-
         launch_domain : Rect, optional
             Launch domain of the task. Ignored if the task is automatically
             parallelized, mandatory otherwise.
@@ -403,65 +396,20 @@ class Context:
         AutoTask or ManualTask
             A new task
         """
-        from .operation import AutoTask, ManualTask
 
-        unique_op_id = self.get_unique_op_id()
-        if not manual:
-            return AutoTask(self, task_id, mapper_id, unique_op_id)
-        else:
-            if launch_domain is None:
-                raise RuntimeError(
-                    "Launch domain must be specified for "
-                    "manual parallelization"
-                )
-            return ManualTask(
-                self,
-                task_id,
-                launch_domain,
-                mapper_id,
-                unique_op_id,
-            )
-
-    def create_manual_task(
-        self,
-        task_id: int,
-        mapper_id: int = 0,
-        launch_domain: Optional[Rect] = None,
-    ) -> ManualTask:
-        """
-        Type safe version of ``Context.create_task``. Always returns a
-        `ManualTask`.
-
-        Parameters
-        ----------
-        task_id : int
-            Task id
-
-        mapper_id : int, optional
-            Mapper id
-
-        launch_domain : Rect, optional
-            Launch domain of the task.
-
-        Returns
-        -------
-        AutoTask
-            A new auto-parallelized task
-
-        See Also
-        --------
-        Context.create_task
-        """
         from .operation import ManualTask
 
-        return cast(
-            ManualTask,
-            self.create_task(
-                task_id=task_id,
-                mapper_id=mapper_id,
-                manual=True,
-                launch_domain=launch_domain,
-            ),
+        unique_op_id = self.get_unique_op_id()
+        if launch_domain is None:
+            raise RuntimeError(
+                "Launch domain must be specified for manual parallelization"
+            )
+        return ManualTask(
+            self,
+            task_id,
+            launch_domain,
+            mapper_id,
+            unique_op_id,
         )
 
     def create_auto_task(
@@ -470,24 +418,23 @@ class Context:
         mapper_id: int = 0,
     ) -> AutoTask:
         """
-        Type safe version of ``Context.create_task``. Always returns an
-        `AutoTask`.
+        Creates an auto task.
 
         Parameters
         ----------
         task_id : int
-            Task id
+            Task id. Scoped locally within the context; i.e., different
+            libraries can use the same task id. There must be a task
+            implementation corresponding to the task id.
 
         mapper_id : int, optional
-            Mapper id
-
-        launch_domain : Rect, optional
-            Launch domain of the task.
+            Id of the mapper that should determine mapping policies for the
+            task. Used only when the library has more than one mapper.
 
         Returns
         -------
         AutoTask
-            A new manually parallelized task
+            A new automatically parallelized task
 
         See Also
         --------
@@ -496,14 +443,8 @@ class Context:
 
         from .operation import AutoTask
 
-        return cast(
-            AutoTask,
-            self.create_task(
-                task_id=task_id,
-                mapper_id=mapper_id,
-                manual=False,
-            ),
-        )
+        unique_op_id = self.get_unique_op_id()
+        return AutoTask(self, task_id, mapper_id, unique_op_id)
 
     def create_copy(self, mapper_id: int = 0) -> Copy:
         """

--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -388,8 +388,7 @@ class Context:
             task. Used only when the library has more than one mapper.
 
         launch_domain : Rect, optional
-            Launch domain of the task. Ignored if the task is automatically
-            parallelized, mandatory otherwise.
+            Launch domain of the task.
 
         Returns
         -------


### PR DESCRIPTION
Follow up to https://github.com/nv-legate/cunumeric/pull/842 this PR removes the generic `create_task` API and leaves only explicit `create_auto_task` and `create_manual_task`