### PR TITLE
Guard against attaching to non-contiguous buffers

### DIFF
--- a/legate/core/_legion/operation.py
+++ b/legate/core/_legion/operation.py
@@ -1145,7 +1145,7 @@ class Attach(Dispatchable[PhysicalRegion]):
         self._launcher = ffi.gc(
             self.launcher, legion.legion_attach_launcher_destroy
         )
-        if not data.c_contiguous and not data.f_contiguous:
+        if not data.contiguous:
             raise RuntimeError("Can only attach to C- or F-contiguous buffers")
         legion.legion_attach_launcher_add_cpu_soa_field(
             self.launcher,
@@ -1314,7 +1314,7 @@ class IndexAttach(Dispatchable[ExternalResources]):
         for sub_region, buf in shard_local_data.items():
             if sub_region.parent is not None:
                 assert sub_region.parent.parent is parent
-            if not buf.c_contiguous and not buf.f_contiguous:
+            if not buf.contiguous:
                 raise RuntimeError(
                     "Can only attach to C- or F-contiguous buffers"
                 )

--- a/legate/core/_legion/operation.py
+++ b/legate/core/_legion/operation.py
@@ -1154,6 +1154,9 @@ class Attach(Dispatchable[PhysicalRegion]):
                 field.fid if isinstance(field, FieldID) else field,
             ),
             ffi.from_buffer(data),
+            # `not c_contiguous` implies `f_contiguous`; doing it this way so
+            # that 0d/1d arrays, which are both c_ and f_contiguous, are
+            # attached as C-ordered
             not data.c_contiguous,
         )
 
@@ -1322,6 +1325,9 @@ class IndexAttach(Dispatchable[ExternalResources]):
                 self.launcher,
                 sub_region.handle,
                 ffi.from_buffer(buf),
+                # `not c_contiguous` implies `f_contiguous`; doing it this way
+                # so that 0d/1d arrays, which are both c_ and f_contiguous, are
+                # attached as C-ordered
                 not buf.c_contiguous,
                 fields,
                 1,  # num_fields

--- a/legate/core/_legion/operation.py
+++ b/legate/core/_legion/operation.py
@@ -1145,6 +1145,8 @@ class Attach(Dispatchable[PhysicalRegion]):
         self._launcher = ffi.gc(
             self.launcher, legion.legion_attach_launcher_destroy
         )
+        if not data.c_contiguous and not data.f_contiguous:
+            raise RuntimeError("Can only attach to C- or F-contiguous buffers")
         legion.legion_attach_launcher_add_cpu_soa_field(
             self.launcher,
             ffi.cast(
@@ -1152,7 +1154,7 @@ class Attach(Dispatchable[PhysicalRegion]):
                 field.fid if isinstance(field, FieldID) else field,
             ),
             ffi.from_buffer(data),
-            data.f_contiguous,
+            not data.c_contiguous,
         )
 
     def set_restricted(self, restricted: bool) -> None:
@@ -1312,11 +1314,15 @@ class IndexAttach(Dispatchable[ExternalResources]):
         for sub_region, buf in shard_local_data.items():
             if sub_region.parent is not None:
                 assert sub_region.parent.parent is parent
+            if not buf.c_contiguous and not buf.f_contiguous:
+                raise RuntimeError(
+                    "Can only attach to C- or F-contiguous buffers"
+                )
             legion.legion_index_attach_launcher_attach_array_soa(
                 self.launcher,
                 sub_region.handle,
                 ffi.from_buffer(buf),
-                buf.f_contiguous,
+                not buf.c_contiguous,
                 fields,
                 1,  # num_fields
                 mem,

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -454,6 +454,8 @@ class AttachmentManager:
     @staticmethod
     def attachment_key(buf: memoryview) -> tuple[int, int]:
         assert isinstance(buf, memoryview)
+        if not buf.contiguous:
+            raise RuntimeError("Cannot attach to non-contiguous buffer")
         ptr = ffi.cast("uintptr_t", ffi.from_buffer(buf))
         base_ptr = int(ptr)  # type: ignore[call-overload]
         return (base_ptr, buf.nbytes)


### PR DESCRIPTION
This is currently extraneous, as cffi.from_buffer(.) only works with C-contiguous buffers anyway, but good to have this documented.