### PR TITLE
Make sure local fields are not enabled for any Python interpreter

### DIFF
--- a/cmake/Modules/legate_core_options.cmake
+++ b/cmake/Modules/legate_core_options.cmake
@@ -75,6 +75,8 @@ if(NOT Legion_MAX_FIELDS MATCHES "^(32|64|128|256|512|1024|2048|4096)$")
   message(FATAL_ERROR "The maximum number of Legate fields must be a power of 2 between 32 and 4096 inclusive")
 endif()
 
+# We never want local fields
+set(Legion_DEFAULT_LOCAL_FIELDS 0)
 
 option(legate_core_STATIC_CUDA_RUNTIME "Statically link the cuda runtime library" OFF)
 option(legate_core_EXCLUDE_LEGION_FROM_ALL "Exclude Legion targets from legate.core's 'all' target" OFF)

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -165,6 +165,7 @@ function(find_or_configure_legion)
     # https://discourse.cmake.org/t/fetchcontent-cache-variables/1538/8
     set(Legion_MAX_DIM ${Legion_MAX_DIM} CACHE STRING "The max number of dimensions for Legion" FORCE)
     set(Legion_MAX_FIELDS ${Legion_MAX_FIELDS} CACHE STRING "The max number of fields for Legion" FORCE)
+    set(Legion_DEFAULT_LOCAL_FIELDS ${Legion_DEFAULT_LOCAL_FIELDS} CACHE STRING "Number of local fields for Legion" FORCE)
     set(Legion_CUDA_ARCH ${Legion_CUDA_ARCH} CACHE STRING
       "Comma-separated list of CUDA architectures to build for (e.g. 60,70)" FORCE)
 

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "9663e2a0d9f26259dc7ecdac63925c0b5d7408b2"
+      "git_tag" : "83a417c848ba5732a53b870bb0119f23d979a9d0"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "bc69f142bfffba8781c999dc0637ebbc07b2cd10"
+      "git_tag" : "9663e2a0d9f26259dc7ecdac63925c0b5d7408b2"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "915f481e5daa9485344866062441d4ce4d7fb365"
+      "git_tag" : "bc69f142bfffba8781c999dc0637ebbc07b2cd10"
     }
   }
 }

