### PR TITLE
Prioritize OMPI_ vs SLURM_ envvars when inferring rank

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -84,7 +84,7 @@ case "$launcher" in
     global_rank="${SLURM_PROCID:-unknown}"
     ;;
   auto  )
-    local_rank="${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-unknown}}}"
+    local_rank="${OMPI_COMM_WORLD_LOCAL_RANK:-${MV2_COMM_WORLD_LOCAL_RANK:-${SLURM_LOCALID:-unknown}}}"
     global_rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${MV2_COMM_WORLD_RANK:-${SLURM_PROCID:-unknown}}}}"
     ;;
   local )


### PR DESCRIPTION
This way we will pick up the correct rank in the case where the user is doing a manual mpirun call inside of a slurm allocation, in which case both SLURM_ and OMPI_ envvars will be present. We now use the OMPI_ ones over the SLURM_ ones, which follows the user's intent.

The reverse (slurm within an mpi call) sounds implausible, so this is IMHO the better polarity.