### PR TITLE
Clean up handling of Legion config options

### DIFF
--- a/cmake/Modules/legate_core_options.cmake
+++ b/cmake/Modules/legate_core_options.cmake
@@ -49,7 +49,6 @@ option(Legion_USE_HDF5 "Enable support for HDF5" OFF)
 option(Legion_USE_CUDA "Enable Legion support for the CUDA runtime" OFF)
 option(Legion_NETWORKS "Networking backends to use (semicolon-separated)" "")
 option(Legion_USE_OpenMP "Use OpenMP" OFF)
-option(Legion_USE_Python "Use Python" OFF)
 option(Legion_BOUNDS_CHECKS "Enable bounds checking in Legion accessors" OFF)
 
 if("${Legion_NETWORKS}" MATCHES ".*gasnet(1|ex).*")

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -179,6 +179,7 @@ function(find_or_configure_legion)
           FIND_PACKAGE_ARGUMENTS EXACT
           EXCLUDE_FROM_ALL       ${exclude_from_all}
           OPTIONS                ${_legion_cuda_options}
+                                 "BUILD_SHARED_LIBS ON"
                                  "CMAKE_CXX_STANDARD ${_cxx_std}"
                                  "Legion_VERSION ${version}"
                                  "Legion_BUILD_BINDINGS ON"
@@ -197,6 +198,8 @@ function(find_or_configure_legion)
                                  "Legion_USE_OpenMP ${Legion_USE_OpenMP}"
                                  "Legion_USE_Python ON"
                                  "Legion_BOUNDS_CHECKS ${Legion_BOUNDS_CHECKS}"
+                                 "Legion_BUILD_JUPYTER ON"
+                                 "Legion_EMBED_GASNet_CONFIGURE_ARGS --with-ibv-max-hcas=8"
     )
   endif()
 

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -70,6 +70,16 @@ function(find_or_configure_legion)
 
   if(Legion_FOUND)
     message(STATUS "CPM: using local package Legion@${version}")
+
+    # Check that required Legion options are set
+    if(NOT Legion_USE_Python)
+      message(FATAL_ERROR "Legion was not compiled with Legion_USE_Python")
+    endif()
+
+    # TODO: The following should also be checked, but are not currently reported by Legion:
+    # Legion_BUILD_BINDINGS
+    # Legion_REDOP_HALF
+    # Legion_REDOP_COMPLEX
   else()
 
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/cpm_helpers.cmake)
@@ -206,17 +216,6 @@ function(find_or_configure_legion)
   set(Legion_USE_CUDA ${Legion_USE_CUDA} PARENT_SCOPE)
   set(Legion_USE_OpenMP ${Legion_USE_OpenMP} PARENT_SCOPE)
   set(Legion_NETWORKS ${Legion_NETWORKS} PARENT_SCOPE)
-
-  # Check that required Legion options are set
-  # for cases where we used an existing Legion installation
-  if(NOT Legion_USE_Python)
-    message(FATAL_ERROR "Legion was not compiled with Legion_USE_Python")
-  endif()
-
-  # TODO: The following should also be checked, but are not currently reported by Legion:
-  # Legion_BUILD_BINDINGS
-  # Legion_REDOP_HALF
-  # Legion_REDOP_COMPLEX
 
   message(VERBOSE "Legion_USE_CUDA=${Legion_USE_CUDA}")
   message(VERBOSE "Legion_USE_OpenMP=${Legion_USE_OpenMP}")

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -195,19 +195,28 @@ function(find_or_configure_legion)
                                  "Legion_USE_CUDA ${Legion_USE_CUDA}"
                                  "Legion_NETWORKS ${Legion_NETWORKS}"
                                  "Legion_USE_OpenMP ${Legion_USE_OpenMP}"
-                                 "Legion_USE_Python ${Legion_USE_Python}"
+                                 "Legion_USE_Python ON"
                                  "Legion_BOUNDS_CHECKS ${Legion_BOUNDS_CHECKS}"
     )
   endif()
 
   set(Legion_USE_CUDA ${Legion_USE_CUDA} PARENT_SCOPE)
   set(Legion_USE_OpenMP ${Legion_USE_OpenMP} PARENT_SCOPE)
