### PR TITLE
Add a missing include to cmake for legate helper functions

### DIFF
--- a/legate_core_cpp.cmake
+++ b/legate_core_cpp.cmake
@@ -501,6 +501,7 @@ rapids_export(
   LANGUAGES ${ENABLED_LANGUAES}
 )
 option(legate_core_EXAMPLE_BUILD_TESTS OFF)
+include(cmake/legate_helper_functions.cmake)
 if (legate_core_EXAMPLE_BUILD_TESTS)
   set(legate_core_ROOT ${CMAKE_CURRENT_BINARY_DIR})
   add_subdirectory(examples)


### PR DESCRIPTION
This include is only necessary when legate is built as a submodule.