### PR TITLE
Mapper refactoring

### DIFF
--- a/legate/core/_lib/context.pyx
+++ b/legate/core/_lib/context.pyx
@@ -29,7 +29,7 @@ cdef extern from "core/task/task_info.h" namespace "legate" nogil:
 cdef extern from "core/runtime/context.h" namespace "legate" nogil:
     cdef cppclass LibraryContext:
         unsigned int get_task_id(long long)
-        unsigned int get_mapper_id(long long)
+        unsigned int get_mapper_id()
         int get_reduction_op_id(long long)
         unsigned int get_projection_id(long long)
         unsigned int get_sharding_id(long long)
@@ -70,8 +70,8 @@ cdef class Context:
     def get_task_id(self, long long local_task_id) -> int:
         return self._context.get_task_id(local_task_id)
 
-    def get_mapper_id(self, long long local_mapper_id) -> int:
-        return self._context.get_mapper_id(local_mapper_id)
+    def get_mapper_id(self) -> int:
+        return self._context.get_mapper_id()
 
     def get_reduction_op_id(self, long long local_redop_id) -> int:
         return self._context.get_reduction_op_id(local_redop_id)

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -711,7 +711,6 @@ class TaskLauncher:
         self,
         context: Context,
         task_id: int,
-        mapper_id: int = 0,
         tag: int = 0,
         error_on_interference: bool = True,
         side_effect: bool = False,
@@ -719,9 +718,9 @@ class TaskLauncher:
     ) -> None:
         assert type(tag) != bool
         self._context = context
+        self._mapper_id = context.mapper_id
         self._core_types = runtime.core_context.type_system
         self._task_id = task_id
-        self._mapper_id = mapper_id
         self._inputs: list[LauncherArg] = []
         self._outputs: list[LauncherArg] = []
         self._reductions: list[LauncherArg] = []
@@ -747,16 +746,8 @@ class TaskLauncher:
         return self._task_id
 
     @property
-    def library_mapper_id(self) -> int:
-        return self._mapper_id
-
-    @property
     def legion_task_id(self) -> int:
         return self._context.get_task_id(self._task_id)
-
-    @property
-    def legion_mapper_id(self) -> int:
-        return self._context.get_mapper_id(self._mapper_id)
 
     def __del__(self) -> None:
         del self._req_analyzer
@@ -921,7 +912,7 @@ class TaskLauncher:
             self._context.empty_argmap,
             argbuf.get_string(),
             argbuf.get_size(),
-            mapper=self.legion_mapper_id,
+            mapper=self._mapper_id,
             tag=self._tag,
             provenance=self._provenance,
         )
@@ -962,7 +953,7 @@ class TaskLauncher:
             self.legion_task_id,
             argbuf.get_string(),
             argbuf.get_size(),
-            mapper=self.legion_mapper_id,
+            mapper=self._mapper_id,
             tag=self._tag,
             provenance=self._provenance,
         )
@@ -1004,13 +995,12 @@ class CopyLauncher:
         context: Context,
         source_oor: bool = True,
         target_oor: bool = True,
-        mapper_id: int = 0,
         tag: int = 0,
         provenance: Optional[str] = None,
     ) -> None:
         assert type(tag) != bool
         self._context = context
-        self._mapper_id = mapper_id
+        self._mapper_id = context.mapper_id
         self._inputs: list[LauncherArg] = []
         self._outputs: list[LauncherArg] = []
         self._reductions: list[LauncherArg] = []
@@ -1026,14 +1016,6 @@ class CopyLauncher:
         self._source_oor = source_oor
         self._target_oor = target_oor
         self._provenance = provenance