-  set(Legion_USE_Python ${Legion_USE_Python} PARENT_SCOPE)
   set(Legion_NETWORKS ${Legion_NETWORKS} PARENT_SCOPE)
+
+  # Check that required Legion options are set
+  # for cases where we used an existing Legion installation
+  if(NOT Legion_USE_Python)
+    message(FATAL_ERROR "Legion was not compiled with Legion_USE_Python")
+  endif()
+
+  # TODO: The following should also be checked, but are not currently reported by Legion:
+  # Legion_BUILD_BINDINGS
+  # Legion_REDOP_HALF
+  # Legion_REDOP_COMPLEX
 
   message(VERBOSE "Legion_USE_CUDA=${Legion_USE_CUDA}")
   message(VERBOSE "Legion_USE_OpenMP=${Legion_USE_OpenMP}")
-  message(VERBOSE "Legion_USE_Python=${Legion_USE_Python}")
   message(VERBOSE "Legion_NETWORKS=${Legion_NETWORKS}")
 
 endfunction()

--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -9,8 +9,7 @@ CMAKE_ARGS+="
 --log-level=VERBOSE
 -DBUILD_MARCH=haswell
 -DLegion_USE_OpenMP=ON
--DLegion_USE_Python=ON
--DLegion_BUILD_BINDINGS=ON"
+"
 
 # We rely on an environment variable to determine if we need to build cpu-only bits
 if [ -z "$CPU_ONLY" ]; then

--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -8,8 +8,7 @@ CMAKE_ARGS="$(echo "$CMAKE_ARGS" | sed -r "s@_INCLUDE=ONLY@_INCLUDE=BOTH@g")"
 CMAKE_ARGS+="
 --log-level=VERBOSE
 -DBUILD_MARCH=haswell
--DLegion_USE_OpenMP=ON
-"
+-DLegion_USE_OpenMP=ON"
 
 # We rely on an environment variable to determine if we need to build cpu-only bits
 if [ -z "$CPU_ONLY" ]; then

--- a/install.py
+++ b/install.py
@@ -743,14 +743,18 @@ def driver():
         dest="legion_dir",
         required=False,
         default=None,
