### PR TITLE
`LibraryContext*` everywehere

### DIFF
--- a/cmake/legate_helper_functions.cmake
+++ b/cmake/legate_helper_functions.cmake
@@ -343,7 +343,7 @@ void registration_callback()
 {
   auto context = legate::Runtime::get_runtime()->create_library(library_name);
 
-  Registry::get_registrar().register_all_tasks(*context);
+  Registry::get_registrar().register_all_tasks(context);
 }
 
 }  // namespace @target@

--- a/src/core/comm/comm.cc
+++ b/src/core/comm/comm.cc
@@ -25,7 +25,7 @@ namespace comm {
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context)
+                    const LibraryContext* context)
 {
 #ifdef LEGATE_USE_CUDA
   nccl::register_tasks(machine, runtime, context);

--- a/src/core/comm/comm.h
+++ b/src/core/comm/comm.h
@@ -24,7 +24,7 @@ namespace comm {
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context);
+                    const LibraryContext* context);
 
 }  // namespace comm
 }  // namespace legate

--- a/src/core/comm/comm_cpu.cc
+++ b/src/core/comm/comm_cpu.cc
@@ -91,24 +91,25 @@ static void finalize_cpucoll(const Legion::Task* task,
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context)
+                    const LibraryContext* context)
 {
   const auto& command_args = Legion::Runtime::get_input_args();
   coll::collInit(command_args.argc, command_args.argv);
 
-  auto init_cpucoll_mapping_task_id = context.get_task_id(LEGATE_CORE_INIT_CPUCOLL_MAPPING_TASK_ID);
+  auto init_cpucoll_mapping_task_id =
+    context->get_task_id(LEGATE_CORE_INIT_CPUCOLL_MAPPING_TASK_ID);
   const char* init_cpucoll_mapping_task_name = "core::comm::cpu::init_mapping";
   runtime->attach_name(init_cpucoll_mapping_task_id,
                        init_cpucoll_mapping_task_name,
                        false /*mutable*/,
                        true /*local only*/);
 
-  auto init_cpucoll_task_id          = context.get_task_id(LEGATE_CORE_INIT_CPUCOLL_TASK_ID);
+  auto init_cpucoll_task_id          = context->get_task_id(LEGATE_CORE_INIT_CPUCOLL_TASK_ID);
   const char* init_cpucoll_task_name = "core::comm::cpu::init";
   runtime->attach_name(
     init_cpucoll_task_id, init_cpucoll_task_name, false /*mutable*/, true /*local only*/);
 
-  auto finalize_cpucoll_task_id = context.get_task_id(LEGATE_CORE_FINALIZE_CPUCOLL_TASK_ID);
+  auto finalize_cpucoll_task_id = context->get_task_id(LEGATE_CORE_FINALIZE_CPUCOLL_TASK_ID);
   const char* finalize_cpucoll_task_name = "core::comm::cpu::finalize";
   runtime->attach_name(
     finalize_cpucoll_task_id, finalize_cpucoll_task_name, false /*mutable*/, true /*local only*/);

--- a/src/core/comm/comm_cpu.h
+++ b/src/core/comm/comm_cpu.h
@@ -25,7 +25,7 @@ namespace cpu {
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context);
+                    const LibraryContext* context);
 
 }  // namespace cpu
 }  // namespace comm

