### PR TITLE
Add provenance information to nvtx ranges

### DIFF
--- a/src/core/task/task.cc
+++ b/src/core/task/task.cc
@@ -59,7 +59,10 @@ void task_wrapper(VariantImpl variant_impl,
   Legion::Runtime::legion_task_preamble(args, arglen, p, task, regions, legion_context, runtime);
 
 #ifdef LEGATE_USE_CUDA
-  nvtx::Range auto_range(task_name);
+  std::stringstream ss;
+  ss << task_name << " @ " + task->get_provenance_string();
+  std::string msg = ss.str();
+  nvtx::Range auto_range(msg.c_str());
 #endif
 
   Core::show_progress(task, legion_context, runtime);


### PR DESCRIPTION
Before:

<img width="1904" alt="Screenshot 2023-03-29 at 3 23 32 PM" src="https://user-images.githubusercontent.com/215728/228681210-1f1a1440-ca0d-42e8-9350-ed534143bee1.png">

After:

<img width="1904" alt="Screenshot 2023-03-29 at 3 23 36 PM" src="https://user-images.githubusercontent.com/215728/228681229-e90a04e1-2061-4ee3-ba01-1b3ec5fa4224.png">
