### PR TITLE
Fixes for resource scoping

### DIFF
--- a/legate/core/machine.py
+++ b/legate/core/machine.py
@@ -216,7 +216,7 @@ class Machine:
         if isinstance(key, ProcessorKind):
             return self.only(key)
         elif isinstance(key, (slice, int)):
-            if len(self._proc_ranges.keys()) > 1:
+            if len(self._non_empty_kinds) > 1:
                 raise ValueError(
                     "Ambiguous slicing: slicing is not allowed on a machine "
                     "with more than one processor kind"

--- a/legate/core/machine.py
+++ b/legate/core/machine.py
@@ -133,7 +133,7 @@ class ProcessorRange:
             )
         return (
             self.low // self.per_node_count,
-            self.high // self.per_node_count,
+            (self.high + self.per_node_count - 1) // self.per_node_count,
         )
 
     def __repr__(self) -> str:

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -165,12 +165,9 @@ void BaseMapper::select_task_options(const Legion::Mapping::MapperContext ctx,
     LEGATE_ABORT;
   }
 
-  auto target      = legate_mapper_->task_target(legate_task, options);
-  auto local_range = machine.slice(target, machine_desc);
-#ifdef DEBUG_LEGATE
-  assert(!local_range.empty());
-#endif
-  output.initial_proc = local_range.first();
+  auto target = legate_mapper_->task_target(legate_task, options);
+  // The initial processor just needs to have the same kind as the eventual target of this task
+  output.initial_proc = machine.procs(target).front();
 
   // We never want valid instances
   output.valid_instances = false;
@@ -278,10 +275,18 @@ void BaseMapper::map_task(const Legion::Mapping::MapperContext ctx,
   assert(variant.has_value());
 #endif
   output.chosen_variant = *variant;
-  // Just put our target proc in the target processors for now
-  output.target_procs.push_back(task.target_proc);
 
   Task legate_task(&task, context, runtime, ctx);
+
+  if (task.is_index_space)
+    // If this is an index task, point tasks already have the right targets, so we just need to
+    // copy them to the mapper output
+    output.target_procs.push_back(task.target_proc);
+  else {
+    // If this is a single task, here is the right place to compute the final target processor
+    auto local_range = machine.slice(legate_task.target(), legate_task.machine_desc());
+    output.target_procs.push_back(local_range.first());
+  }
 
   const auto& options = default_store_targets(task.target_proc.kind());
 

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -284,7 +284,11 @@ void BaseMapper::map_task(const Legion::Mapping::MapperContext ctx,
     output.target_procs.push_back(task.target_proc);
   else {
     // If this is a single task, here is the right place to compute the final target processor
-    auto local_range = machine.slice(legate_task.target(), legate_task.machine_desc());
+    auto local_range =
+      machine.slice(legate_task.target(), legate_task.machine_desc(), task.local_function);
+#ifdef DEBUG_LEGATE
+    assert(!local_range.empty());
+#endif
     output.target_procs.push_back(local_range.first());
   }
 

--- a/src/core/runtime/shard.cc
+++ b/src/core/runtime/shard.cc
@@ -110,7 +110,6 @@ class LegateShardingFunctor : public Legion::ShardingFunctor {
       offset_(offset),
       per_node_count_(per_node_count)
   {
-    num_shards_ = end_node_id_ - start_node_id_ + 1;
   }
 
  public:
@@ -122,14 +121,17 @@ class LegateShardingFunctor : public Legion::ShardingFunctor {
     auto hi    = proj_functor_->project_point(launch_space.hi(), launch_space);
     auto point = proj_functor_->project_point(p, launch_space);
 
-    return (linearize(lo, hi, point) + offset_) / per_node_count_ + start_node_id_;
+    auto shard_id = (linearize(lo, hi, point) + offset_) / per_node_count_ + start_node_id_;
+#ifdef DEBUG_LEGATE
+    assert(start_node_id_ <= shard_id && shard_id < end_node_id_);
+#endif
+    return shard_id;
   }
 
  private:
   LegateProjectionFunctor* proj_functor_;
   uint32_t start_node_id_;
   uint32_t end_node_id_;
-  uint32_t num_shards_;
   uint32_t offset_;
   uint32_t per_node_count_;
 };


### PR DESCRIPTION
This PR fixes two bugs in the resource scoping code:

1) Node ranges weren't correctly computed to be half-open intervals
2) The base mapper was trying to find initial processors out of empty processor ranges