--- a/src/core/comm/comm_nccl.cu
+++ b/src/core/comm/comm_nccl.cu
@@ -124,19 +124,19 @@ static void finalize_nccl(const Legion::Task* task,
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context)
+                    const LibraryContext* context)
 {
-  auto init_nccl_id_task_id          = context.get_task_id(LEGATE_CORE_INIT_NCCL_ID_TASK_ID);
+  auto init_nccl_id_task_id          = context->get_task_id(LEGATE_CORE_INIT_NCCL_ID_TASK_ID);
   const char* init_nccl_id_task_name = "core::comm::nccl::init_id";
   runtime->attach_name(
     init_nccl_id_task_id, init_nccl_id_task_name, false /*mutable*/, true /*local only*/);
 
-  auto init_nccl_task_id          = context.get_task_id(LEGATE_CORE_INIT_NCCL_TASK_ID);
+  auto init_nccl_task_id          = context->get_task_id(LEGATE_CORE_INIT_NCCL_TASK_ID);
   const char* init_nccl_task_name = "core::comm::nccl::init";
   runtime->attach_name(
     init_nccl_task_id, init_nccl_task_name, false /*mutable*/, true /*local only*/);
 
-  auto finalize_nccl_task_id          = context.get_task_id(LEGATE_CORE_FINALIZE_NCCL_TASK_ID);
+  auto finalize_nccl_task_id          = context->get_task_id(LEGATE_CORE_FINALIZE_NCCL_TASK_ID);
   const char* finalize_nccl_task_name = "core::comm::nccl::finalize";
   runtime->attach_name(
     finalize_nccl_task_id, finalize_nccl_task_name, false /*mutable*/, true /*local only*/);

--- a/src/core/comm/comm_nccl.h
+++ b/src/core/comm/comm_nccl.h
@@ -25,7 +25,7 @@ namespace nccl {
 
 void register_tasks(Legion::Machine machine,
                     Legion::Runtime* runtime,
-                    const LibraryContext& context);
+                    const LibraryContext* context);
 
 bool needs_barrier();
 

--- a/src/core/runtime/projection.cc
+++ b/src/core/runtime/projection.cc
@@ -239,9 +239,9 @@ struct create_affine_functor_fn {
 };
 
 void register_legate_core_projection_functors(Legion::Runtime* runtime,
-                                              const LibraryContext& context)
+                                              const LibraryContext* context)
 {
-  auto proj_id = context.get_projection_id(LEGATE_CORE_DELINEARIZE_PROJ_ID);
+  auto proj_id = context->get_projection_id(LEGATE_CORE_DELINEARIZE_PROJ_ID);
   auto functor = new DelinearizationFunctor(runtime);
   log_legate.debug("Register delinearizing functor: functor: %p, id: %d", functor, proj_id);
   runtime->register_projection_functor(proj_id, functor, true /*silence warnings*/);

--- a/src/core/runtime/projection.h
+++ b/src/core/runtime/projection.h
@@ -51,7 +51,7 @@ class LegateProjectionFunctor : public Legion::ProjectionFunctor {
 };
 
 void register_legate_core_projection_functors(Legion::Runtime* runtime,
-                                              const LibraryContext& context);
+                                              const LibraryContext* context);
 
 LegateProjectionFunctor* find_legate_projection_functor(Legion::ProjectionID proj_id,
                                                         bool allow_missing = false);