--- a/install.py
+++ b/install.py
@@ -429,7 +429,6 @@ def install(
 -DCMAKE_CUDA_ARCHITECTURES={arch}
 -DLegion_MAX_DIM={str(maxdim)}
 -DLegion_MAX_FIELDS={str(maxfields)}
--DLegion_DEFAULT_LOCAL_FIELDS="0"
 -DLegion_SPY={("ON" if spy else "OFF")}
 -DLegion_BOUNDS_CHECKS={("ON" if check_bounds else "OFF")}
 -DLegion_USE_CUDA={("ON" if cuda else "OFF")}

--- a/install.py
+++ b/install.py
@@ -429,6 +429,7 @@ def install(
 -DCMAKE_CUDA_ARCHITECTURES={arch}
 -DLegion_MAX_DIM={str(maxdim)}
 -DLegion_MAX_FIELDS={str(maxfields)}
+-DLegion_DEFAULT_LOCAL_FIELDS="0"
 -DLegion_SPY={("ON" if spy else "OFF")}
 -DLegion_BOUNDS_CHECKS={("ON" if check_bounds else "OFF")}
 -DLegion_USE_CUDA={("ON" if cuda else "OFF")}

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -422,6 +422,12 @@ def cmd_user_opts(
     return config.user_opts
 
 
+def cmd_python(
+    config: ConfigProtocol, system: System, launcher: Launcher
+) -> CommandPart:
+    return ("python",)
+
+
 _CMD_PARTS_SHARED = (
     # This has to go before script name
     cmd_nocr,
@@ -472,6 +478,8 @@ CMD_PARTS_LEGION = (
 
 CMD_PARTS_CANONICAL = (
     (
+        # Executable name that will get stripped by the runtime
+        cmd_python,
         # User script
         cmd_user_script,
     )

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -210,13 +210,6 @@ def cmd_python_processor(
     return ("-ll:py", "1")
 
 
-def cmd_local_field(
-    config: ConfigProtocol, system: System, launcher: Launcher
-) -> CommandPart:
-    # We always need no local fields
-    return ("-lg:local", "0")
-
-
 def cmd_kthreads(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
@@ -432,7 +425,6 @@ def cmd_user_opts(
 _CMD_PARTS_SHARED = (
     # This has to go before script name
     cmd_nocr,
-    cmd_local_field,
     cmd_kthreads,
     # Translate the requests to Realm command line parameters
     cmd_cpus,

--- a/tests/integration/region_manager/CMakeLists.txt
+++ b/tests/integration/region_manager/CMakeLists.txt
@@ -1,0 +1,29 @@
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+
+project(region_manager VERSION 0.1 LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(BUILD_SHARED_LIBS ON)
+
+find_package(legate_core REQUIRED)
+
+legate_add_cpp_subdirectory(src TARGET region_manager EXPORT region_manager-export)
+
+legate_add_cffi(${CMAKE_CURRENT_SOURCE_DIR}/src/region_manager_cffi.h TARGET region_manager)
+legate_default_python_install(region_manager EXPORT region_manager-export)

--- a/tests/integration/region_manager/editable-install.sh
+++ b/tests/integration/region_manager/editable-install.sh
@@ -1,0 +1,5 @@
+legate_root=`python -c 'import legate.install_info as i; from pathlib import Path; print(Path(i.libpath).parent.resolve())'`
+echo "Using Legate at $legate_root"
+cmake -S . -B build -D legate_core_ROOT=$legate_root
+cmake --build build --parallel 4
+python -m pip install -e .

--- a/tests/integration/region_manager/examples/test_region_manager.py
+++ b/tests/integration/region_manager/examples/test_region_manager.py
@@ -1,0 +1,33 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from region_manager import user_context, user_lib
+
+import legate.core.types as ty
+
+
+def test_region_manager():
+    task = user_context.create_auto_task(user_lib.cffi.TESTER)
+    for _ in range(2000):
+        store = user_context.create_store(ty.int64, shape=(10,))
+        task.add_output(store)
+    task.execute()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(sys.argv))

--- a/tests/integration/region_manager/install.sh
+++ b/tests/integration/region_manager/install.sh
@@ -1,0 +1,1 @@
+python -m pip install .

--- a/tests/integration/region_manager/region_manager/__init__.py
+++ b/tests/integration/region_manager/region_manager/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .lib import user_lib, user_context

--- a/tests/integration/region_manager/region_manager/lib.py
+++ b/tests/integration/region_manager/region_manager/lib.py
@@ -1,0 +1,56 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+from typing import Any
+
+from legate.core import Library, get_legate_runtime
+
+
+class UserLibrary(Library):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.shared_object: Any = None
+
+    @property
+    def cffi(self) -> Any:
+        return self.shared_object
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_shared_library(self) -> str:
+        from region_manager.install_info import libpath
+
+        return os.path.join(
+            libpath, f"libregion_manager{self.get_library_extension()}"
+        )
+
+    def get_c_header(self) -> str:
+        from region_manager.install_info import header
+
+        return header
+
+    def get_registration_callback(self) -> str:
+        return "perform_registration"
+
+    def initialize(self, shared_object: Any) -> None:
+        self.shared_object = shared_object
+
+    def destroy(self) -> None:
+        pass
+
+
+user_lib = UserLibrary("region_manager")
+user_context = get_legate_runtime().register_library(user_lib)

--- a/tests/integration/region_manager/setup.py
+++ b/tests/integration/region_manager/setup.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+from pathlib import Path
+
+from setuptools import find_packages
+from skbuild import setup
+
+import legate.install_info as lg_install_info
+
+legate_dir = Path(lg_install_info.libpath).parent.as_posix()
+
+cmake_flags = [
+    f"-Dlegate_core_ROOT:STRING={legate_dir}",
+]
+
+env_cmake_args = os.environ.get("CMAKE_ARGS")
+if env_cmake_args is not None:
+    cmake_flags.append(env_cmake_args)
+os.environ["CMAKE_ARGS"] = " ".join(cmake_flags)
+
+
+setup(
+    name="Region manager test",
+    version="0.1",
+    description="Region manager test",
+    author="NVIDIA Corporation",
+    license="Apache 2.0",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Topic :: Database",
+        "Topic :: Scientific/Engineering",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    packages=find_packages(
+        where=".",
+        include=["region_manager", "region_manager.*"],
+    ),
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/tests/integration/region_manager/src/CMakeLists.txt
+++ b/tests/integration/region_manager/src/CMakeLists.txt
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+add_library(
+  region_manager
+  tester.cc
+  library.cc
+)
+
+target_include_directories(region_manager
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  INTERFACE
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(region_manager PRIVATE legate::core)
+

--- a/tests/integration/region_manager/src/library.cc
+++ b/tests/integration/region_manager/src/library.cc
@@ -1,0 +1,38 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "library.h"
+#include "tester.h"
+
+namespace region_manager {
+
+static const char* const library_name = "region_manager";
+
+void registration_callback()
+{
+  auto context = legate::Runtime::get_runtime()->create_library(library_name);
+  TesterTask::register_variants(context);
+}
+
+}  // namespace region_manager
+
+extern "C" {
+
+void perform_registration(void)
+{
+  legate::Core::perform_registration<region_manager::registration_callback>();
+}
+}

--- a/tests/integration/region_manager/src/library.h
+++ b/tests/integration/region_manager/src/library.h
@@ -1,0 +1,28 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "legate.h"
+
+namespace region_manager {
+
+template <typename T, int ID>
+struct Task : public legate::LegateTask<T> {
+  static constexpr int TASK_ID = ID;
+};
+
+}  // namespace region_manager

--- a/tests/integration/region_manager/src/region_manager_cffi.h
+++ b/tests/integration/region_manager/src/region_manager_cffi.h
@@ -1,0 +1,34 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __REGION_MANAGER_C__
+#define __REGION_MANAGER_C__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum TreeReduceOpCode {
+  TESTER = 0,
+};
+
+void perform_registration(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __REGION_MANAGER_C__

--- a/tests/integration/region_manager/src/tester.cc
+++ b/tests/integration/region_manager/src/tester.cc
@@ -1,0 +1,23 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "tester.h"
+
+namespace region_manager {
+
+/*static*/ void TesterTask::cpu_variant(legate::TaskContext& context) {}
+
+}  // namespace region_manager

--- a/tests/integration/region_manager/src/tester.h
+++ b/tests/integration/region_manager/src/tester.h
@@ -1,0 +1,29 @@
+/* Copyright 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "library.h"
+#include "region_manager_cffi.h"
+
+namespace region_manager {
+
+struct TesterTask : public legate::LegateTask<TesterTask> {
+  static constexpr int TASK_ID = TESTER;
+  static void cpu_variant(legate::TaskContext& context);
+};
+
+}  // namespace region_manager

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -55,7 +55,6 @@ def test_CMD_PARTS() -> None:
         m.cmd_python_processor,
         m.cmd_module,
         m.cmd_nocr,
-        m.cmd_local_field,
         m.cmd_kthreads,
         m.cmd_cpus,
         m.cmd_gpus,
@@ -683,15 +682,6 @@ class Test_cmd_python_processor:
         result = m.cmd_python_processor(config, system, launcher)
 
         assert result == ("-ll:py", "1")
-
-
-class Test_cmd_local_field:
-    def test_default(self, genobjs: GenObjs) -> None:
-        config, system, launcher = genobjs([])
-
-        result = m.cmd_local_field(config, system, launcher)
-
-        assert result == ("-lg:local", "0")
 
 
 class Test_cmd_kthreads:


### PR DESCRIPTION
We've been suppressing reservation for local fields in each field space by [explicitly passing `-lg:local 0`](https://github.com/nv-legate/legate.core/blob/branch-23.05/legate/driver/command.py#L217), but never been doing the same in the code path for the canonical Python interpreter. So, any code that tries to have more than 252 active stores crashes with the canonical Python interpreter. This PR fixes the issue by just configuring Legion with no local fields. This PR also bumps up the commit hash for Legion, as [Legion's cmake build also had to be updated](https://gitlab.com/StanfordLegion/legion/-/commit/bc69f142bfffba8781c999dc0637ebbc07b2cd10) for this.