-
-    @property
-    def library_mapper_id(self) -> int:
-        return self._mapper_id
-
-    @property
-    def legion_mapper_id(self) -> int:
-        return self._context.get_mapper_id(self._mapper_id)
 
     def add_store(
         self,
@@ -1170,7 +1152,7 @@ class CopyLauncher:
 
         copy = IndexCopy(
             launch_domain,
-            mapper=self.legion_mapper_id,
+            mapper=self._mapper_id,
             tag=self._tag,
             provenance=self._provenance,
         )
@@ -1201,7 +1183,7 @@ class CopyLauncher:
         pack_args(argbuf, self._target_indirects)
 
         copy = SingleCopy(
-            mapper=self.legion_mapper_id,
+            mapper=self._mapper_id,
             tag=self._tag,
             provenance=self._provenance,
         )
@@ -1244,27 +1226,18 @@ class FillLauncher:
         lhs: Store,
         lhs_proj: Proj,
         value: Store,
-        mapper_id: int = 0,
         tag: int = 0,
         provenance: Optional[str] = None,
     ) -> None:
         self._context = context
+        self._mapper_id = context.mapper_id
         self._lhs = lhs
         self._lhs_proj = lhs_proj
         self._value = value
-        self._mapper_id = mapper_id
         self._tag = tag
         self._sharding_space: Union[IndexSpace, None] = None
         self._point: Union[Point, None] = None
         self._provenance = provenance
-
-    @property
-    def library_mapper_id(self) -> int:
-        return self._mapper_id
-
-    @property
-    def legion_mapper_id(self) -> int:
-        return self._context.get_mapper_id(self._mapper_id)
 
     def set_sharding_space(self, space: IndexSpace) -> None:
         self._sharding_space = space
@@ -1283,7 +1256,7 @@ class FillLauncher:
             self._lhs.storage.region.get_root(),
             self._lhs.storage.field.field_id,
             self._value.storage,
-            self.legion_mapper_id,
+            self._mapper_id,
             self._tag,
             launch_domain.to_domain(),
             self._provenance,
@@ -1301,7 +1274,7 @@ class FillLauncher:
             self._lhs.storage.region.get_root(),
             self._lhs.storage.field.field_id,
             self._value.storage,
-            self.legion_mapper_id,
+            self._mapper_id,
             self._tag,
             self._provenance,
         )

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1657,7 +1657,7 @@ class Runtime:
                 self.legion_context,
                 self.legion_runtime,
                 redop,
-                mapper=self.core_context.get_mapper_id(0),
+                mapper=self.core_context.mapper_id,
             )
 
     def reduce_exception_future_map(
@@ -1672,7 +1672,7 @@ class Runtime:
                 self.legion_context,
                 self.legion_runtime,
                 self.core_context.get_reduction_op_id(redop),
-                mapper=self.core_context.get_mapper_id(0),
+                mapper=self.core_context.mapper_id,
                 tag=self.core_library.LEGATE_CORE_JOIN_EXCEPTION_TAG,
             )
 

