### PR TITLE
Fix off-by-one errors in resource scoping code

### DIFF
--- a/legate/core/machine.py
+++ b/legate/core/machine.py
@@ -137,7 +137,7 @@ class ProcessorRange:
         )
 
     def __repr__(self) -> str:
-        if self.high < self.low:
+        if self.empty:
             return "<empty>"
         return f"[{self.low}, {self.high}] ({self.per_node_count} per node)"
 
@@ -247,7 +247,7 @@ class Machine:
             return ProcessorRange.create(
                 kind,
                 low=0,
-                high=num_procs - 1,
+                high=num_procs,
                 per_node_count=num_procs // num_nodes,
             )
 

--- a/src/core/mapping/machine.cc
+++ b/src/core/mapping/machine.cc
@@ -250,7 +250,7 @@ LocalProcessorRange Machine::slice(TaskTarget target,
 
   uint32_t num_local_procs = local_procs.size();
   uint32_t my_low          = num_local_procs * local_node;
-  ProcessorRange my_range(my_low, my_low + num_local_procs - 1, global_range.per_node_count);
+  ProcessorRange my_range(my_low, my_low + num_local_procs, global_range.per_node_count);
 
   auto slice = global_range & my_range;
   if (slice.empty()) {


### PR DESCRIPTION
These were causing single-GPU runs to fail, so they were easy to find. I didn't check other configurations, there might still be some lurking.