### PR TITLE
Use subsumption checks for instance policies

### DIFF
--- a/src/core/mapping/instance_manager.cc
+++ b/src/core/mapping/instance_manager.cc
@@ -82,9 +82,7 @@ bool InstanceSet::find_instance(Region region,
   assert(ifinder != instances_.end());
 
   auto& spec = ifinder->second;
-  // TODO: policies don't need to be exactly the same but the policy of the existing instance
-  // only needs to subsume the requested policy
-  if (spec.policy == policy) {
+  if (spec.policy.subsumes(policy)) {
     result = spec.instance;
     return true;
   } else

--- a/src/core/mapping/mapping.cc
+++ b/src/core/mapping/mapping.cc
@@ -87,6 +87,13 @@ bool InstanceMappingPolicy::operator!=(const InstanceMappingPolicy& other) const
   return !operator==(other);
 }
 
+bool InstanceMappingPolicy::subsumes(const InstanceMappingPolicy& other) const
+{
+  // the allocation policy doesn't concern the instance layout
+  return target == other.target && layout == other.layout && ordering == other.ordering &&
+         (exact || !other.exact);
+}
+
 void InstanceMappingPolicy::populate_layout_constraints(
   const Store& store, Legion::LayoutConstraintSet& layout_constraints) const
 {

--- a/src/core/mapping/mapping.h
+++ b/src/core/mapping/mapping.h
@@ -226,6 +226,19 @@ struct InstanceMappingPolicy {
   bool operator==(const InstanceMappingPolicy&) const;
   bool operator!=(const InstanceMappingPolicy&) const;
 
+ public:
+  /**
+   * @brief Indicates whether this policy subsumes a given policy
+   *
+   * Policy `A` subsumes policy `B`, if every instance created under `B` satisfies `A` as well.
+   *
+   * @param other Policy to check the subsumption against
+   *
+   * @return true If this policy subsumes `other`
+   * @return false Otherwise
+   */
+  bool subsumes(const InstanceMappingPolicy& other) const;
+
  private:
   friend class StoreMapping;
   void populate_layout_constraints(const Store& store,


### PR DESCRIPTION
The instance manager was checking equality between policies when deciding whether a given instance can be reused. That's overly strict in certain cases and was causing thrashing on the instance cache. This PR replaces the equality check with a subsumption check.