### PR TITLE
Docs updates

### DIFF
--- a/docs/legate/core/source/api/runtime.rst
+++ b/docs/legate/core/source/api/runtime.rst
@@ -50,7 +50,6 @@ runtime, the runtime gives back a context object unique to the library.
    :toctree: generated/
 
    context.Context.create_store
-   context.Context.create_task
    context.Context.create_manual_task
    context.Context.create_auto_task
    context.Context.create_copy

--- a/docs/legate/core/source/conf.py
+++ b/docs/legate/core/source/conf.py
@@ -22,15 +22,12 @@
 # -- Project information -----------------------------------------------------
 
 project = "legate.core"
-copyright = "2021-2022, NVIDIA"
+copyright = "2021-2023, NVIDIA"
 author = "NVIDIA"
 
 
 # -- General configuration ---------------------------------------------------
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -43,36 +40,29 @@ extensions = [
 
 suppress_warnings = ["ref.myst"]
 
-# The master toctree document.
-master_doc = "index"
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
-
 source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = "pydata_sphinx_theme"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-pygments_style = "sphinx"
+html_theme = "pydata_sphinx_theme"
 
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
+html_theme_options = {
+    "footer_start": ["copyright"],
+    "github_url": "https://github.com/nv-legate/legate.core",
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
+    "logo": {
+        "text": project,
+        "link": "https://nv-legate.github.io/legate.core/",
+    },
+    "navbar_align": "left",
+    "navbar_end": ["navbar-icon-links", "theme-switcher"],
+    "primary_sidebar_end": ["indices.html"],
+    "secondary_sidebar_items": ["page-toc"],
+    "show_nav_level": 2,
+    "show_toc_level": 2,
 }
 
 # -- Options for extensions --------------------------------------------------
@@ -81,7 +71,14 @@ autosummary_generate = True
 
 copybutton_prompt_text = ">>> "
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+}
+
 mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+
+pygments_style = "sphinx"
 
 
 def setup(app):

--- a/docs/legate/core/source/index.rst
+++ b/docs/legate/core/source/index.rst
@@ -1,19 +1,34 @@
+:html_theme.sidebar_secondary.remove:
+
 Welcome to Legate Core's documentation!
 =======================================
 
+The Legate project endeavors to democratize computing by making it possible
+for all programmers to leverage the power of large clusters of CPUs and GPUs
+by running the same code that runs on a desktop or a laptop at scale. Using
+this technology, computational and data scientists can develop and test
+programs on moderately sized data sets on local machines and then immediately
+scale up to larger data sets deployed on many nodes in the cloud or on a
+supercomputer without any code modifications.
+
 .. toctree::
-  :maxdepth: 1
+  :maxdepth: 2
+  :caption: Contents:
 
   Overview <README.md>
   Build instructions <BUILD.md>
   Python API Reference <api/index.rst>
   C++ API Reference <https://nv-legate.github.io/legate.core/cpp-interface>
   Contributing <CONTRIBUTING.md>
+
+.. toctree::
+  :maxdepth: 1
+
   Versions <versions.rst>
 
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`search`

--- a/docs/legate/core/source/versions.rst
+++ b/docs/legate/core/source/versions.rst
@@ -9,8 +9,8 @@ Summary of the versioning and release methodology used by Legate projects.
 Versioning method
 -----------------
 
-All Legate projects use the [CalVer](https://calver.org/) versioning method for
-all releases starting with June 2021 release.
+All Legate projects use the `CalVer`_ versioning method for all releases
+starting with June 2021 release.
 
 The Legate team is aware of the impacts that public API changes cause to users,
 so API & ABI compatibility is guaranteed within each `YY.MM` version.
@@ -34,3 +34,5 @@ There is no limit or time constraint of these releases as they are governed by
 the need to fix critical issues in the current release. Generally, hotfix/patch
 releases contain only one change and are typically bug fixes; new features
 should not be introduced in this way.
+
+.. _CalVer: https://calver.org/


### PR DESCRIPTION
This PR makes some small fixes:

* manual `create_task` API needed removing (causing docs build failure)
* terminal copyright date was not correct
* rst file had unusable markdown-style link

Additionally the `conf.py` andindex was cleaned up and made to more closely match the changes that were already made to cunumeric. 

The front page now looks like this:

![image](https://user-images.githubusercontent.com/1078448/225390127-c21f8097-668f-42f1-923e-29fff5ce763d.png)

I do think the "Overview" would be improved if, instead of re-using the README.md, a dedicated `index.rst` was added. cc @magnatelee @manopapad 
