### PR TITLE
Add simple --last-failed option

### DIFF
--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -91,3 +91,6 @@ class CustomTest:
 #:
 #: Client test scripts should udpate this set with their own customizations.
 CUSTOM_FILES: list[CustomTest] = []
+
+#: Location to store a list of last-failed tests
+LAST_FAILED_FILENAME: str = ".legate-test-last-failed"

--- a/legate/tester/args.py
+++ b/legate/tester/args.py
@@ -88,6 +88,14 @@ selection.add_argument(
 )
 
 
+selection.add_argument(
+    "--last-failed",
+    action="store_true",
+    default=False,
+    help="Only run the failed tests from the last run",
+)
+
+
 feature_opts = parser.add_argument_group("Feature stage configuration options")
 
 

--- a/tests/unit/legate/tester/test___init__.py
+++ b/tests/unit/legate/tester/test___init__.py
@@ -27,6 +27,7 @@ from legate.tester import (
     DEFAULT_OMPTHREADS,
     DEFAULT_PROCESS_ENV,
     FEATURES,
+    LAST_FAILED_FILENAME,
     PER_FILE_ARGS,
     SKIPPED_EXAMPLES,
 )
@@ -61,6 +62,9 @@ class TestConsts:
 
     def test_FEATURES(self) -> None:
         assert FEATURES == ("cpus", "cuda", "eager", "openmp")
+
+    def test_LAST_FAILED_FILENAME(self) -> None:
+        assert LAST_FAILED_FILENAME == ".legate-test-last-failed"
 
     def test_SKIPPED_EXAMPLES(self) -> None:
         assert isinstance(SKIPPED_EXAMPLES, set)

--- a/tests/unit/legate/tester/test_args.py
+++ b/tests/unit/legate/tester/test_args.py
@@ -39,6 +39,9 @@ class TestParserDefaults:
     def test_unit(self) -> None:
         assert m.parser.get_default("unit") is False
 
+    def test_last_failed(self) -> None:
+        assert m.parser.get_default("last_failed") is False
+
     def test_cpus(self) -> None:
         assert m.parser.get_default("cpus") == DEFAULT_CPUS_PER_NODE
 

--- a/tests/unit/legate/tester/test_config.py
+++ b/tests/unit/legate/tester/test_config.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path, PurePath
 
 import pytest
+from pytest_mock import MockerFixture
 
 from legate.tester import (
     DEFAULT_CPUS_PER_NODE,
@@ -35,6 +36,8 @@ from legate.tester import (
 from legate.tester.args import PIN_OPTIONS, PinOptionsType
 from legate.util import colors
 
+REPO_TOP = Path(__file__).parents[4]
+
 
 class TestConfig:
     def test_default_init(self) -> None:
@@ -46,6 +49,7 @@ class TestConfig:
         assert c.integration is True
         assert c.unit is False
         assert c.files is None
+        assert c.last_failed is False
 
         assert c.features == ("cpus",)
 
@@ -85,6 +89,14 @@ class TestConfig:
 
         assert colors.ENABLED is True
 
+    def test_files(self) -> None:
+        c = m.Config(["test.py", "--files", "a", "b", "c"])
+        assert c.files == ["a", "b", "c"]
+
+    def test_last_failed(self) -> None:
+        c = m.Config(["test.py", "--last-failed"])
+        assert c.last_failed
+
     @pytest.mark.parametrize("feature", FEATURES)
     def test_env_features(
         self, monkeypatch: pytest.MonkeyPatch, feature: str
@@ -108,19 +120,6 @@ class TestConfig:
         # also test with multiple / duplication
         c = m.Config(["test.py", "--use", f"cpus,{feature}"])
         assert set(c.features) == {"cpus", feature}
-
-    # TODO (bv) restore when generalized
-    @pytest.mark.skip
-    def test_unit(self) -> None:
-        c = m.Config(["test.py", "--unit"])
-        assert len(c.test_files) > 0
-        assert any("examples" in str(x) for x in c.test_files)
-        assert any("integration" in str(x) for x in c.test_files)
-        assert any("unit" in str(x) for x in c.test_files)
-
-    def test_files(self) -> None:
-        c = m.Config(["test.py", "--files", "a", "b", "c"])
-        assert c.files == ["a", "b", "c"]
 
     @pytest.mark.parametrize(
         "opt", ("cpus", "gpus", "gpu-delay", "fbmem", "omps", "ompthreads")
@@ -202,3 +201,43 @@ class TestConfig:
         cov_args = ["--cov-args", "run -a"]
         c = m.Config(["test.py"] + cov_args)
         assert c.cov_args == "run -a"
+
+
+class Test_test_files:
+    def test_basic(self) -> None:
+        c = m.Config(["test.py", "--root-dir", str(REPO_TOP)])
+
+        # if legate.tester style examples or integration tests are
+        # ever added to this repo, then these can be enabled
+        # assert len(c.test_files) > 0
+        # assert any("examples" in str(x) for x in c.test_files)
+        # assert any("integration" in str(x) for x in c.test_files)
+
+        assert not any("unit" in str(x) for x in c.test_files)
+
+    # works because we have unit tests in this repo
+    def test_unit(self) -> None:
+        c = m.Config(["test.py", "--unit", "--root-dir", str(REPO_TOP)])
+        assert len(c.test_files) > 0
+        assert any("unit" in str(x) for x in c.test_files)
+
+    def test_error(self) -> None:
+        c = m.Config(["test.py", "--files", "a", "b", "--last-failed"])
+        with pytest.raises(RuntimeError):
+            c.test_files
+
+    @pytest.mark.parametrize("data", ("", " ", "\n", " \n "))
+    def test_last_failed_empty(self, mocker: MockerFixture, data: str) -> None:
+        mock_last_failed = mocker.mock_open(read_data=data)
+        mocker.patch("builtins.open", mock_last_failed)
+        c1 = m.Config(
+            ["test.py", "--last-failed", "--root-dir", str(REPO_TOP)]
+        )
+        c2 = m.Config(["test.py", "--root-dir", str(REPO_TOP)])
+        assert c1.test_files == c2.test_files
+
+    def test_last_failed(self, mocker: MockerFixture) -> None:
+        mock_last_failed = mocker.mock_open(read_data="\nfoo\nbar\nbaz\n")
+        mocker.patch("builtins.open", mock_last_failed)
+        c = m.Config(["test.py", "--last-failed", "--root-dir", str(REPO_TOP)])
+        assert c.test_files == (Path("foo"), Path("bar"), Path("baz"))


### PR DESCRIPTION
This PR adds a basic `--last-failed` option to `legate.tester` that can be use to re-run only the failed tests from the last test execution. 

This implementation is fairly simplistic. Some notes:

*  `--last-failed` will only be used by actual humans doing local testing, and will be re-run from the same directory is was just previously run from. A hidden text file with test  paths is saved in the current directory and recorded test paths are not "absolute-ized", but these things could be made more sophisticated if necessary (configurable save location, etc). 

* Failed tests are recorded once, regardless of what feature(s) they failed for (`cpus`, `eager`, etc), and will be re-run for every feature that is chosen on the next run. More work would be needed to support an automatic "exact replay" mode that took features into account. (We would have to ignore user-supplied `--features` which might be confusing, or be explicitly incompatible with user-supplied `--features` which might be annoying)

* Currently `--last-failed` is made explicitly incompatible with `--files` but this could potentially be relaxed if supporting that combination seems important. 
* 