### PR TITLE
Update Legion SHA (bug fix in Legion)

### DIFF
--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "e1f1ef61e29c3160419d0cd528950b2d565c2a0d"
+      "git_tag" : "b66b612ecd33f28d755e28bf8ae82b6589464d4a"
     }
   }
 }


### PR DESCRIPTION
The release version of Legion needs to be updated to fix issues discovered by QA.