### PR TITLE
More error checking for stores

### DIFF
--- a/src/core/data/store.h
+++ b/src/core/data/store.h
@@ -267,6 +267,7 @@ class FutureWrapper {
 
 /**
  * @ingroup data
+ *
  * @brief A multi-dimensional data container storing task data
  */
 class Store {
@@ -338,8 +339,13 @@ class Store {
 
  public:
   /**
-   * @brief Returns a read-only accessor to the store for the entire domain. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a read-only accessor to the store for the entire domain.
+   *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
    *
    * @return A read-only accessor to the store
    */
@@ -349,6 +355,12 @@ class Store {
    * @brief Returns a write-only accessor to the store for the entire domain. Validates type and
    * dimension by default, disable with VALIDATE_TYPE = false.
    *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
+   *
    * @return A write-only accessor to the store
    */
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
@@ -356,6 +368,12 @@ class Store {
   /**
    * @brief Returns a read-write accessor to the store for the entire domain. Validates type and
    * dimension by default, disable with VALIDATE_TYPE = false.
+   *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
    *
    * @return A read-write accessor to the store
    */
@@ -370,15 +388,25 @@ class Store {
    * @tparam EXCLUSIVE Indicates whether reductions can be performed in exclusive mode. If
    * `EXCLUSIVE` is `false`, every reduction via the acecssor is performed atomically.
    *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
+   *
    * @return A reduction accessor to the store
    */
-  template <typename OP, bool EXCLUSIVE, int32_t DIM>
+  template <typename OP, bool EXCLUSIVE, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor() const;
 
  public:
   /**
    * @brief Returns a read-only accessor to the store for specific bounds. Validates type and
    * dimension by default, disable with VALIDATE_TYPE = false.
+   *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
    *
    * @param bounds Domain within which accesses should be allowed.
    * The actual bounds for valid access are determined by an intersection between
@@ -392,6 +420,12 @@ class Store {
    * @brief Returns a write-only accessor to the store for the entire domain. Validates type and
    * dimension by default, disable with VALIDATE_TYPE = false.
    *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
+   *
    * @param bounds Domain within which accesses should be allowed.
    * The actual bounds for valid access are determined by an intersection between
    * the store's domain and the bounds.
@@ -403,6 +437,12 @@ class Store {
   /**
    * @brief Returns a read-write accessor to the store for the entire domain. Validates type and
    * dimension by default, disable with VALIDATE_TYPE = false.
+   *
+   * @tparam T Element type
+   *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
    *
    * @param bounds Domain within which accesses should be allowed.
    * The actual bounds for valid access are determined by an intersection between
@@ -425,9 +465,13 @@ class Store {
    * @tparam EXCLUSIVE Indicates whether reductions can be performed in exclusive mode. If
    * `EXCLUSIVE` is `false`, every reduction via the acecssor is performed atomically.
    *
+   * @tparam DIM Number of dimensions
+   *
+   * @tparam VALIDATE_TYPE If `true` (default), validates type and number of dimensions
+   *
    * @return A reduction accessor to the store
    */
-  template <typename OP, bool EXCLUSIVE, int32_t DIM>
+  template <typename OP, bool EXCLUSIVE, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRD<OP, EXCLUSIVE, DIM> reduce_accessor(const Rect<DIM>& bounds) const;
 
  public:
@@ -548,9 +592,10 @@ class Store {
   void remove_transform();
 
  private:
-  void check_valid_return() const;
-  void check_buffer_dimension(const int32_t dim) const;
   void check_accessor_dimension(const int32_t dim) const;
+  void check_buffer_dimension(const int32_t dim) const;
+  void check_shape_dimension(const int32_t dim) const;
+  void check_valid_binding() const;
   template <typename T>
   void check_accessor_type() const;
 

--- a/src/core/data/store.h
+++ b/src/core/data/store.h
@@ -352,8 +352,7 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRO<T, DIM> read_accessor() const;
   /**
-   * @brief Returns a write-only accessor to the store for the entire domain. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a write-only accessor to the store for the entire domain.
    *
    * @tparam T Element type
    *
@@ -366,8 +365,7 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorWO<T, DIM> write_accessor() const;
   /**
-   * @brief Returns a read-write accessor to the store for the entire domain. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a read-write accessor to the store for the entire domain.
    *
    * @tparam T Element type
    *
@@ -380,13 +378,13 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRW<T, DIM> read_write_accessor() const;
   /**
-   * @brief Returns a reduction accessor to the store for the entire domain
+   * @brief Returns a reduction accessor to the store for the entire domain.
    *
    * @tparam OP Reduction operator class. For details about reduction operators, See
    * LibraryContext::register_reduction_operator.
    *
    * @tparam EXCLUSIVE Indicates whether reductions can be performed in exclusive mode. If
-   * `EXCLUSIVE` is `false`, every reduction via the acecssor is performed atomically.
+   * `EXCLUSIVE` is `false`, every reduction via the accessor is performed atomically.
    *
    * @tparam DIM Number of dimensions
    *
@@ -399,8 +397,7 @@ class Store {
 
  public:
   /**
-   * @brief Returns a read-only accessor to the store for specific bounds. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a read-only accessor to the store for specific bounds.
    *
    * @tparam T Element type
    *
@@ -417,8 +414,7 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRO<T, DIM> read_accessor(const Rect<DIM>& bounds) const;
   /**
-   * @brief Returns a write-only accessor to the store for the entire domain. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a write-only accessor to the store for the entire domain.
    *
    * @tparam T Element type
    *
@@ -435,8 +431,7 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorWO<T, DIM> write_accessor(const Rect<DIM>& bounds) const;
   /**
-   * @brief Returns a read-write accessor to the store for the entire domain. Validates type and
-   * dimension by default, disable with VALIDATE_TYPE = false.
+   * @brief Returns a read-write accessor to the store for the entire domain.
    *
    * @tparam T Element type
    *
@@ -453,7 +448,7 @@ class Store {
   template <typename T, int32_t DIM, bool VALIDATE_TYPE = true>
   AccessorRW<T, DIM> read_write_accessor(const Rect<DIM>& bounds) const;
   /**
-   * @brief Returns a reduction accessor to the store for the entire domain
+   * @brief Returns a reduction accessor to the store for the entire domain.
    *
    * @param bounds Domain within which accesses should be allowed.
    * The actual bounds for valid access are determined by an intersection between
@@ -463,7 +458,7 @@ class Store {
    * LibraryContext::register_reduction_operator.
    *
    * @tparam EXCLUSIVE Indicates whether reductions can be performed in exclusive mode. If
-   * `EXCLUSIVE` is `false`, every reduction via the acecssor is performed atomically.
+   * `EXCLUSIVE` is `false`, every reduction via the accessor is performed atomically.
    *
    * @tparam DIM Number of dimensions
    *

--- a/src/core/data/store.inl
+++ b/src/core/data/store.inl
@@ -276,22 +276,17 @@ void Store::check_accessor_type() const
   if (in_type == this->code()) return;
   // Test exact match for primitive types
   if (in_type != Type::Code::INVALID) {
-    log_legate.error(
-      "Type mismatch: %s accessor to a %s store. Disable type checking via "
-      "accessor template parameter if this is intended.",
-      PrimitiveType(in_type).to_string().c_str(),
-      this->type().to_string().c_str());
-    LEGATE_ABORT;
+    throw std::invalid_argument(
+      "Type mismatch: " + PrimitiveType(in_type).to_string() + " accessor to a " +
+      type().to_string() +
+      " store. Disable type checking via accessor template parameter if this is intended.");
   }
   // Test size matches for other types
-  if (sizeof(T) != this->type().size()) {
-    log_legate.error(
-      "Type size mismatch: store type %s has size %d, requested type has size %d. Disable type "
-      "checking via accessor template parameter if this is intended.",
-      this->type().to_string().c_str(),
-      this->type().size(),
-      sizeof(T));
-    LEGATE_ABORT;
+  if (sizeof(T) != type().size()) {
+    throw std::invalid_argument(
+      "Type size mismatch: store type " + type().to_string() + " has size " +
+      std::to_string(type().size()) + ", requested type has size " + std::to_string(sizeof(T)) +
+      ". Disable type checking via accessor template parameter if this is intended.");
   }
 }
 
@@ -346,12 +341,14 @@ AccessorRW<T, DIM> Store::read_write_accessor() const
   return region_field_.read_write_accessor<T, DIM>(shape<DIM>());
 }
 
-template <typename OP, bool EXCLUSIVE, int DIM>
+template <typename OP, bool EXCLUSIVE, int DIM, bool VALIDATE_TYPE>
 AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor() const
 {
-#ifdef DEBUG_LEGATE
-  check_accessor_dimension(DIM);
-#endif
+  using T = typename OP::LHS;
+  if constexpr (VALIDATE_TYPE) {
+    check_accessor_dimension(DIM);
+    check_accessor_type<T>();
+  }
 
   if (is_future_) return future_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, shape<DIM>());
 
@@ -387,10 +384,6 @@ AccessorWO<T, DIM> Store::write_accessor(const Rect<DIM>& bounds) const
     check_accessor_type<T>();
   }
 
-#ifdef DEBUG_LEGATE
-  check_accessor_dimension(DIM);
-#endif
-
   if (is_future_) return future_.write_accessor<T, DIM>(bounds);
 
   if (!transform_->identity()) {
@@ -417,12 +410,14 @@ AccessorRW<T, DIM> Store::read_write_accessor(const Rect<DIM>& bounds) const
   return region_field_.read_write_accessor<T, DIM>(bounds);
 }
 
-template <typename OP, bool EXCLUSIVE, int DIM>
+template <typename OP, bool EXCLUSIVE, int DIM, bool VALIDATE_TYPE>
 AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Rect<DIM>& bounds) const
 {
-#ifdef DEBUG_LEGATE
-  check_accessor_dimension(DIM);
-#endif
+  using T = typename OP::LHS;
+  if constexpr (VALIDATE_TYPE) {
+    check_accessor_dimension(DIM);
+    check_accessor_type<T>();
+  }
 
   if (is_future_) return future_.reduce_accessor<OP, EXCLUSIVE, DIM>(redop_id_, bounds);
 
@@ -436,28 +431,18 @@ AccessorRD<OP, EXCLUSIVE, DIM> Store::reduce_accessor(const Rect<DIM>& bounds) c
 template <typename T, int32_t DIM>
 Buffer<T, DIM> Store::create_output_buffer(const Point<DIM>& extents, bool bind_buffer /*= false*/)
 {
-#ifdef DEBUG_LEGATE
-  check_valid_return();
+  check_valid_binding();
   check_buffer_dimension(DIM);
-#endif
   return unbound_field_.create_output_buffer<T, DIM>(extents, bind_buffer);
 }
 
 template <int32_t DIM>
 Rect<DIM> Store::shape() const
 {
-#ifdef DEBUG_LEGATE
-  if (!(DIM == dim_ || (dim_ == 0 && DIM == 1))) {
-    log_legate.error(
-      "Dimension mismatch: invalid to retrieve a %d-D shape from a %d-D store", DIM, dim_);
-    LEGATE_ABORT;
-  }
-#endif
-
-  auto dom = domain();
-  if (dom.dim > 0)
-    return dom.bounds<DIM, Legion::coord_t>();
-  else {
+  check_shape_dimension(DIM);
+  if (dim_ > 0) {
+    return domain().bounds<DIM, Legion::coord_t>();
+  } else {
     auto p = Point<DIM>::ZEROES();
     return Rect<DIM>(p, p);
   }
@@ -466,19 +451,15 @@ Rect<DIM> Store::shape() const
 template <typename VAL>
 VAL Store::scalar() const
 {
-#ifdef DEBUG_LEGATE
-  assert(is_future_);
-#endif
+  if (!is_future_) throw std::invalid_argument("Scalars can be retrieved only from scalar stores");
   return future_.scalar<VAL>();
 }
 
 template <typename T, int32_t DIM>
 void Store::bind_data(Buffer<T, DIM>& buffer, const Point<DIM>& extents)
 {
-#ifdef DEBUG_LEGATE
-  check_valid_return();
+  check_valid_binding();
   check_buffer_dimension(DIM);
-#endif
   unbound_field_.bind_data(buffer, extents);
 }
 


### PR DESCRIPTION
This PR makes two changes to error checking for `legate::Store`

1) Type validation for reduction accessors (was missing in #745)
2) Exceptions instead of `LEGATE_ABORT`