### PR TITLE
Bug/allow rebuilds with scikit build

### DIFF
--- a/cmake/legate_helper_functions.cmake
+++ b/cmake/legate_helper_functions.cmake
@@ -202,7 +202,7 @@ function(legate_default_python_install target)
 endfunction()
 
 function(legate_add_cpp_subdirectory dir)
-  set(options)
+  set(options ALWAYS_BUILD)
   set(one_value_args EXPORT TARGET)
   set(multi_value_args)
   cmake_parse_arguments(
@@ -230,7 +230,7 @@ function(legate_add_cpp_subdirectory dir)
           BUILD_EXPORT_SET ${LEGATE_OPT_EXPORT}
           INSTALL_EXPORT_SET ${LEGATE_OPT_EXPORT})
 
-  if (SKBUILD)
+  if (SKBUILD AND NOT LEGATE_OPT_ALWAYS_BUILD)
     if (NOT DEFINED ${target}_ROOT)
       set(${target}_ROOT ${CMAKE_SOURCE_DIR}/build)
     endif()

--- a/cmake/legate_helper_functions.cmake
+++ b/cmake/legate_helper_functions.cmake
@@ -182,7 +182,7 @@ function(legate_default_python_install target)
     message(FATAL_ERROR "Need EXPORT name for legate_default_python_install")
   endif()
 
-  if (SKBUILD)
+  if (SKBUILD AND NOT TARGET legate::${target}_python)
     add_library(${target}_python INTERFACE)
     add_library(legate::${target}_python ALIAS ${target}_python)
     target_link_libraries(${target}_python INTERFACE legate::core legate::${target})


### PR DESCRIPTION
Currently due to the implicit logic around `SKBUILD` it isn't possible for projects to safely build/install multiple times in a row.

  Consider a project that looks like:
  ```
  legate_add_cpp_subdirectory(cpp TARGET legate_user EXPORT legate_user-export)
  legate_default_python_install(legate_user EXPORT legate_user-export)
  ```
  
  When a local user runs scikit-build the first time everything will work correctly as `legate_user` doesn't exist in the install location. But when invoked a second time it will find the installed version, and not build. So to install an updated version
of the files you need to first clean your env which is not a nice pattern.

So with the PR, projects can explicitly state they always want to build from source and never search for a local version.