--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -198,6 +198,7 @@ list(APPEND legate_core_SOURCES
   src/core/data/transform.cc
   src/core/mapping/base_mapper.cc
   src/core/mapping/core_mapper.cc
+  src/core/mapping/default_mapper.cc
   src/core/mapping/instance_manager.cc
   src/core/mapping/mapping.cc
   src/core/mapping/operation.cc

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -69,12 +69,12 @@ std::string log_mappable(const Legion::Mappable& mappable, bool prefix_only = fa
 
 }  // namespace
 
-BaseMapper::BaseMapper(std::unique_ptr<LegateMapper> legate_mapper,
+BaseMapper::BaseMapper(LegateMapper* legate_mapper,
                        Legion::Runtime* rt,
                        Legion::Machine m,
                        const LibraryContext* ctx)
   : Mapper(rt->get_mapper_runtime()),
-    legate_mapper_(std::move(legate_mapper)),
+    legate_mapper_(legate_mapper),
     legion_runtime(rt),
     machine(m),
     context(ctx),

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -69,7 +69,7 @@ std::string log_mappable(const Legion::Mappable& mappable, bool prefix_only = fa
 
 }  // namespace
 
-BaseMapper::BaseMapper(LegateMapper* legate_mapper,
+BaseMapper::BaseMapper(mapping::Mapper* legate_mapper,
                        Legion::Runtime* rt,
                        Legion::Machine m,
                        const LibraryContext* ctx)

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -40,7 +40,7 @@ enum class Strictness : bool {
 
 class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface {
  public:
-  BaseMapper(LegateMapper* legate_mapper,
+  BaseMapper(mapping::Mapper* legate_mapper,
              Legion::Runtime* rt,
              Legion::Machine machine,
              const LibraryContext* context);
@@ -344,7 +344,7 @@ class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface 
   }
 
  private:
-  LegateMapper* legate_mapper_;
+  mapping::Mapper* legate_mapper_;
 
  public:
   Legion::Runtime* const legion_runtime;

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -40,7 +40,7 @@ enum class Strictness : bool {
 
 class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface {
  public:
-  BaseMapper(std::unique_ptr<LegateMapper> legate_mapper,
+  BaseMapper(LegateMapper* legate_mapper,
              Legion::Runtime* rt,
              Legion::Machine machine,
              const LibraryContext* context);
@@ -344,7 +344,7 @@ class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface 
   }
 
  private:
-  std::unique_ptr<LegateMapper> legate_mapper_;
+  LegateMapper* legate_mapper_;
 
  public:
   Legion::Runtime* const legion_runtime;

--- a/src/core/mapping/core_mapper.cc
+++ b/src/core/mapping/core_mapper.cc
@@ -481,7 +481,7 @@ void register_legate_core_mapper(Legion::Machine machine,
 {
   // Replace all the default mappers with our custom mapper for the Legate
   // top-level task and init task
-  runtime->add_mapper(context->get_mapper_id(0),
+  runtime->add_mapper(context->get_mapper_id(),
                       new CoreMapper(runtime->get_mapper_runtime(), machine, context));
 }
 

--- a/src/core/mapping/default_mapper.cc
+++ b/src/core/mapping/default_mapper.cc
@@ -19,7 +19,8 @@
 namespace legate {
 namespace mapping {
 
-void DefaultMapper::set_machine(const MachineQueryInterface* machine) { machine_ = machine; }
+// Default mapper doesn't use the machine query interface
+void DefaultMapper::set_machine(const MachineQueryInterface* machine) {}
 
 TaskTarget DefaultMapper::task_target(const Task& task, const std::vector<TaskTarget>& options)
 {

--- a/src/core/mapping/default_mapper.cc
+++ b/src/core/mapping/default_mapper.cc
@@ -1,0 +1,42 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "core/mapping/default_mapper.h"
+
+namespace legate {
+namespace mapping {
+
+void DefaultMapper::set_machine(const MachineQueryInterface* machine) { machine_ = machine; }
+
+TaskTarget DefaultMapper::task_target(const Task& task, const std::vector<TaskTarget>& options)
+{
+  return options.front();
+}
+
+std::vector<StoreMapping> DefaultMapper::store_mappings(const Task& task,
+                                                        const std::vector<StoreTarget>& options)
+{
+  return {};
+}
+
+Scalar DefaultMapper::tunable_value(TunableID tunable_id)
+{
+  LEGATE_ABORT;
+  return Scalar(0);
+}
+
+}  // namespace mapping
+}  // namespace legate

--- a/src/core/mapping/default_mapper.h
+++ b/src/core/mapping/default_mapper.h
@@ -21,7 +21,7 @@
 namespace legate {
 namespace mapping {
 
-class DefaultMapper : public LegateMapper {
+class DefaultMapper : public Mapper {
  public:
   virtual ~DefaultMapper() {}
 

--- a/src/core/mapping/default_mapper.h
+++ b/src/core/mapping/default_mapper.h
@@ -1,0 +1,40 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "core/mapping/mapping.h"
+
+#pragma once
+
+namespace legate {
+namespace mapping {
+
+class DefaultMapper : public LegateMapper {
+ public:
+  virtual ~DefaultMapper() {}
+
+ public:
+  void set_machine(const MachineQueryInterface* machine);
+  TaskTarget task_target(const Task& task, const std::vector<TaskTarget>& options);
+  std::vector<StoreMapping> store_mappings(const Task& task,
+                                           const std::vector<StoreTarget>& options);
+  virtual Scalar tunable_value(TunableID tunable_id);
+
+ private:
+  const MachineQueryInterface* machine_;
+};
+
+}  // namespace mapping
+}  // namespace legate

--- a/src/core/mapping/default_mapper.h
+++ b/src/core/mapping/default_mapper.h
@@ -26,14 +26,11 @@ class DefaultMapper : public Mapper {
   virtual ~DefaultMapper() {}
 
  public:
-  void set_machine(const MachineQueryInterface* machine);
-  TaskTarget task_target(const Task& task, const std::vector<TaskTarget>& options);
+  void set_machine(const MachineQueryInterface* machine) override;
+  TaskTarget task_target(const Task& task, const std::vector<TaskTarget>& options) override;
   std::vector<StoreMapping> store_mappings(const Task& task,
-                                           const std::vector<StoreTarget>& options);
-  virtual Scalar tunable_value(TunableID tunable_id);
-
- private:
-  const MachineQueryInterface* machine_;
+                                           const std::vector<StoreTarget>& options) override;
+  Scalar tunable_value(TunableID tunable_id) override;
 };
 
 }  // namespace mapping

--- a/src/core/mapping/mapping.h
+++ b/src/core/mapping/mapping.h
@@ -381,9 +381,9 @@ class MachineQueryInterface {
  *
  * The APIs give Legate libraries high-level control on task and store mappings
  */
-class LegateMapper {
+class Mapper {
  public:
-  virtual ~LegateMapper() {}
+  virtual ~Mapper() {}
   /**
    * @brief Sets a machine query interface. This call gives the mapper a chance
    * to cache the machine query interface.

--- a/src/core/mapping/operation.cc
+++ b/src/core/mapping/operation.cc
@@ -15,6 +15,7 @@
  */
 
 #include "core/mapping/operation.h"
+#include "core/runtime/context.h"
 #include "core/utilities/deserializer.h"
 
 namespace legate {

--- a/src/core/mapping/operation.h
+++ b/src/core/mapping/operation.h
@@ -21,7 +21,6 @@
 
 #include "core/data/scalar.h"
 #include "core/data/transform.h"
-#include "core/runtime/context.h"
 
 /**
  * @file
@@ -29,6 +28,9 @@
  */
 
 namespace legate {
+
+class LibraryContext;
+
 namespace mapping {
 
 class RegionField {

--- a/src/core/runtime/context.cc
+++ b/src/core/runtime/context.cc
@@ -46,7 +46,7 @@ const char* InvalidTaskIdException::what() const throw() { return error_message.
 
 LibraryContext::LibraryContext(const std::string& library_name,
                                const ResourceConfig& config,
-                               std::unique_ptr<mapping::LegateMapper> mapper)
+                               std::unique_ptr<mapping::Mapper> mapper)
   : runtime_(Legion::Runtime::get_runtime()),
     library_name_(library_name),
     mapper_(std::move(mapper))

--- a/src/core/runtime/context.cc
+++ b/src/core/runtime/context.cc
@@ -44,14 +44,15 @@ InvalidTaskIdException::InvalidTaskIdException(const std::string& library_name,
 
 const char* InvalidTaskIdException::what() const throw() { return error_message.c_str(); }
 
-LibraryContext::LibraryContext(const std::string& library_name, const ResourceConfig& config)
-  : runtime_(Legion::Runtime::get_runtime()), library_name_(library_name)
+LibraryContext::LibraryContext(const std::string& library_name,
+                               const ResourceConfig& config,
+                               std::unique_ptr<mapping::LegateMapper> mapper)
+  : runtime_(Legion::Runtime::get_runtime()),
+    library_name_(library_name),
+    mapper_(std::move(mapper))
 {
   task_scope_ = ResourceIdScope(
     runtime_->generate_library_task_ids(library_name.c_str(), config.max_tasks), config.max_tasks);
-  mapper_scope_ =
-    ResourceIdScope(runtime_->generate_library_mapper_ids(library_name.c_str(), config.max_mappers),
-                    config.max_mappers);
   redop_scope_ = ResourceIdScope(
     runtime_->generate_library_reduction_ids(library_name.c_str(), config.max_reduction_ops),
     config.max_reduction_ops);
@@ -61,6 +62,15 @@ LibraryContext::LibraryContext(const std::string& library_name, const ResourceCo
   shard_scope_ = ResourceIdScope(
     runtime_->generate_library_sharding_ids(library_name.c_str(), config.max_shardings),
     config.max_shardings);
+
+  auto base_mapper =
+    new mapping::BaseMapper(mapper_.get(), runtime_, Realm::Machine::get_machine(), this);
+  Legion::Mapping::Mapper* legion_mapper = base_mapper;
+  if (Core::log_mapping_decisions)
+    legion_mapper = new Legion::Mapping::LoggingWrapper(base_mapper, &base_mapper->logger);
+
+  mapper_id_ = runtime_->generate_library_mapper_ids(library_name.c_str(), 1);
+  runtime_->add_mapper(mapper_id_, legion_mapper);
 }
 
 const std::string& LibraryContext::get_library_name() const { return library_name_; }
@@ -69,12 +79,6 @@ Legion::TaskID LibraryContext::get_task_id(int64_t local_task_id) const
 {
   assert(task_scope_.valid());
   return task_scope_.translate(local_task_id);
-}
-
-Legion::MapperID LibraryContext::get_mapper_id(int64_t local_mapper_id) const
-{
-  assert(mapper_scope_.valid());
-  return mapper_scope_.translate(local_mapper_id);
 }
 
 Legion::ReductionOpID LibraryContext::get_reduction_op_id(int64_t local_redop_id) const
@@ -105,12 +109,6 @@ int64_t LibraryContext::get_local_task_id(Legion::TaskID task_id) const
   return task_scope_.invert(task_id);
 }
 
-int64_t LibraryContext::get_local_mapper_id(Legion::MapperID mapper_id) const
-{
-  assert(mapper_scope_.valid());
-  return mapper_scope_.invert(mapper_id);
-}
-
 int64_t LibraryContext::get_local_reduction_op_id(Legion::ReductionOpID redop_id) const
 {
   assert(redop_scope_.valid());
@@ -138,11 +136,6 @@ bool LibraryContext::valid_task_id(Legion::TaskID task_id) const
   return task_scope_.in_scope(task_id);
 }
 
-bool LibraryContext::valid_mapper_id(Legion::MapperID mapper_id) const
-{
-  return mapper_scope_.in_scope(mapper_id);
-}
-
 bool LibraryContext::valid_reduction_op_id(Legion::ReductionOpID redop_id) const
 {
   return redop_scope_.in_scope(redop_id);
@@ -156,17 +149,6 @@ bool LibraryContext::valid_projection_id(Legion::ProjectionID proj_id) const
 bool LibraryContext::valid_sharding_id(Legion::ShardingID shard_id) const
 {
   return shard_scope_.in_scope(shard_id);
-}
-
-void LibraryContext::register_mapper(std::unique_ptr<mapping::LegateMapper> mapper,
-                                     int64_t local_mapper_id) const
-{
-  auto base_mapper = new legate::mapping::BaseMapper(
-    std::move(mapper), runtime_, Realm::Machine::get_machine(), this);
-  Legion::Mapping::Mapper* legion_mapper = base_mapper;
-  if (Core::log_mapping_decisions)
-    legion_mapper = new Legion::Mapping::LoggingWrapper(base_mapper, &base_mapper->logger);
-  runtime_->add_mapper(get_mapper_id(local_mapper_id), legion_mapper);
 }
 
 void LibraryContext::register_task(int64_t local_task_id, std::unique_ptr<TaskInfo> task_info)

--- a/src/core/runtime/context.h
+++ b/src/core/runtime/context.h
@@ -62,10 +62,6 @@ struct ResourceConfig {
    */
   int64_t max_tasks{1024};
   /**
-   * @brief Maximum number of mappers that the library can register
-   */
-  int64_t max_mappers{1};
-  /**
    * @brief Maximum number of custom reduction operators that the library can register
    */
   int64_t max_reduction_ops{0};
@@ -122,7 +118,7 @@ class LibraryContext {
    */
   LibraryContext(const std::string& library_name,
                  const ResourceConfig& config,
-                 std::unique_ptr<mapping::LegateMapper> mapper);
+                 std::unique_ptr<mapping::Mapper> mapper);
 
  public:
   LibraryContext(const LibraryContext&) = delete;
@@ -224,7 +220,7 @@ class LibraryContext {
 
  private:
   Legion::MapperID mapper_id_;
-  std::unique_ptr<mapping::LegateMapper> mapper_;
+  std::unique_ptr<mapping::Mapper> mapper_;
   std::unordered_map<int64_t, std::unique_ptr<TaskInfo>> tasks_;
 };
 

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -163,7 +163,7 @@ LibraryContext* Runtime::find_library(const std::string& library_name,
 
 LibraryContext* Runtime::create_library(const std::string& library_name,
                                         const ResourceConfig& config,
-                                        std::unique_ptr<mapping::LegateMapper> mapper)
+                                        std::unique_ptr<mapping::Mapper> mapper)
 {
   if (libraries_.find(library_name) != libraries_.end()) {
     log_legate.error("Library %s already exists", library_name.c_str());

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -29,7 +29,7 @@ namespace legate {
 
 namespace mapping {
 
-class LegateMapper;
+class Mapper;
 
 }  // namespace mapping
 
@@ -81,8 +81,8 @@ class Runtime {
  public:
   LibraryContext* find_library(const std::string& library_name, bool can_fail = false) const;
   LibraryContext* create_library(const std::string& library_name,
-                                 const ResourceConfig& config                  = ResourceConfig{},
-                                 std::unique_ptr<mapping::LegateMapper> mapper = nullptr);
+                                 const ResourceConfig& config            = ResourceConfig{},
+                                 std::unique_ptr<mapping::Mapper> mapper = nullptr);
 
  public:
   static Runtime* get_runtime();

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -27,6 +27,12 @@
 
 namespace legate {
 
+namespace mapping {
+
+class LegateMapper;
+
+}  // namespace mapping
+
 extern uint32_t extract_env(const char* env_name,
                             const uint32_t default_value,
                             const uint32_t test_value);
@@ -75,7 +81,8 @@ class Runtime {
  public:
   LibraryContext* find_library(const std::string& library_name, bool can_fail = false) const;
   LibraryContext* create_library(const std::string& library_name,
-                                 const ResourceConfig& config = ResourceConfig{});
+                                 const ResourceConfig& config                  = ResourceConfig{},
+                                 std::unique_ptr<mapping::LegateMapper> mapper = nullptr);
 
  public:
   static Runtime* get_runtime();

--- a/tests/integration/registry/src/library.cc
+++ b/tests/integration/registry/src/library.cc
@@ -20,41 +20,6 @@
 
 namespace rg {
 
-class Mapper : public legate::mapping::LegateMapper {
- public:
-  Mapper() {}
-
- private:
-  Mapper(const Mapper& rhs)            = delete;
-  Mapper& operator=(const Mapper& rhs) = delete;
-
-  // Legate mapping functions
- public:
-  void set_machine(const legate::mapping::MachineQueryInterface* machine) override
-  {
-    machine_ = machine;
-  }
-
-  legate::mapping::TaskTarget task_target(
-    const legate::mapping::Task& task,
-    const std::vector<legate::mapping::TaskTarget>& options) override
-  {
-    return options.front();
-  }
-
-  std::vector<legate::mapping::StoreMapping> store_mappings(
-    const legate::mapping::Task& task,
-    const std::vector<legate::mapping::StoreTarget>& options) override
-  {
-    return {};
-  }
-
-  legate::Scalar tunable_value(legate::TunableID tunable_id) override { return 0; }
-
- private:
-  const legate::mapping::MachineQueryInterface* machine_;
-};
-
 static const char* const library_name = "registry";
 
 Legion::Logger log_registry(library_name);
@@ -73,8 +38,6 @@ void registration_callback()
   Registry::get_registrar().register_all_tasks(*context);
   // Immediate task registration
   WorldTask::register_variants(*context);
-
-  context->register_mapper(std::make_unique<Mapper>(), 0);
 }
 
 }  // namespace rg


### PR DESCRIPTION
Per the internal discussion, this PR implements the following changes to the Legate mapper:

- Libraries can now have only one mapper and should provide their mappers at the registration time.
- When no mapper is given, the default mapper will be used for the library.
- Mapper id parameters have been removed from the APIs where they were expected.

This PR builds on #675 and so it currently inherits all of the changes. I will rebase this PR once #675 is merged.

