### PR TITLE
Restoring the cudatoolkit conda dependency

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -107,6 +107,7 @@ requirements:
     - numpy {{ numpy_version }}
 {% if gpu_enabled_bool %}
     - nccl
+    - cudatoolkit ={{ cuda_version }}
     - cuda-nvcc ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}


### PR DESCRIPTION
Something in the unit tests seems to not be able to use the cudart library being found in `cuda-cudart` putting back the `cudatoolkit` dependency until we can determine it wasn't that change.