### PR TITLE
Use ordered future map reductions by default

### DIFF
--- a/legate/core/_legion/future.py
+++ b/legate/core/_legion/future.py
@@ -269,7 +269,7 @@ class FutureMap:
         context: legion.legion_context_t,
         runtime: legion.legion_runtime_t,
         redop: int,
-        deterministic: bool = False,
+        ordered: bool = True,
         mapper: int = 0,
         tag: int = 0,
     ) -> Future:
@@ -285,8 +285,9 @@ class FutureMap:
             The Legion runtime handle
         redop : int
             ID for the reduction operator to use for reducing futures
-        deterministic : bool
-            Whether this reduction needs to be performed deterministically
+        ordered : bool
+            If ``True``, reductions are performed in an ordered manner
+            so the result is deterministic
         mapper : int
             ID of the mapper for managing the mapping of the task
         tag : int
@@ -302,7 +303,7 @@ class FutureMap:
                 context,
                 self.handle,
                 redop,
-                deterministic,
+                ordered,
                 mapper,
                 tag,
             )

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1909,7 +1909,10 @@ class Runtime:
         return launcher.execute(launch_domain).future_map
 
     def reduce_future_map(
-        self, future_map: Union[Future, FutureMap], redop: int
+        self,
+        future_map: Union[Future, FutureMap],
+        redop: int,
+        ordered: bool = True,
     ) -> Future:
         if isinstance(future_map, Future):
             return future_map
@@ -1918,6 +1921,7 @@ class Runtime:
                 self.legion_context,
                 self.legion_runtime,
                 redop,
+                ordered=ordered,
                 mapper=self.core_context.mapper_id,
             )
 


### PR DESCRIPTION
Legion recently changed future map reductions to be ordered by default so all the shards would see the same results, but Legate hasn't been using them, which this PR fixes.