### PR TITLE
usage of protocol does not work with 3.9

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from argparse import Action, ArgumentParser
 from dataclasses import dataclass
 from textwrap import indent
-from typing import Literal, Protocol, Tuple
+from typing import Literal, Tuple
 
 # --- Types -------------------------------------------------------------------
 
@@ -29,7 +29,7 @@ def V(version: str) -> tuple[int, ...]:
     return tuple(int(x) for x in padded_version)
 
 
-class SectionConfig(Protocol):
+class SectionConfig:
     header: str
 
     @property


### PR DESCRIPTION
@manopapad for some reason the original code does not work on perlmutter `module python` (3.9) during bootstrapping instructions. I think this is fine though/