### PR TITLE
Fix bugs in corner cases of `tree_reduce`

### DIFF
--- a/examples/reduction/src/unique.cc
+++ b/examples/reduction/src/unique.cc
@@ -29,7 +29,8 @@ template <typename VAL>
 void add_to_set(std::unordered_set<VAL>& unique_values, legate::Store& input)
 {
   auto shape = input.shape<1>();
-  auto acc   = input.read_accessor<VAL, 1>();
+  if (shape.empty()) return;
+  auto acc = input.read_accessor<VAL, 1>();
   for (legate::PointInRectIterator<1> it(shape, false /*fortran_order*/); it.valid(); ++it)
     unique_values.insert(acc[*it]);
 }
@@ -37,7 +38,10 @@ void add_to_set(std::unordered_set<VAL>& unique_values, legate::Store& input)
 template <typename VAL>
 void copy_to_output(legate::Store& output, const std::unordered_set<VAL>& values)
 {
-  if (values.empty()) output.bind_empty_data();
+  if (values.empty()) {
+    output.bind_empty_data();
+    return;
+  }
 
   int64_t num_values = values.size();
   auto out_buf =

--- a/tests/integration/tree_reduce/examples/test_tree_reduce.py
+++ b/tests/integration/tree_reduce/examples/test_tree_reduce.py
@@ -31,9 +31,11 @@ def test_tree_reduce_normal():
     task.add_output(part)
     task.execute()
 
-    user_context.tree_reduce(
+    result = user_context.tree_reduce(
         user_lib.shared_object.REDUCE_NORMAL, store, radix=4
     )
+    # The result should be a normal store
+    assert not result.unbound
 
 
 def test_tree_reduce_unbound():
@@ -45,9 +47,26 @@ def test_tree_reduce_unbound():
     task.add_output(store)
     task.execute()
 
-    user_context.tree_reduce(
+    result = user_context.tree_reduce(
         user_lib.shared_object.REDUCE_UNBOUND, store, radix=num_tasks
     )
+    # The result should be a normal store
+    assert not result.unbound
+
+
+def test_tree_single_proc():
+    task = user_context.create_manual_task(
+        user_lib.shared_object.PRODUCE_UNBOUND, Rect([1])
+    )
+    store = user_context.create_store(ty.int64, ndim=1)
+    task.add_output(store)
+    task.execute()
+
+    result = user_context.tree_reduce(
+        user_lib.shared_object.REDUCE_UNBOUND, store, radix=4
+    )
+    # The result should be a normal store
+    assert not result.unbound
 
 
 if __name__ == "__main__":

--- a/tests/integration/tree_reduce/src/tree_reduce_cffi.h
+++ b/tests/integration/tree_reduce/src/tree_reduce_cffi.h
@@ -23,7 +23,7 @@ extern "C" {
 
 enum Constants {
   NUM_NORMAL_PRODUCER = 3,
-  TILE_SIZE           = 4,
+  TILE_SIZE           = 10,
 };
 
 enum TreeReduceOpCode {
@@ -31,6 +31,7 @@ enum TreeReduceOpCode {
   REDUCE_NORMAL   = 1,
   PRODUCE_UNBOUND = 2,
   REDUCE_UNBOUND  = 3,
+
 };
 
 void perform_registration(void);


### PR DESCRIPTION
`tree_reduce` wasn't correctly handling cases where the input is produced by a single task. 