### PR TITLE
Support PYTHONFAULTHANDLER

### DIFF
--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -257,7 +257,7 @@ class Launcher:
             env["LEGION_FREEZE_ON_ERROR"] = "1"
 
         # Debugging options
-        if system.env.get("PYTHONFAULTHANDLER", None) != "1":
+        if system.env.get("PYTHONFAULTHANDLER", "") != "":
             env["REALM_BACKTRACE"] = "1"
 
         if config.debugging.gasnet_trace:

--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -257,7 +257,7 @@ class Launcher:
             env["LEGION_FREEZE_ON_ERROR"] = "1"
 
         # Debugging options
-        if system.env.get("PYTHONFAULTHANDLER", "") != "":
+        if system.env.get("PYTHONFAULTHANDLER", "") == "":
             env["REALM_BACKTRACE"] = "1"
 
         if config.debugging.gasnet_trace:

--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -257,7 +257,8 @@ class Launcher:
             env["LEGION_FREEZE_ON_ERROR"] = "1"
 
         # Debugging options
-        env["REALM_BACKTRACE"] = "1"
+        if system.env.get("PYTHONFAULTHANDLER", None) != "1":
+            env["REALM_BACKTRACE"] = "1"
 
         if config.debugging.gasnet_trace:
             env["GASNET_TRACEFILE"] = str(

--- a/tests/unit/legate/driver/test_launcher.py
+++ b/tests/unit/legate/driver/test_launcher.py
@@ -340,6 +340,21 @@ class TestLauncherEnv:
 
         assert env["REALM_BACKTRACE"] == "1"
 
+    def test_realm_backtrace_with_faulthandler(
+        self,
+        genconfig: GenConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        launch: LauncherType,
+    ) -> None:
+        monkeypatch.setenv("PYTHONFAULTHANDLER", "1")
+
+        system = System()
+        config = genconfig(["--launcher", launch])
+
+        env = m.Launcher.create(config, system).env
+
+        assert "REALM_BACKTRACE" not in env
+
     def test_gasnet_trace(
         self, genconfig: GenConfig, launch: LauncherType
     ) -> None:


### PR DESCRIPTION
This PR conditions the setting of `REALM_BACKTRACE` depending on whether `PYTHONFAULTHANDLER` is already set. 

@marcinz if we want to set `PYTHONFAULTHANDLER=1` but *only* for the "Eager" job, where can that change be made?