### PR TITLE
Update Conda build scripts

### DIFF
--- a/conda/conda-build/conda_build_config.yaml
+++ b/conda/conda-build/conda_build_config.yaml
@@ -3,7 +3,7 @@ gpu_enabled:
   - false
 
 python:
-  - "3.9,!=3.9.7"
+  - 3.9
   - 3.10
   - 3.11
 

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -23,7 +23,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version='.'.join(environ.get('CUDA', '11.5').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '11.8').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 
@@ -129,6 +129,7 @@ requirements:
 
   run_constrained:
     - __glibc >=2.17  # [linux]
+    - python != 3.9.7
 {% if gpu_enabled_bool %}
     - __cuda >={{ cuda_version }}
 {% endif %}


### PR DESCRIPTION
This includes two changes for the conda build scripts:
1. Updates how the restriction on python 3.9.7 is done through run_constrains
2. Updates to 11.8 since SM90 is included in the build command