### PR TITLE
Don't use traceback.walk_stack(None)

### DIFF
--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -14,6 +14,7 @@
 #
 from __future__ import annotations
 
+import inspect
 import traceback
 from typing import (
     TYPE_CHECKING,
@@ -53,7 +54,7 @@ class AnyCallable(Protocol):
 
 
 def find_last_user_frame(libname: str) -> str:
-    for frame, _ in traceback.walk_stack(None):
+    for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if "__name__" not in frame.f_globals:
             continue
         if not any(


### PR DESCRIPTION
Thanks once again to @syamajala for finding this.

Turns out `traceback.walk_stack(None)` was always broken, and broke even worse in Python 3.11, see https://github.com/python/cpython/issues/96092.

On my local 3.9 installation, `walk_stack(None)` skips one frame:

```
Trying to find last frame before entering cuNumeric
<frame at 0x7f9bee1952d0, file '/Users/mpapadakis/legate.core/legate/core/context.py', line 368, code wrapper>
  __name__ = legate.core.context
<frame at 0x10b02ba00, file 'a.py', line 24, code <module>>
  __name__ = __main__
  stopped here
The full stack was:
  File "/Users/mpapadakis/legion/bindings/python/build/lib/legion_top.py", line 481, in legion_python_main
    run_path(args[start], run_name='__main__')
  File "/Users/mpapadakis/legion/bindings/python/build/lib/legion_top.py", line 302, in run_path
    exec(code, module.__dict__, module.__dict__)
  File "a.py", line 24, in <module>
    a = cn.ones((1024 * 1024,))
  File "/Users/mpapadakis/legate.core/legate/core/context.py", line 368, in wrapper
    self.set_provenance(find_last_user_frame(self._libname))
  File "/Users/mpapadakis/legate.core/legate/core/context.py", line 70, in find_last_user_frame
    print("".join(traceback.format_stack()))
```

On Seshu's 3.11 installation, it skips even more frames:

```
Trying to find last frame before entering cuNumeric
<frame at 0x7f0fb27f57a0, file '/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legion_top.py', line 302, code run_path>
  __name__ = legion_top
  stopped here
The full stack was:
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legion_top.py", line 481, in legion_python_main
    run_path(args[start], run_name='__main__')
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legion_top.py", line 302, in run_path
    exec(code, module.__dict__, module.__dict__)
  File "TXAS_NKedge_laser_cunumeric.py", line 209, in <module>
    andor_corr = data['andor_dir'] - andor_bckg[None,:]
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py", line 369, in wrapper
    self.set_provenance(find_last_user_frame(self._libname))
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py", line 71, in find_last_user_frame
    print("".join(traceback.format_stack()))
```

resulting in wrong provenance strings: http://sapling.stanford.edu/~seshu/rixs/legate_prof/?start=0&end=19841501.2&collapseAll=false&resolution=10

With this change all stack frames are walked. On my 3.9 installation:

```
Trying to find last frame before entering cuNumeric
<frame at 0x10d3f2c80, file '/Users/mpapadakis/legate.core/legate/core/context.py', line 59, code find_last_user_frame>
  __name__ = legate.core.context
<frame at 0x7fdd1870d9a0, file '/Users/mpapadakis/legate.core/legate/core/context.py', line 369, code wrapper>
  __name__ = legate.core.context
<frame at 0x10d99ba00, file 'a.py', line 24, code <module>>
  __name__ = __main__
  stopped here
The full stack was:
  File "/Users/mpapadakis/legion/bindings/python/build/lib/legion_top.py", line 481, in legion_python_main
    run_path(args[start], run_name='__main__')
  File "/Users/mpapadakis/legion/bindings/python/build/lib/legion_top.py", line 302, in run_path
    exec(code, module.__dict__, module.__dict__)
  File "a.py", line 24, in <module>
    a = cn.ones((1024 * 1024,))
  File "/Users/mpapadakis/legate.core/legate/core/context.py", line 369, in wrapper
    self.set_provenance(find_last_user_frame(self._libname))
  File "/Users/mpapadakis/legate.core/legate/core/context.py", line 71, in find_last_user_frame
    print("".join(traceback.format_stack()))
```

On Seshu's 3.11 installation:

```
Trying to find last frame before entering cuNumeric
<frame at 0x7f2de1e90930, file '/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py', line 60, code find_last_user_frame>
  __name__ = legate.core.context
<frame at 0x7f2df55104a0, file '/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py', line 370, code wrapper>
  __name__ = legate.core.context
<frame at 0x7f2de1e158b0, file 'TXAS_NKedge_laser_cunumeric.py', line 209, code <module>>
  __name__ = __main__
  stopped here
The full stack was:
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legion_top.py", line 481, in legion_python_main
    run_path(args[start], run_name='__main__')
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legion_top.py", line 302, in run_path
    exec(code, module.__dict__, module.__dict__)
  File "TXAS_NKedge_laser_cunumeric.py", line 209, in <module>
    andor_corr = data['andor_dir'] - andor_bckg[None,:]
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py", line 370, in wrapper
    self.set_provenance(find_last_user_frame(self._libname))
  File "/sdf/home/s/seshu/cunumeric-23.03.00-cuda/lib/python3.11/site-packages/legate/core/context.py", line 72, in find_last_user_frame
    print("".join(traceback.format_stack()))
```

and the provenance strings work correctly now http://sapling.stanford.edu/~seshu/rixs/legate_prof.5/?start=0&end=36583372.7847842&collapseAll=false&resolution=10