--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -186,9 +186,9 @@ LibraryContext* Runtime::create_library(const std::string& library_name,
 
 void register_legate_core_tasks(Legion::Machine machine,
                                 Legion::Runtime* runtime,
-                                const LibraryContext& context)
+                                const LibraryContext* context)
 {
-  auto extract_scalar_task_id          = context.get_task_id(LEGATE_CORE_EXTRACT_SCALAR_TASK_ID);
+  auto extract_scalar_task_id          = context->get_task_id(LEGATE_CORE_EXTRACT_SCALAR_TASK_ID);
   const char* extract_scalar_task_name = "core::extract_scalar";
   runtime->attach_name(
     extract_scalar_task_id, extract_scalar_task_name, false /*mutable*/, true /*local only*/);
@@ -219,7 +219,7 @@ void register_legate_core_tasks(Legion::Machine machine,
 }
 
 extern void register_exception_reduction_op(Legion::Runtime* runtime,
-                                            const LibraryContext& context);
+                                            const LibraryContext* context);
 
 /*static*/ void core_registration_callback(Legion::Machine machine,
                                            Legion::Runtime* runtime,
@@ -233,15 +233,15 @@ extern void register_exception_reduction_op(Legion::Runtime* runtime,
   config.max_reduction_ops = LEGATE_CORE_MAX_REDUCTION_OP_ID;
   auto core_lib            = Runtime::get_runtime()->create_library(core_library_name, config);
 
-  register_legate_core_tasks(machine, runtime, *core_lib);
+  register_legate_core_tasks(machine, runtime, core_lib);
 
   register_legate_core_mapper(machine, runtime, core_lib);
 
-  register_exception_reduction_op(runtime, *core_lib);
+  register_exception_reduction_op(runtime, core_lib);
 
-  register_legate_core_projection_functors(runtime, *core_lib);
+  register_legate_core_projection_functors(runtime, core_lib);
 
-  register_legate_core_sharding_functors(runtime, *core_lib);
+  register_legate_core_sharding_functors(runtime, core_lib);
 
   auto fut = runtime->select_tunable_value(
     Legion::Runtime::get_context(), LEGATE_CORE_TUNABLE_HAS_SOCKET_MEM, core_lib->get_mapper_id());

--- a/src/core/runtime/shard.cc
+++ b/src/core/runtime/shard.cc
@@ -82,19 +82,19 @@ class LinearizingShardingFunctor : public Legion::ShardingFunctor {
   }
 };
 
-void register_legate_core_sharding_functors(Legion::Runtime* runtime, const LibraryContext& context)
+void register_legate_core_sharding_functors(Legion::Runtime* runtime, const LibraryContext* context)
 {
-  runtime->register_sharding_functor(context.get_sharding_id(LEGATE_CORE_TOPLEVEL_TASK_SHARD_ID),
+  runtime->register_sharding_functor(context->get_sharding_id(LEGATE_CORE_TOPLEVEL_TASK_SHARD_ID),
                                      new ToplevelTaskShardingFunctor(),
                                      true /*silence warnings*/);
 
-  auto sharding_id = context.get_sharding_id(LEGATE_CORE_LINEARIZE_SHARD_ID);
+  auto sharding_id = context->get_sharding_id(LEGATE_CORE_LINEARIZE_SHARD_ID);
   runtime->register_sharding_functor(
     sharding_id, new LinearizingShardingFunctor(), true /*silence warnings*/);
   // Use linearizing functor for identity projections
   functor_id_table[0] = sharding_id;
   // and for the delinearizing projection
-  functor_id_table[context.get_projection_id(LEGATE_CORE_DELINEARIZE_PROJ_ID)] = sharding_id;
+  functor_id_table[context->get_projection_id(LEGATE_CORE_DELINEARIZE_PROJ_ID)] = sharding_id;
 }
 
 class LegateShardingFunctor : public Legion::ShardingFunctor {

--- a/src/core/runtime/shard.h
+++ b/src/core/runtime/shard.h
@@ -23,7 +23,7 @@
 namespace legate {
 
 void register_legate_core_sharding_functors(Legion::Runtime* runtime,
-                                            const LibraryContext& context);
+                                            const LibraryContext* context);
 
 Legion::ShardingID find_sharding_functor_by_projection_functor(Legion::ProjectionID proj_id);
 

--- a/src/core/task/registrar.cc
+++ b/src/core/task/registrar.cc
@@ -27,10 +27,10 @@ void TaskRegistrar::record_task(int64_t local_task_id, std::unique_ptr<TaskInfo>
   pending_task_infos_.push_back(std::make_pair(local_task_id, std::move(task_info)));
 }
 
-void TaskRegistrar::register_all_tasks(LibraryContext& context)
+void TaskRegistrar::register_all_tasks(LibraryContext* context)
 {
   for (auto& [local_task_id, task_info] : pending_task_infos_)
-    context.register_task(local_task_id, std::move(task_info));
+    context->register_task(local_task_id, std::move(task_info));
   pending_task_infos_.clear();
 }
 

--- a/src/core/task/registrar.h
+++ b/src/core/task/registrar.h
@@ -85,7 +85,7 @@ class TaskRegistrar {
    *
    * @param context Context of the library that owns this registrar
    */
-  void register_all_tasks(LibraryContext& context);
+  void register_all_tasks(LibraryContext* context);
 
  private:
   std::vector<std::pair<int64_t, std::unique_ptr<TaskInfo>>> pending_task_infos_;

--- a/src/core/task/return.cc
+++ b/src/core/task/return.cc
@@ -323,9 +323,9 @@ void ReturnValues::finalize(Legion::Context legion_context) const
   return_buffer.finalize(legion_context);
 }
 
-void register_exception_reduction_op(Legion::Runtime* runtime, const LibraryContext& context)
+void register_exception_reduction_op(Legion::Runtime* runtime, const LibraryContext* context)
 {
-  auto redop_id = context.get_reduction_op_id(LEGATE_CORE_JOIN_EXCEPTION_OP);
+  auto redop_id = context->get_reduction_op_id(LEGATE_CORE_JOIN_EXCEPTION_OP);
   auto* redop   = Realm::ReductionOpUntyped::create_reduction_op<JoinReturnedException>();
   Legion::Runtime::register_reduction_op(
     redop_id, redop, returned_exception_init, returned_exception_fold);

--- a/src/core/task/task.h
+++ b/src/core/task/task.h
@@ -80,7 +80,7 @@ struct LegateTask {
    * use the default set of options
    */
   static void register_variants(
-    LibraryContext& context, const std::map<LegateVariantCode, VariantOptions>& all_options = {});
+    LibraryContext* context, const std::map<LegateVariantCode, VariantOptions>& all_options = {});
 
  private:
   template <typename, template <typename...> typename, bool>

--- a/src/core/task/task.inl
+++ b/src/core/task/task.inl
@@ -47,10 +47,10 @@ template <typename T>
 
 template <typename T>
 /*static*/ void LegateTask<T>::register_variants(
-  LibraryContext& context, const std::map<LegateVariantCode, VariantOptions>& all_options)
+  LibraryContext* context, const std::map<LegateVariantCode, VariantOptions>& all_options)
 {
   auto task_info = create_task_info(all_options);
-  context.register_task(T::TASK_ID, std::move(task_info));
+  context->register_task(T::TASK_ID, std::move(task_info));
 }
 
 template <typename T>

--- a/tests/integration/registry/src/library.cc
+++ b/tests/integration/registry/src/library.cc
@@ -35,9 +35,9 @@ void registration_callback()
   auto context = legate::Runtime::get_runtime()->create_library(library_name);
 
   // Task registration via a registrar
-  Registry::get_registrar().register_all_tasks(*context);
+  Registry::get_registrar().register_all_tasks(context);
   // Immediate task registration
-  WorldTask::register_variants(*context);
+  WorldTask::register_variants(context);
 }
 
 }  // namespace rg


### PR DESCRIPTION
Some APIs take a `LibraryContext&`, whereas others that are added recently need a `LibraryContext*`. This PR is to make the APIs consistently use `LibraryContext*`.