### PR TITLE
Remove dependency on pyarrow

### DIFF
--- a/conda/conda-build/conda_build_config.yaml
+++ b/conda/conda-build/conda_build_config.yaml
@@ -12,6 +12,3 @@ numpy_version:
 
 cmake_version:
   - ">=3.20.1,!=3.23.0"
-
-pyarrow_version:
-  - ">=8.0.0"

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -121,7 +121,6 @@ requirements:
     - cffi
     - llvm-openmp
     - numpy {{ numpy_version }}
-    - pyarrow {{ pyarrow_version }}
     - typing_extensions
 {% if gpu_enabled_bool %}
     - cuda-cudart >={{ cuda_version }}

--- a/examples/reduction/setup.py
+++ b/examples/reduction/setup.py
@@ -56,5 +56,5 @@ setup(
     ),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["cunumeric", "pyarrow>=5"],
+    install_requires=["cunumeric"],
 )

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -143,7 +143,6 @@ class RuntimeConfig(SectionConfig):
             "libblas=*=*openblas*",
             "openblas=*=*openmp*",
             "opt_einsum",
-            "pyarrow>=5",
             "scipy",
             "typing_extensions",
         )


### PR DESCRIPTION
This is no longer used in Legate, and the `libarrow` conda package (required by `pyarrow`) is actually causing issues when building GASNet, because it pulls `ucx` (required for Arrow's `feather` component, which we don't use, but is bundled in the `libarrow` package regardless), which nowadays pulls `rdma-core`, whose `libibverbs.so` conflicts with the system version.