### PR TITLE
Don't automatically close dlopen'ed .so's of Legate libs

### DIFF
--- a/legate/core/utils.py
+++ b/legate/core/utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import traceback
+from ctypes.util import find_library
 from types import TracebackType
 from typing import (
     Any,
@@ -25,6 +26,8 @@ from typing import (
     Optional,
     TypeVar,
 )
+
+import cffi  # type: ignore [import]
 
 T = TypeVar("T", bound="Hashable")
 
@@ -86,3 +89,18 @@ def capture_traceback_repr(
             tb_lineno=frame.f_lineno,
         )
     return "".join(traceback.format_tb(tb)) if tb is not None else None
+
+
+_loader_ns = cffi.FFI()
+_loader_ns.cdef("void *dlopen(const char *filename, int flags);")
+# Can't do loader_ns.dlopen(None) on Windows with Python 3
+# see https://bugs.python.org/issue23606
+_loader_lib = _loader_ns.dlopen(find_library("dl"))
+
+
+def dlopen_no_autoclose(ffi: Any, lib_path: str) -> Any:
+    # Use an already-opened library handle, which cffi will convert to a
+    # regular FFI object (using the definitions previously added using
+    # ffi.cdef), but will not automatically dlclose() on collection.
+    handle = _loader_lib.dlopen(lib_path.encode(), _loader_ns.RTLD_NOW)
+    return ffi.dlopen(handle)


### PR DESCRIPTION
Any library that is `dlopen`ed through python's `cffi` will be automatically `dlclose`d when the library object gets collected. This removes certain symbols that may be necessary for destructors that will be called later. This happened to me on MacOS, when running using the canonical python interpreter:

```
Process 56020 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x2a8725418)
    frame #0: 0x000000019a8299d9 liblgcore.dylib`std::__1::default_delete<legate::mapping::Mapper>::operator(this=0x0000600003302548, __ptr=0x0000600000229860)[abi:v15006](legate::mapping::Mapper*) const at unique_ptr.h:48:5
   45  	  _LIBCPP_INLINE_VISIBILITY void operator()(_Tp* __ptr) const _NOEXCEPT {
   46  	    static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
   47  	    static_assert(!is_void<_Tp>::value, "cannot delete an incomplete type");
-> 48  	    delete __ptr;
   49  	  }
   50  	};
   51
Target 0: (python) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x2a8725418)
  * frame #0: 0x000000019a8299d9 liblgcore.dylib`std::__1::default_delete<legate::mapping::Mapper>::operator(this=0x0000600003302548, __ptr=0x0000600000229860)[abi:v15006](legate::mapping::Mapper*) const at unique_ptr.h:48:5
    frame #1: 0x000000019a82999c liblgcore.dylib`std::__1::unique_ptr<legate::mapping::Mapper, std::__1::default_delete<legate::mapping::Mapper> >::reset[abi:v15006](this=0x0000600003302548, __p=0x0000000000000000) at unique_ptr.h:305:7
    frame #2: 0x000000019a829939 liblgcore.dylib`std::__1::unique_ptr<legate::mapping::Mapper, std::__1::default_delete<legate::mapping::Mapper> >::~unique_ptr[abi:v15006](this=0x0000600003302548) at unique_ptr.h:259:19
    frame #3: 0x000000019a826225 liblgcore.dylib`std::__1::unique_ptr<legate::mapping::Mapper, std::__1::default_delete<legate::mapping::Mapper> >::~unique_ptr[abi:v15006](this=0x0000600003302548) at unique_ptr.h:259:17
    frame #4: 0x000000019a84347a liblgcore.dylib`legate::LibraryContext::~LibraryContext(this=0x00006000033024e0) at context.h:62:7
    frame #5: 0x000000019a83fb75 liblgcore.dylib`legate::LibraryContext::~LibraryContext(this=0x00006000033024e0) at context.h:62:7
    frame #6: 0x000000019a83fa0d liblgcore.dylib`legate::Runtime::~Runtime(this=0x000000019a9b32e8) at runtime.cc:159:41
    frame #7: 0x000000019a83fc05 liblgcore.dylib`legate::Runtime::~Runtime(this=0x000000019a9b32e8) at runtime.cc:158:1
    frame #8: 0x00007ff8119d5ba1 libsystem_c.dylib`__cxa_finalize_ranges + 409
    frame #9: 0x00007ff8119d59bb libsystem_c.dylib`exit + 35
    frame #10: 0x00007ff811b1b8d3 libdyld.dylib`dyld4::LibSystemHelpers::exit(int) const + 11
    frame #11: 0x00007ff8117aa458 dyld`start + 1960
```

In this case, by the time the `Runtime` object is destroyed at application shutdown, the cuNumeric shared library has already been `dlclose`d, so the `delete` call on the remaining `cunumeric::CuNumericMapper` object fails, because the vtable for that class is no longer present (necessary to find the virtual destructor):

```
(lldb) b LibraryContext::LibraryContext
(lldb) b LibraryContext::~LibraryContext
(lldb) b cblas_dgemv
(lldb) r

