### PR TITLE
Have each test worker stick to its original shard

### DIFF
--- a/legate/tester/stages/test_stage.py
+++ b/legate/tester/stages/test_stage.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import multiprocessing
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 from typing_extensions import Protocol
 
@@ -56,6 +57,12 @@ class TestStage(Protocol):
 
     #: Any fixed stage-specific command-line args to pass
     args: ArgList
+
+    #: Shard assigned to each worker in the pool.
+    #: Each worker in the pool will get a local copy of this attribute,
+    #: will populate it on first touch by pulling from the global shard
+    #: queue, then keep using its assigned shard throughout the run.
+    worker_shard: Union[Shard, None] = None
 
     # --- Protocol methods
 
@@ -246,13 +253,14 @@ class TestStage(Protocol):
             Process execution wrapper
 
         """
-        test_path = config.root_dir / test_file
+        if self.worker_shard is None:
+            self.worker_shard = self.shards.get()
 
-        shard = self.shards.get()
+        test_path = config.root_dir / test_file
 
         cov_args = self.cov_args(config)
 
-        stage_args = self.args + self.shard_args(shard, config)
+        stage_args = self.args + self.shard_args(self.worker_shard, config)
         file_args = self.file_args(test_file, config)
 
         cmd = (
@@ -267,7 +275,7 @@ class TestStage(Protocol):
         if custom_args:
             cmd += custom_args
 
-        self.delay(shard, config, system)
+        self.delay(self.worker_shard, config, system)
 
         result = system.run(
             cmd,
@@ -276,8 +284,6 @@ class TestStage(Protocol):
             timeout=config.timeout,
         )
         log_proc(self.name, result, config, verbose=config.verbose)
-
-        self.shards.put(shard)
 
         return result
 


### PR DESCRIPTION
Currently a worker will pick a new shard out of the global queue (in FIFO order) as it starts each test. In cases where one test is taking significantly longer than others, it might happen that enough other workers pick up the same shard as the slow worker, leading to oversubscription and OOM-adjacent issues. Consider the following testing run on a DGX-1V box with 8x 16GB GPUs:

```
mpapadakis@prm-dgx-02:/home/scratch.mpapadakis_sw/py-legate/cunumeric$ for F in temp/*.py; do echo $F; cat $F; echo; done
temp/a.py
from time import sleep
sleep(10)

temp/b.py
from time import sleep
sleep(3)

temp/c.py
from time import sleep
sleep(3)
```

<details>

<summary>Original output</summary>

```

mpapadakis@prm-dgx-04:/home/scratch.mpapadakis_sw/py-legate/cunumeric$ LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH ./test.py --use cuda --gpus 4 --fbmem 10000 --debug --files temp/*.py

################################################################################
###
### Test Suite Configuration
###
### * Feature stages       : cuda
### * Test files per stage : 3
### * TestSystem description   : 40 cpus / 8 gpus
###
################################################################################

################################################################################
### Entering stage: GPU (with 2 workers)
################################################################################

+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 4,5,6,7 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/b.py
[PASS] (GPU) {7.49s} temp/b.py
+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 0,1,2,3 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/a.py
[PASS] (GPU) {14.59s} temp/a.py
+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 0,1,2,3 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/c.py
[FAIL] (GPU) {35.25s} temp/c.py (exit: 250)
                                      GPU: Passed 2 of 3 tests (66.7%) in 46.76s

################################################################################
###
### Exiting stage: GPU
###
### * Results      : 2 / 3 files passed (66.7%)
### * Elapsed time : 0:00:46.756981
###
################################################################################

    ----------------------------------------------------------------------------

################################################################################
### FAILURES
################################################################################

+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 0,1,2,3 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/c.py
[FAIL] (GPU) {35.25s} temp/c.py (exit: 250)


################################################################################
###
### Overall summary
###
### * GPU   : 2 / 3 passed in 46.76s
###
### All tests: Passed 2 of 3 tests (66.7%) in 46.76s
###
################################################################################
```

</details>

In this case, due to memory requirements, there can only be two workers active at the same time, each on a disjoint set of GPUs. The failed execution proceeds as follows:

* Worker 0 starts running `temp/a.py`, gets a shard from the front of the queue (0,1,2,3).
* Worker 1  starts running `temp/b.py`, gets a shard from the front of the queue (4,5,6,7).
* Worker 1 finishes, puts shard (4,5,6,7) to the back of the queue.
* Worker 1 starts running `temp/c.py`, gets a shard from the front of the queue (0,1,2,3).
* There are two concurrent workers trying to run on GPUs 0,1,2,3, requesting in total more framebuffer memory than is available.

With this change, each worker sticks to the first shard that it pulls off the queue, for all the tests that it ends up running. Given that the original split of resources into shards is a safe allocation, it should be fine to continue using it.

<details>

<summary>After</summary>

```
mpapadakis@prm-dgx-02:/home/scratch.mpapadakis_sw/py-legate/cunumeric$ LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH ./test.py --use cuda --gpus 4 --fbmem 10000 --debug --files temp/*.py

################################################################################
###
### Test Suite Configuration
###
### * Feature stages       : cuda
### * Test files per stage : 3
### * TestSystem description   : 40 cpus / 8 gpus
###
################################################################################

################################################################################
### Entering stage: GPU (with 2 workers)
################################################################################

+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 4,5,6,7 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/b.py
[PASS] (GPU) {7.89s} temp/b.py
+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 0,1,2,3 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/a.py
[PASS] (GPU) {15.03s} temp/a.py
+LEGATE_TEST=1 legate --fbmem 10000 --gpus 4 --gpu-bind 4,5,6,7 /home/scratch.mpapadakis_sw/py-legate/cunumeric/temp/c.py
[PASS] (GPU) {6.59s} temp/c.py
                                     GPU: Passed 3 of 3 tests (100.0%) in 18.52s

################################################################################
###
### Exiting stage: GPU
###
### * Results      : 3 / 3 files passed (100.0%)
### * Elapsed time : 0:00:18.520100
###
################################################################################

    ----------------------------------------------------------------------------

################################################################################
###
### Overall summary
###
### * GPU   : 3 / 3 passed in 18.52s
###
### All tests: Passed 3 of 3 tests (100.0%) in 18.52s
###
################################################################################
```

</details>

Note that worker 1 keeps using shard (4,5,6,7) now.