### PR TITLE
Unify env test flags

### DIFF
--- a/legate/tester/stages/_linux/cpu.py
+++ b/legate/tester/stages/_linux/cpu.py
@@ -18,13 +18,7 @@ from itertools import chain
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import (
-    CUNUMERIC_TEST_ENV,
-    UNPIN_ENV,
-    Shard,
-    StageSpec,
-    adjust_workers,
-)
+from ..util import UNPIN_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -54,9 +48,7 @@ class CPU(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        env = {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
-        env.update(CUNUMERIC_TEST_ENV)
-        return env
+        return {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         args = [

--- a/legate/tester/stages/_linux/gpu.py
+++ b/legate/tester/stages/_linux/gpu.py
@@ -18,7 +18,7 @@ import time
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import CUNUMERIC_TEST_ENV, Shard, StageSpec, adjust_workers
+from ..util import Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -50,7 +50,7 @@ class GPU(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        return dict(CUNUMERIC_TEST_ENV)
+        return {}
 
     def delay(self, shard: Shard, config: Config, system: TestSystem) -> None:
         time.sleep(config.gpu_delay / 1000)

--- a/legate/tester/stages/_linux/omp.py
+++ b/legate/tester/stages/_linux/omp.py
@@ -18,13 +18,7 @@ from itertools import chain
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import (
-    CUNUMERIC_TEST_ENV,
-    UNPIN_ENV,
-    Shard,
-    StageSpec,
-    adjust_workers,
-)
+from ..util import UNPIN_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -54,9 +48,7 @@ class OMP(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        env = {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
-        env.update(CUNUMERIC_TEST_ENV)
-        return env
+        return {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         args = [

--- a/legate/tester/stages/_osx/cpu.py
+++ b/legate/tester/stages/_osx/cpu.py
@@ -17,13 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import (
-    CUNUMERIC_TEST_ENV,
-    UNPIN_ENV,
-    Shard,
-    StageSpec,
-    adjust_workers,
-)
+from ..util import UNPIN_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -53,9 +47,7 @@ class CPU(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        env = dict(UNPIN_ENV)
-        env.update(CUNUMERIC_TEST_ENV)
-        return env
+        return dict(UNPIN_ENV)
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         return ["--cpus", str(config.cpus)]

--- a/legate/tester/stages/_osx/gpu.py
+++ b/legate/tester/stages/_osx/gpu.py
@@ -18,7 +18,7 @@ import time
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import CUNUMERIC_TEST_ENV, UNPIN_ENV, Shard
+from ..util import UNPIN_ENV, Shard
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -48,9 +48,7 @@ class GPU(TestStage):
         raise RuntimeError("GPU test are not supported on OSX")
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        env = dict(UNPIN_ENV)
-        env.update(CUNUMERIC_TEST_ENV)
-        return env
+        return dict(UNPIN_ENV)
 
     def delay(self, shard: Shard, config: Config, system: TestSystem) -> None:
         time.sleep(config.gpu_delay / 1000)

--- a/legate/tester/stages/_osx/omp.py
+++ b/legate/tester/stages/_osx/omp.py
@@ -17,13 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..test_stage import TestStage
-from ..util import (
-    CUNUMERIC_TEST_ENV,
-    UNPIN_ENV,
-    Shard,
-    StageSpec,
-    adjust_workers,
-)
+from ..util import UNPIN_ENV, Shard, StageSpec, adjust_workers
 
 if TYPE_CHECKING:
     from ....util.types import ArgList, EnvDict
@@ -53,9 +47,7 @@ class OMP(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: TestSystem) -> EnvDict:
-        env = dict(UNPIN_ENV)
-        env.update(CUNUMERIC_TEST_ENV)
-        return env
+        return dict(UNPIN_ENV)
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
         return [

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -29,6 +29,7 @@ UNPIN_ENV = {"REALM_SYNTHETIC_CORE_MAP": ""}
 
 # Raise min chunk sizes for deferred codepaths to force eager execution
 EAGER_ENV = {
+    "CUNUMERIC_FORCE_THUNK": "eager",
     "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
     "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
     "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -27,11 +27,8 @@ from ..test_system import ProcessResult
 
 UNPIN_ENV = {"REALM_SYNTHETIC_CORE_MAP": ""}
 
-CUNUMERIC_TEST_ENV = {"CUNUMERIC_TEST": "1"}
-
 # Raise min chunk sizes for deferred codepaths to force eager execution
 EAGER_ENV = {
-    "CUNUMERIC_TEST": "0",
     "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
     "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
     "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/legate/util/settings.py
+++ b/legate/util/settings.py
@@ -336,7 +336,7 @@ class EnvOnlySetting(Generic[T], SettingBase):
         self._test_default = test_default
         self._env_var = env_var
 
-    def __call__(self) -> T | None:
+    def __call__(self) -> T:
         if self._env_var in os.environ:
             return self._convert(os.environ[self._env_var])
 

--- a/tests/unit/legate/tester/stages/_linux/test_cpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_cpu.py
@@ -21,12 +21,11 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import cpu as m
-from legate.tester.stages.util import CUNUMERIC_TEST_ENV, UNPIN_ENV
+from legate.tester.stages.util import UNPIN_ENV
 
 from .. import FakeSystem
 
 unpin_and_test = dict(UNPIN_ENV)
-unpin_and_test.update(CUNUMERIC_TEST_ENV)
 
 
 def test_default() -> None:
@@ -48,7 +47,7 @@ def test_cpu_pin_strict() -> None:
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == []
-    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
+    assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)

--- a/tests/unit/legate/tester/stages/_linux/test_eager.py
+++ b/tests/unit/legate/tester/stages/_linux/test_eager.py
@@ -32,7 +32,6 @@ def test_default() -> None:
     assert stage.kind == "eager"
     assert stage.args == []
     assert stage.env(c, s) == {
-        "CUNUMERIC_TEST": "0",
         "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
         "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
         "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/tests/unit/legate/tester/stages/_linux/test_eager.py
+++ b/tests/unit/legate/tester/stages/_linux/test_eager.py
@@ -32,6 +32,7 @@ def test_default() -> None:
     assert stage.kind == "eager"
     assert stage.args == []
     assert stage.env(c, s) == {
+        "CUNUMERIC_FORCE_THUNK": "eager",
         "CUNUMERIC_MIN_CPU_CHUNK": "2000000000",
         "CUNUMERIC_MIN_OMP_CHUNK": "2000000000",
         "CUNUMERIC_MIN_GPU_CHUNK": "2000000000",

--- a/tests/unit/legate/tester/stages/_linux/test_gpu.py
+++ b/tests/unit/legate/tester/stages/_linux/test_gpu.py
@@ -21,7 +21,6 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import gpu as m
-from legate.tester.stages.util import CUNUMERIC_TEST_ENV
 
 from .. import FakeSystem
 
@@ -32,7 +31,7 @@ def test_default() -> None:
     stage = m.GPU(c, s)
     assert stage.kind == "cuda"
     assert stage.args == []
-    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
+    assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
 

--- a/tests/unit/legate/tester/stages/_linux/test_omp.py
+++ b/tests/unit/legate/tester/stages/_linux/test_omp.py
@@ -21,12 +21,11 @@ import pytest
 
 from legate.tester.config import Config
 from legate.tester.stages._linux import omp as m
-from legate.tester.stages.util import CUNUMERIC_TEST_ENV, UNPIN_ENV
+from legate.tester.stages.util import UNPIN_ENV
 
 from .. import FakeSystem
 
 unpin_and_test = dict(UNPIN_ENV)
-unpin_and_test.update(CUNUMERIC_TEST_ENV)
 
 
 def test_default() -> None:
@@ -48,7 +47,7 @@ def test_cpu_pin_strict() -> None:
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
     assert stage.args == []
-    assert stage.env(c, s) == CUNUMERIC_TEST_ENV
+    assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
     shard = (1, 2, 3)


### PR DESCRIPTION
This PR removes the codepaths that set `CUNUMERIC_TEST` from the `legate.tester`. Corresponding PR in cunumeric removes usage of this flag in favor or `LEGATE_TEST`: https://github.com/nv-legate/cunumeric/pull/922