### PR TITLE
use legate_dir as basis for non-editable install paths

### DIFF
--- a/legate/util/fs.py
+++ b/legate/util/fs.py
@@ -173,8 +173,8 @@ def get_legate_paths() -> LegatePaths:
         return LegatePaths(
             legate_dir=legate_dir,
             legate_build_dir=legate_build_dir,
-            bind_sh_path=Path(sys.argv[0]).parent / "bind.sh",
-            legate_lib_path=Path(sys.argv[0]).parents[1] / "lib",
+            bind_sh_path=legate_dir.parents[2] / "bin" / "bind.sh",
+            legate_lib_path=legate_dir.parents[2] / "lib",
         )
 
     cmake_cache_txt = legate_build_dir.joinpath("CMakeCache.txt")
@@ -269,7 +269,7 @@ def get_legion_paths(legate_paths: LegatePaths) -> LegionPaths:
 
     # If no local build dir found, assume legate installed into the python env
     if legate_build_dir is None:
-        return installed_legion_paths(Path(sys.argv[0]).parents[1])
+        return installed_legion_paths(legate_paths.legate_dir.parents[2])
 
     # If a legate build dir was found, read `Legion_SOURCE_DIR` and
     # `Legion_BINARY_DIR` from in CMakeCache.txt, return paths into the source


### PR DESCRIPTION
When using plain Python invocation, startup fails due to `sys.argv[0]` not being the `legate` executable path. 
```
> python -c "import sys; print(sys.argv[0]); import legate.core"
-c
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/core/__init__.py", line 34, in <module>
    os.environ.update(driver.env)
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/driver/driver.py", line 84, in env
    return self.launcher.env
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/driver/launcher.py", line 136, in env
    self._env, self._custom_env_vars = self._compute_env()
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/driver/launcher.py", line 168, in _compute_env
    if system.legion_paths.legion_module is not None:
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/functools.py", line 993, in __get__
    val = self.func(instance)
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/util/system.py", line 55, in legion_paths
    return get_legion_paths(self.legate_paths)
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/functools.py", line 993, in __get__
    val = self.func(instance)
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/util/system.py", line 44, in legate_paths
    return get_legate_paths()
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/site-packages/legate/util/fs.py", line 177, in get_legate_paths
    legate_lib_path=Path(sys.argv[0]).parents[1] / "lib",
  File "/raid/wonchanl/miniconda3/envs/registry-env/lib/python3.9/pathlib.py", line 645, in __getitem__
    raise IndexError(idx)
IndexError: 1
```

@magnatelee reports this patch fixing things for him locally, as it seems to for me. @trxcllnt are there any gotchas here?  I'm not sure if there are specific cases where this would run into trouble.

Edit: note, `cd` out of repo top to try things, another issue with `proj/proj` layout masking / causing problems. 