### PR TITLE
site.getsitepackages() returns a list of paths, not a path

### DIFF
--- a/install.py
+++ b/install.py
@@ -162,9 +162,9 @@ def get_install_dir():
         return user_site_pkgs
 
     # Otherwise fallback to regular site-packages?
-    if os.path.exists(site_pkgs := site.getsitepackages()):
-        return site_pkgs
-
+    for site_pkgs in site.getsitepackages():
+        if os.path.exists(site_pkgs):
+            return site_pkgs
 
 def install_legion_python_bindings(
     verbose, cmake_exe, legate_build_dir, legion_dir, install_dir


### PR DESCRIPTION
The install.py script fails when falling back to using site.getsitepackages() to determine install path.