### PR TITLE
Add ops-bot config file

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,4 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+copy_prs: true


### PR DESCRIPTION
Setting up config files to for the rapids ops bot so we can leverage their CI resources in the short-term.

This change only enables the PR copying behavior so that we can submit CI requests from the context of the repo itself. It does **not** enable any workflows against the CI machines yet. Branches are automatically deleted when the associated PR is closed.