### PR TITLE
Add a small type cache for array-typed scalar arguments

### DIFF
--- a/docs/legate/core/source/api/runtime.rst
+++ b/docs/legate/core/source/api/runtime.rst
@@ -66,6 +66,7 @@ Legate Runtime
    runtime.Runtime.push_provenance
    runtime.Runtime.pop_provenance
    runtime.Runtime.track_provenance
+   runtime.Runtime.find_or_create_array_type
 
 
 Annotation

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -135,7 +135,7 @@ class ScalarArg:
 
         elem_dtype = self._dtype[0]
         serialize = _SERIALIZERS[elem_dtype]
-        dtype = ty.array_type(elem_dtype, len(self._value))
+        dtype = runtime.find_or_create_array_type(elem_dtype, len(self._value))
         dtype.serialize(buf)
         for v in self._value:
             serialize(buf, v)

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1131,6 +1131,8 @@ class Runtime:
             ProcessorKind.CPU: self.core_library.LEGATE_CPU_VARIANT,
         }
 
+        self._array_type_cache: dict[tuple[ty.Dtype, int], ty.Dtype] = {}
+
     @property
     def has_cpu_communicator(self) -> bool:
         return self._comm_manager.has_cpu_communicator
@@ -2085,6 +2087,17 @@ class Runtime:
                 return result
 
         return wrapper
+
+    def find_or_create_array_type(
+        self, elem_type: ty.Dtype, n: int
+    ) -> ty.Dtype:
+        key = (elem_type, n)
+        cached = self._array_type_cache.get(key)
+        if cached is not None:
+            return cached
+        arr_type = ty.array_type(elem_type, n)
+        self._array_type_cache[key] = arr_type
+        return arr_type
 
 
 runtime: Runtime = Runtime(core_library)

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -2091,6 +2091,26 @@ class Runtime:
     def find_or_create_array_type(
         self, elem_type: ty.Dtype, n: int
     ) -> ty.Dtype:
+        """
+        Finds or creates a fixed array type for a given element type and a
+        size.
+
+        Returns the same array type for the same element type and array size.
+
+        Parameters
+        ----------
+        elem_type : Dtype
+            Element type
+
+        n : int
+            Array size
+
+        Returns
+        -------
+        Dtype
+            Fixed-size array type unique to each pair of an element type and
+            a size
+        """
         key = (elem_type, n)
         if key not in self._array_type_cache:
             self._array_type_cache[key] = ty.array_type(elem_type, n)

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -2092,12 +2092,9 @@ class Runtime:
         self, elem_type: ty.Dtype, n: int
     ) -> ty.Dtype:
         key = (elem_type, n)
-        cached = self._array_type_cache.get(key)
-        if cached is not None:
-            return cached
-        arr_type = ty.array_type(elem_type, n)
-        self._array_type_cache[key] = arr_type
-        return arr_type
+        if key not in self._array_type_cache:
+            self._array_type_cache[key] = ty.array_type(elem_type, n)
+        return self._array_type_cache[key]
 
 
 runtime: Runtime = Runtime(core_library)

--- a/tests/unit/legate/core/test_type_cache.py
+++ b/tests/unit/legate/core/test_type_cache.py
@@ -1,0 +1,37 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from legate.core import get_legate_runtime, types as ty
+
+
+class Test_type_cache:
+    def test_cache(self) -> None:
+        runtime = get_legate_runtime()
+        t_i64_2_1 = runtime.find_or_create_array_type(ty.int64, 2)
+        t_i64_2_2 = runtime.find_or_create_array_type(ty.int64, 2)
+        t_i64_3 = runtime.find_or_create_array_type(ty.int64, 3)
+        t_i32_2 = runtime.find_or_create_array_type(ty.int32, 2)
+
+        assert t_i64_2_1 is t_i64_2_2
+        assert t_i64_2_1.uid != t_i64_3.uid
+        assert t_i64_2_1.uid != t_i32_2.uid
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
This PR adds a small type cache for array-typed scalar arguments so their types are deduplicated. Creating a fresh array type whenever an array-typed scalar argument is passed to a task turns out to be problematic for any attempt to cache task metadata.