### PR TITLE
Add start/end timestamps to test results

### DIFF
--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -20,7 +20,7 @@ from typing import Tuple, Union
 
 from typing_extensions import TypeAlias
 
-from ...util.ui import failed, passed, shell, skipped, timeout
+from ...util.ui import dim, failed, passed, shell, skipped, timeout, yellow
 from ..config import Config
 from ..logger import LOG
 from ..test_system import ProcessResult
@@ -123,11 +123,15 @@ def log_proc(
     """Log a process result according to the current configuration"""
     if config.debug or config.dry_run:
         LOG(shell(proc.invocation))
-    duration = (
-        f" {{{proc.time.total_seconds():0.2f}s}}"
-        if proc.time is not None
-        else ""
-    )
+
+    if proc.time is None or proc.start is None or proc.end is None:
+        duration = ""
+    else:
+        time = yellow(f"{proc.time.total_seconds():0.2f}s")
+        start = f"{proc.start.strftime('%H:%M:%S.%f')[:-4]}"
+        end = f"{proc.end.strftime('%H:%M:%S.%f')[:-4]}"
+        duration = f" {yellow(time)} " + dim(f"{{{start}, {end}}}")
+
     msg = f"({name}){duration} {proc.test_file}"
     details = proc.output.split("\n") if verbose else None
     if proc.skipped:

--- a/legate/tester/stages/util.py
+++ b/legate/tester/stages/util.py
@@ -127,9 +127,9 @@ def log_proc(
     if proc.time is None or proc.start is None or proc.end is None:
         duration = ""
     else:
-        time = yellow(f"{proc.time.total_seconds():0.2f}s")
-        start = f"{proc.start.strftime('%H:%M:%S.%f')[:-4]}"
-        end = f"{proc.end.strftime('%H:%M:%S.%f')[:-4]}"
+        time = f"{proc.time.total_seconds():0.2f}s"
+        start = proc.start.strftime("%H:%M:%S.%f")[:-4]
+        end = proc.end.strftime("%H:%M:%S.%f")[:-4]
         duration = f" {yellow(time)} " + dim(f"{{{start}, {end}}}")
 
     msg = f"({name}){duration} {proc.test_file}"

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -49,7 +49,7 @@ class ProcessResult:
     #: The time the process started
     start: datetime | None = None
 
-    #: The time the process started
+    #: The time the process ended
     end: datetime | None = None
 
     #: Whether this process was actually invoked

--- a/legate/tester/test_system.py
+++ b/legate/tester/test_system.py
@@ -43,11 +43,14 @@ class ProcessResult:
     #: The command invovation, including relevant environment vars
     invocation: str
 
-    #  User-friendly test file path to use in reported output
+    #: User-friendly test file path to use in reported output
     test_file: Path
 
-    #: The time the process took to execute in seconds
-    time: timedelta | None = None
+    #: The time the process started
+    start: datetime | None = None
+
+    #: The time the process started
+    end: datetime | None = None
 
     #: Whether this process was actually invoked
     skipped: bool = False
@@ -60,6 +63,12 @@ class ProcessResult:
 
     #: The collected stdout and stderr output from the process
     output: str = ""
+
+    @property
+    def time(self) -> timedelta | None:
+        if self.start is None or self.end is None:
+            return None
+        return self.end - self.start
 
     @property
     def passed(self) -> bool:
@@ -129,7 +138,7 @@ class TestSystem(System):
         full_env = dict(os.environ)
         full_env.update(env)
 
-        t0 = datetime.now()
+        start = datetime.now()
         try:
             proc = stdlib_run(
                 cmd,
@@ -143,11 +152,13 @@ class TestSystem(System):
         except TimeoutExpired:
             return ProcessResult(invocation, test_file, timeout=True)
 
-        t1 = datetime.now()
+        end = datetime.now()
+
         return ProcessResult(
             invocation,
             test_file,
-            time=t1 - t0,
+            start=start,
+            end=end,
             returncode=proc.returncode,
             output=proc.stdout,
         )

--- a/tests/unit/legate/tester/stages/test_util.py
+++ b/tests/unit/legate/tester/stages/test_util.py
@@ -17,7 +17,7 @@
 """
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -169,14 +169,14 @@ class Test_log_proc:
     def test_time(self) -> None:
         config = Config([])
         config.debug = True
-        proc = ProcessResult(
-            "proc", Path("proc"), time=timedelta(seconds=2.41)
-        )
+        start = datetime.now()
+        end = start + timedelta(seconds=2.41)
+
+        proc = ProcessResult("proc", Path("proc"), start=start, end=end)
 
         LOG.clear()
         m.log_proc("foo", proc, config, verbose=False)
 
-        assert LOG.lines == (
-            shell(proc.invocation),
-            passed(f"(foo) {{2.41s}} {proc.test_file}"),
-        )
+        assert LOG.lines[0] == shell(proc.invocation)
+        assert LOG.lines[1].startswith(passed("(foo) 2.41s {"))
+        assert LOG.lines[1].endswith(f"}} {proc.test_file}")


### PR DESCRIPTION
This PR adds start and end timestams to the test output, in case it is needed for detailed observation of the test plan exectution.  

![image](https://github.com/nv-legate/legate.core/assets/1078448/95d80122-71e6-48c7-a5c2-f93ae7fd7998)
