### PR TITLE
Make `legate::is_floating_point` hold for float16

### DIFF
--- a/src/core/utilities/type_traits.h
+++ b/src/core/utilities/type_traits.h
@@ -200,6 +200,11 @@ struct is_floating_point {
   static constexpr bool value = std::is_floating_point<legate_type_of<CODE>>::value;
 };
 
+template <>
+struct is_floating_point<LegateTypeCode::HALF_LT> {
+  static constexpr bool value = true;
+};
+
 /**
  * @ingroup util
  * @brief A predicate that holds if the type code is of a complex type


### PR DESCRIPTION
`legate::is_float_point` hasn't been returning `true` on `LegateTypeCode::HALF_LT`, even though it should. This PR fixes that issue.