### PR TITLE
special-case tester reporting of LEGATE_CONFIG

### DIFF
--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -279,6 +279,13 @@ class TestStage(Protocol):
     def _env(self, config: Config, system: TestSystem) -> EnvDict:
         env = dict(config.env)
         env.update(self.env(config, system))
+
+        # special case for LEGATE_CONFIG -- if users have specified this on
+        # their own we still want to see the value since it will affect the
+        # test invocation directly.
+        if "LEGATE_CONFIG" in system.env:
+            env["LEGATE_CONFIG"] = system.env["LEGATE_CONFIG"]
+
         return env
 
     def _init(self, config: Config, system: TestSystem) -> None:

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -31,6 +31,12 @@ from ..util.types import EnvDict
 __all__ = ("TestSystem",)
 
 
+def _quote(s: str) -> str:
+    if " " in s:
+        return repr(s)
+    return s
+
+
 @dataclass
 class ProcessResult:
     #: The command invovation, including relevant environment vars
@@ -99,7 +105,7 @@ class TestSystem(System):
         env = env or {}
 
         envstr = (
-            " ".join(f"{k}={v}" for k, v in env.items())
+            " ".join(f"{k}={_quote(v)}" for k, v in env.items())
             + min(len(env), 1) * " "
         )
 

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -65,6 +65,7 @@ class TestSystem(System):
         *,
         dry_run: bool = False,
     ) -> None:
+        super().__init__()
         self.manager = multiprocessing.Manager()
         self.dry_run: bool = dry_run
 


### PR DESCRIPTION
This PR makes the tester include any previously set `LEGATE_CONFIG` in the verbose tester output. 