### PR TITLE
Rename variables and functions to make them clearer

### DIFF
--- a/src/core/data/store.cc
+++ b/src/core/data/store.cc
@@ -65,7 +65,7 @@ bool RegionField::valid() const
 
 Domain RegionField::domain() const { return dim_dispatch(dim_, get_domain_fn{}, pr_); }
 
-OutputRegionField::OutputRegionField(const Legion::OutputRegion& out, Legion::FieldID fid)
+UnboundRegionField::UnboundRegionField(const Legion::OutputRegion& out, Legion::FieldID fid)
   : out_(out),
     fid_(fid),
     num_elements_(
@@ -73,7 +73,7 @@ OutputRegionField::OutputRegionField(const Legion::OutputRegion& out, Legion::Fi
 {
 }
 
-OutputRegionField::OutputRegionField(OutputRegionField&& other) noexcept
+UnboundRegionField::UnboundRegionField(UnboundRegionField&& other) noexcept
   : bound_(other.bound_), out_(other.out_), fid_(other.fid_), num_elements_(other.num_elements_)
 {
   other.bound_        = false;
@@ -82,7 +82,7 @@ OutputRegionField::OutputRegionField(OutputRegionField&& other) noexcept
   other.num_elements_ = Legion::UntypedDeferredValue();
 }
 
-OutputRegionField& OutputRegionField::operator=(OutputRegionField&& other) noexcept
+UnboundRegionField& UnboundRegionField::operator=(UnboundRegionField&& other) noexcept
 {
   bound_        = other.bound_;
   out_          = other.out_;
@@ -97,7 +97,7 @@ OutputRegionField& OutputRegionField::operator=(OutputRegionField&& other) noexc
   return *this;
 }
 
-void OutputRegionField::make_empty(int32_t ndim)
+void UnboundRegionField::bind_empty_data(int32_t ndim)
 {
   update_num_elements(0);
   DomainPoint extents;
@@ -108,7 +108,7 @@ void OutputRegionField::make_empty(int32_t ndim)
   bound_ = true;
 }
 
-ReturnValue OutputRegionField::pack_weight() const
+ReturnValue UnboundRegionField::pack_weight() const
 {
 #ifdef DEBUG_LEGATE
   if (!bound_) {
@@ -121,7 +121,7 @@ ReturnValue OutputRegionField::pack_weight() const
   return ReturnValue(num_elements_, sizeof(size_t));
 }
 
-void OutputRegionField::update_num_elements(size_t num_elements)
+void UnboundRegionField::update_num_elements(size_t num_elements)
 {
   AccessorWO<size_t, 1> acc(num_elements_, sizeof(size_t), false);
   acc[0] = num_elements;
@@ -214,7 +214,7 @@ Store::Store(int32_t dim,
              FutureWrapper future,
              std::shared_ptr<TransformStack>&& transform)
   : is_future_(true),
-    is_output_store_(false),
+    is_unbound_store_(false),
     dim_(dim),
     code_(code),
     redop_id_(redop_id),
@@ -230,7 +230,7 @@ Store::Store(int32_t dim,
              RegionField&& region_field,
              std::shared_ptr<TransformStack>&& transform)
   : is_future_(false),
-    is_output_store_(false),
+    is_unbound_store_(false),
     dim_(dim),
     code_(code),
     redop_id_(redop_id),
@@ -244,27 +244,27 @@ Store::Store(int32_t dim,
 
 Store::Store(int32_t dim,
              int32_t code,
-             OutputRegionField&& output,
+             UnboundRegionField&& unbound_field,
              std::shared_ptr<TransformStack>&& transform)
   : is_future_(false),
-    is_output_store_(true),
+    is_unbound_store_(true),
     dim_(dim),
     code_(code),
     redop_id_(-1),
-    output_field_(std::forward<OutputRegionField>(output)),
+    unbound_field_(std::forward<UnboundRegionField>(unbound_field)),
     transform_(std::forward<decltype(transform)>(transform))
 {
 }
 
 Store::Store(Store&& other) noexcept
   : is_future_(other.is_future_),
-    is_output_store_(other.is_output_store_),
+    is_unbound_store_(other.is_unbound_store_),
     dim_(other.dim_),
     code_(other.code_),
     redop_id_(other.redop_id_),
     future_(other.future_),
     region_field_(std::forward<RegionField>(other.region_field_)),
-    output_field_(std::forward<OutputRegionField>(other.output_field_)),
+    unbound_field_(std::forward<UnboundRegionField>(other.unbound_field_)),
     transform_(std::move(other.transform_)),
     readable_(other.readable_),
     writable_(other.writable_),
@@ -274,15 +274,15 @@ Store::Store(Store&& other) noexcept
 
 Store& Store::operator=(Store&& other) noexcept
 {
-  is_future_       = other.is_future_;
-  is_output_store_ = other.is_output_store_;
-  dim_             = other.dim_;
-  code_            = other.code_;
-  redop_id_        = other.redop_id_;
+  is_future_        = other.is_future_;
+  is_unbound_store_ = other.is_unbound_store_;
+  dim_              = other.dim_;
+  code_             = other.code_;
+  redop_id_         = other.redop_id_;
   if (is_future_)
     future_ = other.future_;
-  else if (is_output_store_)
-    output_field_ = std::move(other.output_field_);
+  else if (is_unbound_store_)
+    unbound_field_ = std::move(other.unbound_field_);
   else
     region_field_ = std::move(other.region_field_);
   transform_ = std::move(other.transform_);
@@ -292,12 +292,12 @@ Store& Store::operator=(Store&& other) noexcept
   return *this;
 }
 
-bool Store::valid() const { return is_future_ || is_output_store_ || region_field_.valid(); }
+bool Store::valid() const { return is_future_ || is_unbound_store_ || region_field_.valid(); }
 
 Domain Store::domain() const
 {
 #ifdef DEBUG_LEGATE
-  assert(!is_output_store_);
+  assert(!is_unbound_store_);
 #endif
   auto result = is_future_ ? future_.domain() : region_field_.domain();
   if (!transform_->identity()) result = transform_->transform(result);
@@ -307,12 +307,12 @@ Domain Store::domain() const
   return result;
 }
 
-void Store::make_empty()
+void Store::bind_empty_data()
 {
 #ifdef DEBUG_LEGATE
   check_valid_return();
 #endif
-  output_field_.make_empty(dim_);
+  unbound_field_.bind_empty_data(dim_);
 }
 
 void Store::remove_transform()
@@ -325,11 +325,11 @@ void Store::remove_transform()
 
 void Store::check_valid_return() const
 {
-  if (!is_output_store_) {
+  if (!is_unbound_store_) {
     log_legate.error("Invalid to return a buffer to a bound store");
     LEGATE_ABORT;
   }
-  if (output_field_.bound()) {
+  if (unbound_field_.bound()) {
     log_legate.error("Invalid to return more than one buffer to an unbound store");
     LEGATE_ABORT;
   }

--- a/src/core/data/store.h
+++ b/src/core/data/store.h
@@ -166,30 +166,30 @@ class RegionField {
   bool reducible_{false};
 };
 
-class OutputRegionField {
+class UnboundRegionField {
  public:
-  OutputRegionField() {}
-  OutputRegionField(const Legion::OutputRegion& out, Legion::FieldID fid);
+  UnboundRegionField() {}
+  UnboundRegionField(const Legion::OutputRegion& out, Legion::FieldID fid);
 
  public:
-  OutputRegionField(OutputRegionField&& other) noexcept;
-  OutputRegionField& operator=(OutputRegionField&& other) noexcept;
+  UnboundRegionField(UnboundRegionField&& other) noexcept;
+  UnboundRegionField& operator=(UnboundRegionField&& other) noexcept;
 
  private:
-  OutputRegionField(const OutputRegionField& other)            = delete;
-  OutputRegionField& operator=(const OutputRegionField& other) = delete;
+  UnboundRegionField(const UnboundRegionField& other)            = delete;
+  UnboundRegionField& operator=(const UnboundRegionField& other) = delete;
 
  public:
   bool bound() const { return bound_; }
 
  public:
   template <typename T, int32_t DIM>
-  Buffer<T, DIM> create_output_buffer(const Point<DIM>& extents, bool return_buffer);
+  Buffer<T, DIM> create_output_buffer(const Point<DIM>& extents, bool bind_buffer);
 
  public:
   template <typename T, int32_t DIM>
-  void return_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents);
-  void make_empty(int32_t dim);
+  void bind_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents);
+  void bind_empty_data(int32_t dim);
 
  public:
   ReturnValue pack_weight() const;
@@ -282,7 +282,7 @@ class Store {
         std::shared_ptr<TransformStack>&& transform = nullptr);
   Store(int32_t dim,
         int32_t code,
-        OutputRegionField&& output,
+        UnboundRegionField&& unbound_field,
         std::shared_ptr<TransformStack>&& transform = nullptr);
 
  public:
@@ -420,17 +420,17 @@ class Store {
   /**
    * @brief Creates a buffer of specified extents for the unbound store. The returned
    * buffer is always consistent with the mapping policy for the store. Can be invoked
-   * multiple times unless `return_buffer` is true.
+   * multiple times unless `bind_buffer` is true.
    *
    * @param extents Extents of the buffer
    *
-   * @param return_buffer If the value is true, the created buffer will be bound
+   * @param bind_buffer If the value is true, the created buffer will be bound
    * to the store upon return
    *
    * @return A reduction accessor to the store
    */
   template <typename T, int32_t DIM>
-  Buffer<T, DIM> create_output_buffer(const Point<DIM>& extents, bool return_buffer = false);
+  Buffer<T, DIM> create_output_buffer(const Point<DIM>& extents, bool bind_buffer = false);
 
  public:
   /**
@@ -499,12 +499,12 @@ class Store {
    *
    */
   template <typename T, int32_t DIM>
-  void return_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents);
+  void bind_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents);
   /**
    * @brief Makes the unbound store empty. Valid only when the store is unbound and
    * has not yet been bound to another buffer.
    */
-  void make_empty();
+  void bind_empty_data();
 
  public:
   /**
@@ -523,9 +523,9 @@ class Store {
    * @return true The store is an unbound store
    * @return false The store is a normal store
    */
-  bool is_output_store() const { return is_output_store_; }
+  bool is_unbound_store() const { return is_unbound_store_; }
   ReturnValue pack() const { return future_.pack(); }
-  ReturnValue pack_weight() const { return output_field_.pack_weight(); }
+  ReturnValue pack_weight() const { return unbound_field_.pack_weight(); }
 
  public:
   // TODO: It'd be btter to return a parent store from this method than permanently
@@ -540,7 +540,7 @@ class Store {
 
  private:
   bool is_future_{false};
-  bool is_output_store_{false};
+  bool is_unbound_store_{false};
   int32_t dim_{-1};
   int32_t code_{-1};
   int32_t redop_id_{-1};
@@ -548,7 +548,7 @@ class Store {
  private:
   FutureWrapper future_;
   RegionField region_field_;
-  OutputRegionField output_field_;
+  UnboundRegionField unbound_field_;
 
  private:
   std::shared_ptr<TransformStack> transform_{nullptr};

--- a/src/core/data/store.inl
+++ b/src/core/data/store.inl
@@ -244,10 +244,9 @@ VAL FutureWrapper::scalar() const
 }
 
 template <typename T, int32_t DIM>
-Buffer<T, DIM> OutputRegionField::create_output_buffer(const Point<DIM>& extents,
-                                                       bool return_buffer)
+Buffer<T, DIM> UnboundRegionField::create_output_buffer(const Point<DIM>& extents, bool bind_buffer)
 {
-  if (return_buffer) {
+  if (bind_buffer) {
 #ifdef DEBUG_LEGATE
     assert(!bound_);
 #endif
@@ -255,11 +254,11 @@ Buffer<T, DIM> OutputRegionField::create_output_buffer(const Point<DIM>& extents
     update_num_elements(extents[0]);
     bound_ = true;
   }
-  return out_.create_buffer<T, DIM>(extents, fid_, nullptr, return_buffer);
+  return out_.create_buffer<T, DIM>(extents, fid_, nullptr, bind_buffer);
 }
 
 template <typename T, int32_t DIM>
-void OutputRegionField::return_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents)
+void UnboundRegionField::bind_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents)
 {
 #ifdef DEBUG_LEGATE
   assert(!bound_);
@@ -399,14 +398,13 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Rect<DIM>& bounds) c
 }
 
 template <typename T, int32_t DIM>
-Buffer<T, DIM> Store::create_output_buffer(const Point<DIM>& extents,
-                                           bool return_buffer /*= false*/)
+Buffer<T, DIM> Store::create_output_buffer(const Point<DIM>& extents, bool bind_buffer /*= false*/)
 {
 #ifdef DEBUG_LEGATE
   check_valid_return();
   check_buffer_dimension(DIM);
 #endif
-  return output_field_.create_output_buffer<T, DIM>(extents, return_buffer);
+  return unbound_field_.create_output_buffer<T, DIM>(extents, bind_buffer);
 }
 
 template <int32_t DIM>
@@ -439,13 +437,13 @@ VAL Store::scalar() const
 }
 
 template <typename T, int32_t DIM>
-void Store::return_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents)
+void Store::bind_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents)
 {
 #ifdef DEBUG_LEGATE
   check_valid_return();
   check_buffer_dimension(DIM);
 #endif
-  output_field_.return_data(buffer, extents);
+  unbound_field_.bind_data(buffer, extents);
 }
 
 }  // namespace legate

--- a/src/core/mapping/mapping.cc
+++ b/src/core/mapping/mapping.cc
@@ -23,6 +23,20 @@
 namespace legate {
 namespace mapping {
 
+DimOrdering::DimOrdering(Kind _kind, std::vector<int32_t>&& _dims)
+  : kind(_kind), dims(std::forward<decltype(dims)>(_dims))
+{
+}
+
+/*static*/ DimOrdering DimOrdering::c_order() { return DimOrdering(Kind::C); }
+
+/*static*/ DimOrdering DimOrdering::fortran_order() { return DimOrdering(Kind::FORTRAN); }
+
+/*static*/ DimOrdering DimOrdering::custom_order(std::vector<int32_t>&& dims)
+{
+  return DimOrdering(Kind::CUSTOM, std::forward<decltype(dims)>(dims));
+}
+
 Memory::Kind get_memory_kind(StoreTarget target)
 {
   switch (target) {
@@ -66,11 +80,11 @@ void DimOrdering::populate_dimension_ordering(const Store& store,
   }
 }
 
-void DimOrdering::c_order() { kind = Kind::C; }
+void DimOrdering::set_c_order() { kind = Kind::C; }
 
-void DimOrdering::fortran_order() { kind = Kind::FORTRAN; }
+void DimOrdering::set_fortran_order() { kind = Kind::FORTRAN; }
 
-void DimOrdering::custom_order(std::vector<int32_t>&& dims)
+void DimOrdering::set_custom_order(std::vector<int32_t>&& dims)
 {
   kind = Kind::CUSTOM;
   dims = std::forward<std::vector<int32_t>&&>(dims);

--- a/src/core/mapping/mapping.h
+++ b/src/core/mapping/mapping.h
@@ -131,6 +131,29 @@ struct DimOrdering {
 
  public:
   DimOrdering() {}
+  DimOrdering(Kind kind, std::vector<int32_t>&& dims = {});
+
+ public:
+  /**
+   * @brief Creates a C ordering object
+   *
+   * @return A `DimOrdering` object
+   */
+  static DimOrdering c_order();
+  /**
+   * @brief Creates a Fortran ordering object
+   *
+   * @return A `DimOrdering` object
+   */
+  static DimOrdering fortran_order();
+  /**
+   * @brief Creates a custom ordering object
+   *
+   * @param dims A vector that stores the order of dimensions.
+   *
+   * @return A `DimOrdering` object
+   */
+  static DimOrdering custom_order(std::vector<int32_t>&& dims);
 
  public:
   DimOrdering(const DimOrdering&)            = default;
@@ -151,17 +174,17 @@ struct DimOrdering {
   /**
    * @brief Sets the dimension ordering to C
    */
-  void c_order();
+  void set_c_order();
   /**
    * @brief Sets the dimension ordering to Fortran
    */
-  void fortran_order();
+  void set_fortran_order();
   /**
    * @brief Sets a custom dimension ordering
    *
    * @param dims A vector that stores the order of dimensions.
    */
-  void custom_order(std::vector<int32_t>&& dims);
+  void set_custom_order(std::vector<int32_t>&& dims);
 
  public:
   /**

--- a/src/core/runtime/context.cc
+++ b/src/core/runtime/context.cc
@@ -221,7 +221,7 @@ Domain TaskContext::get_launch_domain() const { return task_->index_domain; }
 void TaskContext::make_all_unbound_stores_empty()
 {
   for (auto& output : outputs_)
-    if (output.is_output_store()) output.make_empty();
+    if (output.is_unbound_store()) output.bind_empty_data();
 }
 
 ReturnValues TaskContext::pack_return_values() const
@@ -251,7 +251,7 @@ std::vector<ReturnValue> TaskContext::get_return_values() const
   std::vector<ReturnValue> return_values;
 
   for (auto& output : outputs_) {
-    if (!output.is_output_store()) continue;
+    if (!output.is_unbound_store()) continue;
     return_values.push_back(output.pack_weight());
     ++num_unbound_outputs;
   }

--- a/src/core/utilities/deserializer.cc
+++ b/src/core/utilities/deserializer.cc
@@ -60,7 +60,7 @@ void TaskDeserializer::_unpack(Store& value)
   } else {
     auto redop_id = unpack<int32_t>();
     assert(redop_id == -1);
-    auto out = unpack<OutputRegionField>();
+    auto out = unpack<UnboundRegionField>();
     value    = Store(dim, code, std::move(out), std::move(transform));
   }
 }
@@ -97,13 +97,13 @@ void TaskDeserializer::_unpack(RegionField& value)
   value = RegionField(dim, regions_[idx], fid);
 }
 
-void TaskDeserializer::_unpack(OutputRegionField& value)
+void TaskDeserializer::_unpack(UnboundRegionField& value)
 {
   auto dim = unpack<int32_t>();
   auto idx = unpack<uint32_t>();
   auto fid = unpack<int32_t>();
 
-  value = OutputRegionField(outputs_[idx], fid);
+  value = UnboundRegionField(outputs_[idx], fid);
 }
 
 void TaskDeserializer::_unpack(comm::Communicator& value)

--- a/src/core/utilities/deserializer.h
+++ b/src/core/utilities/deserializer.h
@@ -86,7 +86,7 @@ class TaskDeserializer : public BaseDeserializer<TaskDeserializer> {
   void _unpack(Store& value);
   void _unpack(FutureWrapper& value);
   void _unpack(RegionField& value);
-  void _unpack(OutputRegionField& value);
+  void _unpack(UnboundRegionField& value);
   void _unpack(comm::Communicator& value);
   void _unpack(Legion::PhaseBarrier& barrier);
 


### PR DESCRIPTION
This PR addresses left-over comments from @jjwilke on #563. Functions with confusing/obsolete names are renamed.