### PR TITLE
Driver error if legate was compiled w/o required options

### DIFF
--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -237,6 +237,12 @@ def cmd_gpus(
 ) -> CommandPart:
     gpus = config.core.gpus
 
+    if gpus > 0 and not install_info.use_cuda:
+        raise RuntimeError(
+            "--gpus was requested, but this build does not have CUDA "
+            "support enabled"
+        )
+
     # Make sure that we skip busy GPUs
     return () if gpus == 0 else ("-ll:gpu", str(gpus), "-cuda:skipbusy")
 
@@ -247,6 +253,12 @@ def cmd_openmp(
     openmp = config.core.openmp
     ompthreads = config.core.ompthreads
     numamem = config.memory.numamem
+
+    if openmp > 0 and not install_info.use_openmp:
+        raise RuntimeError(
+            "--omps was requested, but this build does not have OpenMP "
+            "support enabled"
+        )
 
     if openmp == 0:
         return ()

--- a/legate/install_info.py.in
+++ b/legate/install_info.py.in
@@ -49,6 +49,7 @@ conduit: str = "@GASNet_CONDUIT@"
 
 build_type: str = "@CMAKE_BUILD_TYPE@"
 
+# this is to support simpler templating from cmake
 ON, OFF = True, False
 
 use_cuda: bool = @Legion_USE_CUDA@

--- a/legate/install_info.py.in
+++ b/legate/install_info.py.in
@@ -49,7 +49,7 @@ conduit: str = "@GASNet_CONDUIT@"
 
 build_type: str = "@CMAKE_BUILD_TYPE@"
 
-# this is to support simpler templating from cmake
+# this is to support simpler templating on the cmake side
 ON, OFF = True, False
 
 use_cuda: bool = @Legion_USE_CUDA@


### PR DESCRIPTION
This PR will make the driver error out with an informative RuntimeError if options like `--gpus` are requested, but the required support is not compiled into the build. 