### PR TITLE
Re-enable future instance creation directly on framebuffer

### DIFF
--- a/src/legate_defines.h
+++ b/src/legate_defines.h
@@ -57,6 +57,3 @@
 #endif
 
 #define LEGATE_MAX_DIM LEGION_MAX_DIM
-
-// TODO: 2022-10-04: Work around a Legion bug, by not instantiating futures on framebuffer.
-#define LEGATE_NO_FUTURES_ON_FB


### PR DESCRIPTION
This is expected to improve the performance of reductions into scalar stores, since the singleton output buffers will be directly instantiated on framebuffer. It should also remove the waits from tasks that pull read-only futures into the framebuffer, to create read accessors, because those futures will already be targeted to the framebuffer during mapping. The Legion bug that was keeping us from using this seems to be fixed, so putting this through its paces once again.