### PR TITLE
Add support for integer division to ProjExpr

### DIFF
--- a/legate/core/projection.py
+++ b/legate/core/projection.py
@@ -83,6 +83,10 @@ class ProjExpr:
             raise ValueError("RHS must be an integer")
         return ProjExpr(self._dim, self._weight, self._offset + other)
 
+    def __floordiv__(self, other: int) -> ProjExpr:
+        if not isinstance(other, int):
+            raise ValueError("RHS must be an integer")
+        return ProjExpr(self._dim, self._weight, self._offset // other)
 
 # todo: (bev) use tuple[...] when feasible
 SymbolicPoint = Tuple[ProjExpr, ...]

--- a/legate/core/projection.py
+++ b/legate/core/projection.py
@@ -88,6 +88,7 @@ class ProjExpr:
             raise ValueError("RHS must be an integer")
         return ProjExpr(self._dim, self._weight, self._offset // other)
 
+
 # todo: (bev) use tuple[...] when feasible
 SymbolicPoint = Tuple[ProjExpr, ...]
 


### PR DESCRIPTION
Expand support of ProjExpr for integer division.

Use case:

```
task.add_input(a, lambda p : (p[0] // rows + row_offset, p[1] // cols + col_offset))
```