### PR TITLE
Locking cuda-cudart to a major version

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -84,8 +84,9 @@ build:
 {% endif %}
 {% if gpu_enabled_bool %}
 # prevent nccl from pulling in cudatoolkit
-  ignore_run_exports:
-    - cudatoolkit
+# once an nccl package compatible with cuda-* packages is introduced, this can be removed
+#  ignore_run_exports:
+#    - cudatoolkit
   ignore_run_exports_from:
     - cuda-nvcc
 {% endif %}

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -107,6 +107,7 @@ requirements:
     - numpy {{ numpy_version }}
 {% if gpu_enabled_bool %}
     - nccl
+    - cudatoolkit ={{ cuda_version }}
     - cuda-nvcc ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -24,7 +24,7 @@
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
 {% set cuda_version='.'.join(environ.get('CUDA', '11.8').split('.')[:2]) %}
-{% set cuda_major=cuda_version.split('.')[0] %}
+{% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 
 package:
@@ -84,9 +84,8 @@ build:
 {% endif %}
 {% if gpu_enabled_bool %}
 # prevent nccl from pulling in cudatoolkit
-# once an nccl package compatible with cuda-* packages is introduced, this can be removed
-#  ignore_run_exports:
-#    - cudatoolkit
+  ignore_run_exports:
+    - cudatoolkit
   ignore_run_exports_from:
     - cuda-nvcc
 {% endif %}
@@ -108,7 +107,6 @@ requirements:
     - numpy {{ numpy_version }}
 {% if gpu_enabled_bool %}
     - nccl
-    - cudatoolkit ={{ cuda_version }}
     - cuda-nvcc ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}
@@ -124,7 +122,7 @@ requirements:
     - pyarrow {{ pyarrow_version }}
     - typing_extensions
 {% if gpu_enabled_bool %}
-    - cuda-cudart >={{ cuda_version }}
+    - cuda-cudart >={{ cuda_version }},<{{ cuda_major+1 }}
     - nccl
 {% endif %}
 


### PR DESCRIPTION
Libraries are linking to cudart.so.11 so we need to lock the run time dependency to the major version being used during compilation