### PR TITLE
Fix example build tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,3 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
   add_touch_legate_core_ninja_build_target()
 endif()
 
-option(legate_core_EXAMPLE_BUILD_TESTS OFF)
-if (legate_core_EXAMPLE_BUILD_TESTS)
-  add_subdirectory(examples)
-endif()

--- a/cmake/legate_helper_functions.cmake
+++ b/cmake/legate_helper_functions.cmake
@@ -153,7 +153,7 @@ header: str = """
     set(libdir ${CMAKE_BINARY_DIR}/legate_${target})
     message("libdir to binary dir")
   endif()
-  add_custom_target("generate_install_info_py" ALL
+  add_custom_target("${target}_generate_install_info_py" ALL
     COMMAND ${CMAKE_COMMAND}
       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
       -Dtarget=${target}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 # We abuse find package for testing purposes here to
 # 'find' the current build tree to test package builds
-set(legate_core_ROOT ${CMAKE_BINARY_DIR})
 
 add_subdirectory(hello)
 add_subdirectory(io)

--- a/install.py
+++ b/install.py
@@ -256,6 +256,7 @@ def install(
     check_bounds,
     clean_first,
     extra_flags,
+    build_examples,
     editable,
     build_isolation,
     thread_count,
@@ -468,6 +469,8 @@ def install(
         cmake_flags += [f"-Dlegate_core_LEGION_BRANCH={legion_branch}"]
     if build_docs:
         cmake_flags += ["-Dlegate_core_BUILD_DOCS=ON"]
+    if build_examples:
+        cmake_flags += ["-Dlegate_core_EXAMPLE_BUILD_TESTS=ON"]
 
     cmake_flags += extra_flags
     build_flags = [f"-j{str(thread_count)}"]
@@ -685,6 +688,13 @@ def driver():
         required=False,
         default=[],
         help="Extra CMake flags.",
+    )
+    parser.add_argument(
+        "--build-examples",
+        dest="build_examples",
+        action=BooleanFlag,
+        default=False,
+        help="Whether to build the examples",
     )
     parser.add_argument(
         "-j",

--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -496,3 +496,8 @@ rapids_export(
   FINAL_CODE_BLOCK code_string
   LANGUAGES ${ENABLED_LANGUAES}
 )
+option(legate_core_EXAMPLE_BUILD_TESTS OFF)
+if (legate_core_EXAMPLE_BUILD_TESTS)
+  set(legate_core_ROOT ${CMAKE_CURRENT_BINARY_DIR})
+  add_subdirectory(examples)
+endif()

--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -448,7 +448,7 @@ Imported Targets:
 
 ]=])
 
-file(READ ${CMAKE_SOURCE_DIR}/cmake/legate_helper_functions.cmake helper_functions)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/cmake/legate_helper_functions.cmake helper_functions)
 
 string(JOIN "\n" code_string
 [=[


### PR DESCRIPTION
* Example rules were not target-specific, which lead to name clashes when building the examples in-tree
* SKBUILD paths did not set the correct Legate root
* Adds flag to install.py for building examples