### PR TITLE
Add support for test timeouts

### DIFF
--- a/legate/tester/args.py
+++ b/legate/tester/args.py
@@ -184,6 +184,17 @@ test_opts = parser.add_argument_group("Test run configuration options")
 
 
 test_opts.add_argument(
+    "--timeout",
+    dest="timeout",
+    type=int,
+    action="store",
+    default=None,
+    required=False,
+    help="Timeout in seconds for individual tests",
+)
+
+
+test_opts.add_argument(
     "--legate",
     dest="legate_dir",
     metavar="LEGATE_DIR",

--- a/legate/tester/config.py
+++ b/legate/tester/config.py
@@ -67,6 +67,7 @@ class Config:
         self.ranks = args.ranks
 
         # test run configuration
+        self.timeout = args.timeout
         self.debug = args.debug
         self.dry_run = args.dry_run
         self.verbose = args.verbose

--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -269,7 +269,12 @@ class TestStage(Protocol):
 
         self.delay(shard, config, system)
 
-        result = system.run(cmd, test_file, env=self._env(config, system))
+        result = system.run(
+            cmd,
+            test_file,
+            env=self._env(config, system),
+            timeout=config.timeout,
+        )
         log_proc(self.name, result, config, verbose=config.verbose)
 
         self.shards.put(shard)

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -20,7 +20,7 @@ from typing import Tuple, Union
 
 from typing_extensions import TypeAlias
 
-from ...util.ui import failed, passed, shell, skipped
+from ...util.ui import failed, passed, shell, skipped, timeout
 from ..config import Config
 from ..logger import LOG
 from ..test_system import ProcessResult
@@ -127,6 +127,8 @@ def log_proc(
     details = proc.output.split("\n") if verbose else None
     if proc.skipped:
         LOG(skipped(msg))
+    elif proc.timeout:
+        LOG(timeout(msg))
     elif proc.returncode == 0:
         LOG(passed(msg, details=details))
     else:

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -123,7 +123,12 @@ def log_proc(
     """Log a process result according to the current configuration"""
     if config.debug or config.dry_run:
         LOG(shell(proc.invocation))
-    msg = f"({name}) {proc.test_file}"
+    duration = (
+        f" {{{proc.time.total_seconds():0.2f}s}}"
+        if proc.time is not None
+        else ""
+    )
+    msg = f"({name}){duration} {proc.test_file}"
     details = proc.output.split("\n") if verbose else None
     if proc.skipped:
         LOG(skipped(msg))

--- a/legate/tester/test_plan.py
+++ b/legate/tester/test_plan.py
@@ -123,7 +123,7 @@ class TestPlan:
         return f"{overall}\n"
 
     def _log_failures(self, all_procs: tuple[ProcessResult, ...]) -> None:
-        if all(proc.passed for proc in all_procs):
+        if not any(proc.returncode for proc in all_procs):
             return
 
         LOG(f"{banner('FAILURES')}\n")

--- a/legate/tester/test_plan.py
+++ b/legate/tester/test_plan.py
@@ -25,7 +25,7 @@ from ..util.ui import banner, rule, summary
 from .config import Config
 from .logger import LOG
 from .stages import STAGES, log_proc
-from .test_system import TestSystem
+from .test_system import ProcessResult, TestSystem
 
 
 class TestPlan:
@@ -63,11 +63,13 @@ class TestPlan:
             chain.from_iterable(s.result.procs for s in self._stages)
         )
         total = len(all_procs)
-        passed = sum(proc.returncode == 0 for proc in all_procs)
+        passed = sum(proc.passed for proc in all_procs)
 
         LOG(f"\n{rule(pad=4)}")
 
-        self._log_failures(total, passed)
+        self._log_failures(all_procs)
+
+        self._log_timeouts(all_procs)
 
         LOG(self.outro(total, passed))
 
@@ -120,13 +122,24 @@ class TestPlan:
 
         return f"{overall}\n"
 
-    def _log_failures(self, total: int, passed: int) -> None:
-        if total == passed:
+    def _log_failures(self, all_procs: tuple[ProcessResult, ...]) -> None:
+        if all(proc.passed for proc in all_procs):
             return
 
         LOG(f"{banner('FAILURES')}\n")
 
         for stage in self._stages:
             procs = (proc for proc in stage.result.procs if proc.returncode)
+            for proc in procs:
+                log_proc(stage.name, proc, self._config, verbose=True)
+
+    def _log_timeouts(self, all_procs: tuple[ProcessResult, ...]) -> None:
+        if not any(proc.timeout for proc in all_procs):
+            return
+
+        LOG(f"{banner('TIMEOUTS')}\n")
+
+        for stage in self._stages:
+            procs = (proc for proc in stage.result.procs if proc.timeout)
             for proc in procs:
                 log_proc(stage.name, proc, self._config, verbose=True)

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -93,7 +93,7 @@ class TestSystem(System):
         *,
         env: EnvDict | None = None,
         cwd: str | None = None,
-        timeout: int | None = 10,
+        timeout: int | None = None,
     ) -> ProcessResult:
         """Wrapper for subprocess.run that encapsulates logging.
 

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import multiprocessing
 import os
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 from subprocess import PIPE, STDOUT, TimeoutExpired, run as stdlib_run
 from typing import Sequence
@@ -44,6 +45,9 @@ class ProcessResult:
 
     #  User-friendly test file path to use in reported output
     test_file: Path
+
+    #: The time the process took to execute in seconds
+    time: timedelta | None = None
 
     #: Whether this process was actually invoked
     skipped: bool = False
@@ -125,6 +129,7 @@ class TestSystem(System):
         full_env = dict(os.environ)
         full_env.update(env)
 
+        t0 = datetime.now()
         try:
             proc = stdlib_run(
                 cmd,
@@ -138,9 +143,11 @@ class TestSystem(System):
         except TimeoutExpired:
             return ProcessResult(invocation, test_file, timeout=True)
 
+        t1 = datetime.now()
         return ProcessResult(
             invocation,
             test_file,
+            time=t1 - t0,
             returncode=proc.returncode,
             output=proc.stdout,
         )

--- a/legate/util/ui.py
+++ b/legate/util/ui.py
@@ -34,10 +34,14 @@ __all__ = (
     "UI_WIDTH",
     "banner",
     "error",
+    "failed",
     "key",
     "kvtable",
+    "passed",
     "rule",
     "section",
+    "skipped",
+    "timeout",
     "value",
     "warn",
 )
@@ -108,6 +112,30 @@ def error(text: str) -> str:
 
     """
     return red(f"ERROR: {text}")
+
+
+def skipped(msg: str) -> str:
+    """Report a skipped test with a cyan [SKIP]
+
+    Parameters
+    ----------
+    msg : str
+        Text to display after [SKIP]
+
+    """
+    return f"{cyan('[SKIP]')} {msg}"
+
+
+def timeout(msg: str) -> str:
+    """Report a timed-out test with a yellow [TIME]
+
+    Parameters
+    ----------
+    msg : str
+        Text to display after [TIME]
+
+    """
+    return f"{yellow('[TIME]')} {msg}"
 
 
 def failed(
@@ -282,18 +310,6 @@ def shell(cmd: str, *, char: str = "+") -> str:
 
     """
     return dim(white(f"{char}{cmd}"))
-
-
-def skipped(msg: str) -> str:
-    """Report a skipped test with a cyan [SKIP]
-
-    Parameters
-    ----------
-    msg : str
-        Text to display after [SKIP]
-
-    """
-    return f"{cyan('[SKIP]')} {msg}"
 
 
 def summary(

--- a/tests/unit/legate/tester/stages/test_util.py
+++ b/tests/unit/legate/tester/stages/test_util.py
@@ -165,3 +165,18 @@ class Test_log_proc:
             shell(proc.invocation),
             passed(f"(foo) {proc.test_file}"),
         )
+
+    def test_time(self) -> None:
+        config = Config([])
+        config.debug = True
+        proc = ProcessResult(
+            "proc", Path("proc"), time=timedelta(seconds=2.41)
+        )
+
+        LOG.clear()
+        m.log_proc("foo", proc, config, verbose=False)
+
+        assert LOG.lines == (
+            shell(proc.invocation),
+            passed(f"(foo) {{2.41s}} {proc.test_file}"),
+        )

--- a/tests/unit/legate/tester/stages/test_util.py
+++ b/tests/unit/legate/tester/stages/test_util.py
@@ -26,7 +26,7 @@ from legate.tester.config import Config
 from legate.tester.logger import LOG
 from legate.tester.stages import util as m
 from legate.tester.test_system import ProcessResult
-from legate.util.ui import failed, passed, shell, skipped
+from legate.util.ui import failed, passed, shell, skipped, timeout
 
 
 def test_StageResult() -> None:
@@ -130,6 +130,15 @@ class Test_log_proc:
                 exit_code=returncode,
             ).split("\n")
         )
+
+    def test_timeout(self) -> None:
+        config = Config([])
+        proc = ProcessResult("proc", Path("proc"), timeout=True)
+
+        LOG.clear()
+        m.log_proc("foo", proc, config, verbose=False)
+
+        assert LOG.lines == (timeout(f"(foo) {proc.test_file}"),)
 
     def test_dry_run(self) -> None:
         config = Config([])

--- a/tests/unit/legate/tester/test_args.py
+++ b/tests/unit/legate/tester/test_args.py
@@ -63,6 +63,9 @@ class TestParserDefaults:
     def test_numamem(self) -> None:
         assert m.parser.get_default("numamem") == DEFAULT_NUMAMEM
 
+    def test_timeout(self) -> None:
+        assert m.parser.get_default("timeout") is None
+
     def test_legate_dir(self) -> None:
         assert m.parser.get_default("legate_dir") is None
 

--- a/tests/unit/legate/tester/test_config.py
+++ b/tests/unit/legate/tester/test_config.py
@@ -57,6 +57,7 @@ class TestConfig:
         assert c.omps == DEFAULT_OMPS_PER_NODE
         assert c.ompthreads == DEFAULT_OMPTHREADS
 
+        assert c.timeout is None
         assert c.debug is False
         assert c.dry_run is False
         assert c.verbose == 0
@@ -136,6 +137,10 @@ class TestConfig:
     def test_workers(self) -> None:
         c = m.Config(["test.py", "-j", "1234"])
         assert c.requested_workers == 1234
+
+    def test_timeout(self) -> None:
+        c = m.Config(["test.py", "--timeout", "10"])
+        assert c.timeout == 10
 
     def test_debug(self) -> None:
         c = m.Config(["test.py", "--debug"])

--- a/tests/unit/legate/tester/test_test_system.py
+++ b/tests/unit/legate/tester/test_test_system.py
@@ -17,6 +17,7 @@
 """
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock
@@ -32,6 +33,7 @@ class TestProcessResult:
         ret = m.ProcessResult("proc", Path("proc"))
         assert ret.invocation == "proc"
         assert ret.test_file == Path("proc")
+        assert ret.time is None
         assert not ret.skipped
         assert not ret.timeout
         assert ret.returncode == 0
@@ -71,13 +73,6 @@ class TestSystem:
     def test_run(self, mock_subprocess_run: MagicMock) -> None:
         s = m.TestSystem()
 
-        expected = m.ProcessResult(
-            CMD,
-            Path("test/file"),
-            returncode=10,
-            output="<output>",
-            timeout=False,
-        )
         mock_subprocess_run.return_value = CompletedProcess(
             CMD, 10, stdout="<output>"
         )
@@ -85,7 +80,14 @@ class TestSystem:
         result = s.run(CMD.split(), Path("test/file"))
         mock_subprocess_run.assert_called()
 
-        assert result == expected
+        assert result.invocation == CMD
+        assert result.test_file == Path("test/file")
+        assert result.time is not None and result.time > timedelta(0)
+        assert not result.skipped
+        assert not result.timeout
+        assert result.returncode == 10
+        assert result.output == "<output>"
+        assert not result.passed
 
     def test_dry_run(self, mock_subprocess_run: MagicMock) -> None:
         s = m.TestSystem(dry_run=True)

--- a/tests/unit/legate/util/test_ui.py
+++ b/tests/unit/legate/util/test_ui.py
@@ -376,6 +376,15 @@ def test_skipped_plain(use_plain_text: UsePlainTextFixture) -> None:
 
 
 @pytest.mark.skipif(colorama is None, reason="colorama required")
+def test_timeout() -> None:
+    assert m.timeout("msg") == f"{colors.yellow('[TIME]')} msg"
+
+
+def test_timeout_plain(use_plain_text: UsePlainTextFixture) -> None:
+    assert m.timeout("msg") == "[TIME] msg"
+
+
+@pytest.mark.skipif(colorama is None, reason="colorama required")
 def test_summary() -> None:
     assert m.summary("foo", 12, 11, timedelta(seconds=2.123)) == colors.bright(
         colors.red(


### PR DESCRIPTION
This PR adds an new `--timeout` option to the tester code that can be used to diagnose infinite hangs. When `--timeout` is specified, and a test exceeds this amount, it will be terminated, and report as `[TIME]` in the running test log. All timed-out tests are also reported in one place at the end:

![2023-06-07](https://github.com/nv-legate/legate.core/assets/1078448/ec890c12-e9bf-4dee-9a5e-3f09ed819e5d)

Additionally, this PR adds support to display per-test time information:

![image](https://github.com/nv-legate/legate.core/assets/1078448/b3c9eac2-7437-4883-b01f-cdd31918bf83)

## Notes

This feature is probably best used as a diagnostic tool for specific situations, rather than enabled by default. Given the extreme ranges of hardware and tests that may be encountered, there is not a reasonable "global default". Instead, when a hanging test is encountered, the `--timeout` may be set in order to determine what test is hanging. 

Lastly, if GPU tests timeout it appears that some subsequent tests run before resources are released, resulting in spurious `(exit: 250)` failures. Perhaps adding a delay after a timeout could remedy this. 