# first breakpoint in LibraryContext::LibraryContext
(lldb) p mapper
(std::unique_ptr<legate::mapping::Mapper, std::default_delete<legate::mapping::Mapper> >) $0 = legate::mapping::Mapper @ 0x0000600000009960 {
  __value_ = 0x0000600000009960
}

# second breakpoint in LibraryContext::LibraryContext
(lldb) p mapper
(std::unique_ptr<legate::mapping::Mapper, std::default_delete<legate::mapping::Mapper> >) $1 = legate::mapping::Mapper @ 0x0000600000208ba0 {
  __value_ = 0x0000600000208ba0
}

# breakpoint in cblas_dgemv
(lldb) command script import lldb.macosx.heap
(lldb) malloc_info --type 0x0000600000009960
0x0000600000009960: malloc(    16) -> 0x600000009960 legate::mapping::DefaultMapper.legate::mapping::Mapper (legate::mapping::DefaultMapper) *addr = {}
(lldb) malloc_info --type 0x0000600000208ba0
0x0000600000208ba0: malloc(    32) -> 0x600000208ba0 cunumeric::CuNumericMapper.legate::mapping::Mapper (cunumeric::CuNumericMapper) *addr = (machine = 0x0000000101862ce0, min_gpu_chunk = 2, min_cpu_chunk = 2, min_omp_chunk = 2)
(lldb) image lookup -r -v -s "vtable for legate::mapping::DefaultMapper"
1 symbols match the regular expression 'vtable for legate::mapping::DefaultMapper' in /Users/mpapadakis/legate.core/build/lib/liblgcore.dylib:
        Address: liblgcore.dylib[0x00000000002380f0] (liblgcore.dylib.__DATA_CONST.__const + 3840)
        Summary: liblgcore.dylib`vtable for legate::mapping::DefaultMapper
         Module: file = "/Users/mpapadakis/legate.core/build/lib/liblgcore.dylib", arch = "x86_64"
         Symbol: id = {0x00009ea1}, range = [0x000000019d65e0f0-0x000000019d65e130), name="vtable for legate::mapping::DefaultMapper", mangled="_ZTVN6legate7mapping13DefaultMapperE"
(lldb) image lookup -r -v -s "vtable for cunumeric::CuNumericMapper"
1 symbols match the regular expression 'vtable for cunumeric::CuNumericMapper' in /Users/mpapadakis/cunumeric/build/lib/libcunumeric.dylib:
        Address: libcunumeric.dylib[0x00000000011a5400] (libcunumeric.dylib.__DATA_CONST.__const + 5808)
        Summary: libcunumeric.dylib`vtable for cunumeric::CuNumericMapper
         Module: file = "/Users/mpapadakis/cunumeric/build/lib/libcunumeric.dylib", arch = "x86_64"
         Symbol: id = {0x0004ba7a}, range = [0x00000002ab264400-0x00000002ab264440), name="vtable for cunumeric::CuNumericMapper", mangled="_ZTVN9cunumeric15CuNumericMapperE"
(lldb) image list
# ...
[205] 166C6623-9B4C-3326-99B0-63C7F27B6016 0x000000019d426000 /Users/mpapadakis/legate.core/build/lib/liblgcore.dylib
# ...
[208] 678172A8-73AB-3514-B168-A007BE2D1686 0x00000002aa0bf000 /Users/mpapadakis/cunumeric/build/lib/libcunumeric.dylib
# ...

# breakpoint in LibraryContext::~LibraryContext:
(lldb) f 1
(lldb) p context->mapper_
(std::unique_ptr<legate::mapping::Mapper, std::default_delete<legate::mapping::Mapper> >) $5 = legate::mapping::Mapper @ 0x0000600000208ba0 {
  __value_ = 0x0000600000208ba0
}
(lldb) image lookup -r -v -s "vtable for legate::mapping::DefaultMapper"
1 symbols match the regular expression 'vtable for legate::mapping::DefaultMapper' in /Users/mpapadakis/legate.core/build/lib/liblgcore.dylib:
        Address: liblgcore.dylib[0x00000000002380f0] (liblgcore.dylib.__DATA_CONST.__const + 3840)
        Summary: liblgcore.dylib`vtable for legate::mapping::DefaultMapper
         Module: file = "/Users/mpapadakis/legate.core/build/lib/liblgcore.dylib", arch = "x86_64"
         Symbol: id = {0x00009ea1}, range = [0x000000019d65e0f0-0x000000019d65e130), name="vtable for legate::mapping::DefaultMapper", mangled="_ZTVN6legate7mapping13DefaultMapperE"
(lldb) image lookup -r -v -s "vtable for cunumeric::CuNumericMapper"
# nothing printed; vtable no longer present
(lldb) image list
# ...
[205] 166C6623-9B4C-3326-99B0-63C7F27B6016 0x000000019d426000 /Users/mpapadakis/legate.core/build/lib/liblgcore.dylib
# ...
# libcunumeric.dylib missing
```