### PR TITLE
Use parent frame indiscriminately in nested provenance

### DIFF
--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -54,11 +54,9 @@ class AnyCallable(Protocol):
 
 def caller_frameinfo() -> str:
     frame = inspect.currentframe()
-    for _ in range(2):
-        if frame is not None:
-            frame = frame.f_back
-    if frame is None:
+    if frame is None or frame.f_back is None or frame.f_back.f_back is None:
         return "<unknown>"
+    frame = frame.f_back.f_back
     return f"{frame.f_code.co_filename}:{frame.f_lineno}"
 
 

--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -58,7 +58,7 @@ def caller_frameinfo() -> str:
         if frame is not None:
             frame = frame.f_back
     if frame is None:
-        return ""
+        return "<unknown>"
     return f"{frame.f_code.co_filename}:{frame.f_lineno}"
 
 


### PR DESCRIPTION
Currently, even if all nested calls to provenance-tracking functions are recorded, each level will record the same provenance string (*), since they all go all the way up to the first user-level frame. With this change, each time we record provenance we simply use the frame which called into the tracked function. This should be equivalent to the current behavior in cases where nesting is disabled, but should allow us to better track intra-library recursive calls if we want to.

Eventually we will want to be recording all the levels of nesting, in the machine-readable part of the provenance, not just the top or bottom.

(*) Technically if the calls switch between libraries, the stack walking will stop at each library switch, but that doesn't help if we're trying to track recursive calls within the same library.