### PR TITLE
avoid undefined behavior in `Span::end`

### DIFF
--- a/src/core/utilities/span.h
+++ b/src/core/utilities/span.h
@@ -68,13 +68,13 @@ struct Span {
    *
    * @return Pointer to the first element
    */
-  const T* begin() const { return &data_[0]; }
+  const T* begin() const { return data_; }
   /**
    * @brief Returns the pointer to the end of allocation
    *
    * @return Pointer to the end of allocation
    */
-  const T* end() const { return &data_[size_]; }
+  const T* end() const { return data_ + size_; }
 
  public:
   /**


### PR DESCRIPTION
The expression `&data[size_]` is forming a reference to the last+1 element of the range. That memory address may not be dereferencable.

Rather than forming a reference and taking the address, we can obtain the same result with some simple pointer arithmetic.