-        help="Path to an existing Legion build directory.",
+        help="Path to an existing Legion build directory. A recent checkout "
+        "of the control_replication branch is required, configured with "
+        "Legion_BUILD_BINDINGS=ON, Legion_REDOP_HALF=ON, "
+        "Legion_REDOP_COMPLEX=ON, Legion_USE_Python=ON.",
     )
     parser.add_argument(
         "--legion-src-dir",
         dest="legion_src_dir",
         required=False,
         default=None,
-        help="Path to an existing Legion source directory.",
+        help="Path to an existing Legion source directory. A recent checkout "
+        "of the control_replication branch is required.",
     )
     parser.add_argument(
         "--legion-url",

--- a/install.py
+++ b/install.py
@@ -420,11 +420,13 @@ def install(
     if debug or verbose:
         cmake_flags += [f"--log-level={'DEBUG' if debug else 'VERBOSE'}"]
 
+    # NOTE: Any unconditional Legion configuration settings should be added to
+    # cmake/thirdparty/get_legion.cmake, so that pure-cmake builds will also
+    # pick them up.
     cmake_flags += f"""\
 -DCMAKE_BUILD_TYPE={(
     "Debug" if debug else "RelWithDebInfo" if debug_release else "Release"
 )}
--DBUILD_SHARED_LIBS=ON
 -DBUILD_MARCH={march}
 -DCMAKE_CUDA_ARCHITECTURES={arch}
 -DLegion_MAX_DIM={str(maxdim)}
@@ -437,11 +439,6 @@ def install(
 -DLegion_NETWORKS={";".join(networks)}
 -DLegion_USE_HDF5={("ON" if hdf else "OFF")}
 -DLegion_Python_Version={pyversion}
--DLegion_REDOP_COMPLEX=ON
--DLegion_REDOP_HALF=ON
--DLegion_BUILD_BINDINGS=ON
--DLegion_BUILD_JUPYTER=ON
--DLegion_EMBED_GASNet_CONFIGURE_ARGS="--with-ibv-max-hcas=8"
 """.splitlines()
 
     if nccl_dir:

--- a/install.py
+++ b/install.py
@@ -436,7 +436,6 @@ def install(
 -DLegion_USE_LLVM={("ON" if llvm else "OFF")}
 -DLegion_NETWORKS={";".join(networks)}
 -DLegion_USE_HDF5={("ON" if hdf else "OFF")}
--DLegion_USE_Python=ON
 -DLegion_Python_Version={pyversion}
 -DLegion_REDOP_COMPLEX=ON
 -DLegion_REDOP_HALF=ON

--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -89,11 +89,9 @@ macro(_enable_cuda_language)
   endif()
 endmacro()
 
-if(Legion_USE_Python)
-  _find_package_Python3()
-  if(Python3_FOUND AND Python3_VERSION)
-    set(Legion_Python_Version ${Python3_VERSION})
-  endif()
+_find_package_Python3()
+if(Python3_FOUND AND Python3_VERSION)
+  set(Legion_Python_Version ${Python3_VERSION})
 endif()
 
 if(Legion_USE_CUDA)
@@ -102,19 +100,14 @@ endif()
 
 ###
 # If we find Legion already configured on the system, it will report whether it
-# was compiled with Python (Legion_USE_PYTHON), CUDA (Legion_USE_CUDA), OpenMP
-# (Legion_USE_OpenMP), and networking (Legion_NETWORKS).
+# was compiled with CUDA (Legion_USE_CUDA), OpenMP (Legion_USE_OpenMP), and
+# networking (Legion_NETWORKS).
 #
 # We use the same variables as Legion because we want to enable/disable each of
 # these features based on how Legion was configured (it doesn't make sense to
 # build legate.core's Python bindings if Legion's bindings weren't compiled).
 ###
 include(cmake/thirdparty/get_legion.cmake)
-
-# If Legion_USE_Python was toggled ON by find_package(Legion), find Python3
-if(Legion_USE_Python AND (NOT Python3_FOUND))
-  _find_package_Python3()
-endif()
 
 if(Legion_NETWORKS)
   find_package(MPI REQUIRED COMPONENTS CXX)
@@ -458,7 +451,6 @@ endif()
 ]=]
   "set(Legion_USE_CUDA ${Legion_USE_CUDA})"
   "set(Legion_USE_OpenMP ${Legion_USE_OpenMP})"
-  "set(Legion_USE_Python ${Legion_USE_Python})"
   "set(Legion_NETWORKS ${Legion_NETWORKS})"
   "set(Legion_BOUNDS_CHECKS ${Legion_BOUNDS_CHECKS})"
 [=[

--- a/legate_core_python.cmake
+++ b/legate_core_python.cmake
@@ -37,8 +37,6 @@ endif()
 
 if(NOT legate_core_FOUND)
   set(SKBUILD OFF)
-  set(Legion_USE_Python ON)
-  set(Legion_BUILD_BINDINGS ON)
   add_subdirectory(. "${CMAKE_CURRENT_SOURCE_DIR}/build")
   set(SKBUILD ON)
 endif()

--- a/scripts/build-separately-no-install.sh
+++ b/scripts/build-separately-no-install.sh
@@ -20,8 +20,6 @@ if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 cmake_args+="
 -D Legion_USE_CUDA=ON
 -D Legion_USE_OpenMP=ON
--D Legion_USE_Python=ON
--D Legion_BUILD_BINDINGS=ON
 -D CMAKE_CUDA_ARCHITECTURES=NATIVE
 ";
 


### PR DESCRIPTION
* Always build Legion with python support and FFI bindings. This way even if a user starts with a default cmake build, then does `pip install`, the Legion build that cmake did will automatically be compatible with the python layer. We could just change the default to be ON everywhere, but I don't see a reason why we need to support Legion builds w/o python and bindings, but maybe folks have a different opinion.
* Move unconditional Legion configuration flags out of `install.py`, and leave a note to put those in the cmake configuration. As is we run the risk that developers will only update `install.py` and forget to update the cmake-only defaults.
* Document major required Legion configuration flags, so that users know how to build Legion such that it's compatible with Legate. Automatically check all the ones that Legion exports (others will have to wait until the Legion cmake build starts exporting them).