### PR TITLE
Force other packages in env to use OpenBLAS as their BLAS backend

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -139,6 +139,7 @@ class RuntimeConfig(SectionConfig):
             "cffi",
             "llvm-openmp",
             "numpy>=1.22",
+            "libblas=*=*openblas*",
             "openblas=*=*openmp*",
             "opt_einsum",
             "pyarrow>=5",


### PR DESCRIPTION
Without this, the NumPy packages will side-load libcblas from netlib or MKL. These BLAS alternatives will then be included at runtime in addition to OpenBLAS, and can "shadow" the function implementations that we're trying to use from OpenBLAS.