### PR TITLE
Specify C++ standard when building cython sources

### DIFF
--- a/legate/core/_lib/CMakeLists.txt
+++ b/legate/core/_lib/CMakeLists.txt
@@ -23,3 +23,7 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
 )
+
+foreach(target IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
+  target_compile_features(${target} PRIVATE cxx_std_17)
+endforeach()


### PR DESCRIPTION
Fix by @trxcllnt.

Without this addition there would be no `-std=` flag passed to the compiler that's building the cython files, and certain compilers (like Apple clang) fall back to C++98 mode in that case.

This is solving the compilation issue, but apparently the more general solution is for libraries to advertise the minimum C++ standard version that is required by any code in their public headers. For Legion that would be C++11, for Legate it might be C++17, or something lower, depending on what features we use in our public headers (e.g. we use `enable_if_t` in `deserializer.h`, which is C++14 feature, but I think that's not a public header).


