### PR TITLE
add --info command line option

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from argparse import REMAINDER, ArgumentDefaultsHelpFormatter, ArgumentParser
 
 from .. import __version__
+from ..util.args import InfoAction
 from ..util.shared_args import (
     CPUS,
     FBMEM,
@@ -387,4 +388,11 @@ other.add_argument(
     "--version",
     action="version",
     version=__version__,
+)
+
+other.add_argument(
+    "--info",
+    action=InfoAction,
+    help="Print information about the capabilities of this build of legate, "
+    "and immediately exit.",
 )

--- a/legate/install_info.py.in
+++ b/legate/install_info.py.in
@@ -44,3 +44,13 @@ libpath: str = get_libpath()
 header: str = """@header@"""
 
 networks: list[str] = "@Legion_NETWORKS@".split()
+
+conduit: str = "@GASNet_CONDUIT@"
+
+build_type: str = "@CMAKE_BUILD_TYPE@"
+
+ON, OFF = True, False
+
+use_cuda: bool = @Legion_USE_CUDA@
+
+use_openmp: bool = @Legion_USE_OpenMP@

--- a/legate/util/args.py
+++ b/legate/util/args.py
@@ -14,7 +14,8 @@
 #
 from __future__ import annotations
 
-from argparse import Action, ArgumentParser, Namespace
+import sys
+from argparse import SUPPRESS, Action, ArgumentParser, Namespace
 from dataclasses import dataclass, fields
 from typing import (
     Any,
@@ -22,6 +23,7 @@ from typing import (
     Iterable,
     Iterator,
     Literal,
+    NoReturn,
     Sequence,
     Type,
     TypeVar,
@@ -29,6 +31,8 @@ from typing import (
 )
 
 from typing_extensions import TypeAlias
+
+from . import info
 
 
 class _UnsetType:
@@ -141,3 +145,21 @@ class ExtendAction(Action, Generic[T]):
             items.append(values)
         # removing any duplicates before storing
         setattr(namespace, self.dest, list(set(items)))
+
+
+class InfoAction(Action):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs["metavar"] = None
+        kwargs["nargs"] = 0
+        kwargs["default"] = SUPPRESS
+        super().__init__(*args, **kwargs)
+
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: Union[str, Sequence[T], None],
+        option_string: Union[str, None] = None,
+    ) -> NoReturn:
+        info.print_build_info()
+        sys.exit()

--- a/legate/util/info.py
+++ b/legate/util/info.py
@@ -1,0 +1,29 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" """
+
+from .. import install_info as info
+
+
+def print_build_info() -> None:
+    print(
+        f"""Legate build configuration:
+  build_type : {info.build_type}
+  use_openmp : {info.use_openmp}
+  use_cuda   : {info.use_cuda}
+  networks   : {','.join(info.networks) if info.networks else 'None'}
+  conduit    : {info.conduit}
+"""
+    )

--- a/legate/util/info.py
+++ b/legate/util/info.py
@@ -23,7 +23,7 @@ def print_build_info() -> None:
   build_type : {info.build_type}
   use_openmp : {info.use_openmp}
   use_cuda   : {info.use_cuda}
-  networks   : {','.join(info.networks) if info.networks else 'None'}
+  networks   : {','.join(info.networks) if info.networks else ''}
   conduit    : {info.conduit}
 """
     )

--- a/legate_core_python.cmake
+++ b/legate_core_python.cmake
@@ -46,6 +46,10 @@ endif()
 add_custom_target("generate_install_info_py" ALL
   COMMAND ${CMAKE_COMMAND}
           -DLegion_NETWORKS="${Legion_NETWORKS}"
+          -DGASNet_CONDUIT="${GASNet_CONDUIT}"
+          -DLegion_USE_CUDA="${Legion_USE_CUDA}"
+          -DLegion_USE_OpenMP="${Legion_USE_OpenMP}"
+          -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
           -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
           -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_install_info_py.cmake"
   COMMENT "Generate install_info.py"

--- a/tests/unit/legate/driver/test_args.py
+++ b/tests/unit/legate/driver/test_args.py
@@ -14,6 +14,8 @@
 #
 from __future__ import annotations
 
+from argparse import SUPPRESS
+
 import legate.driver.args as m
 import legate.driver.defaults as defaults
 
@@ -179,6 +181,9 @@ class TestParserDefaults:
 
     def test_rlwrap(self) -> None:
         assert m.parser.get_default("rlwrap") is False
+
+    def test_info(self) -> None:
+        assert m.parser.get_default("info") == SUPPRESS
 
 
 class TestParserConfig:

--- a/tests/unit/legate/util/test_args.py
+++ b/tests/unit/legate/util/test_args.py
@@ -19,8 +19,10 @@ from dataclasses import dataclass
 from typing import Iterable, TypeVar
 
 import pytest
+from pytest_mock import MockerFixture
 
 import legate.util.args as m
+import legate.util.info as info
 
 from ...util import powerset
 
@@ -68,6 +70,20 @@ class TestExtendAction:
     def test_repeat(self) -> None:
         ns = self.parser.parse_args(["--foo", "a", "--foo", "a"])
         assert ns.foo == ["a"]
+
+
+class TestInfoAction:
+    parser = ArgumentParser()
+    parser.add_argument("--info", action=m.InfoAction)
+
+    def tests_basic(self, mocker: MockerFixture) -> None:
+        mock_print_info = mocker.patch.object(info, "print_build_info")
+        mock_sys_exit = mocker.patch("sys.exit")
+
+        self.parser.parse_args(["--info"])
+
+        mock_print_info.assert_called_once()
+        mock_sys_exit.assert_called_once()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
fixes: #632
 
This PR adds an `--info` command line option to the driver that prints out information about the build configuration:
```
docs310 ❯ legate --info
Legate build configuration:
  build_type : Release
  use_openmp : True
  use_cuda   : True
  networks   : None
  conduit    : 
```

Questions:

* Would machine-readable (e.g. JSON) output be preferable?
* Currently convert empty list to "None" for "networks" field, is this desired? Could print nothing, or [], or omit the field in this case.
* Prints nothing if there is no conduit, is this desired? Could omit the field, etc. 

cc @manopapad @trxcllnt 