### PR TITLE
Add interface files to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include versioneer.py
 include legate/_version.py
 include legate/py.typed
+
+# include interface files
+recursive-include legate *.pyi


### PR DESCRIPTION
We will install the interface files ending in the `.pyi` extension to enable proper mypy type checking.