### PR TITLE
Update Thrust to the latest version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 # - Download and initialize RAPIDS CMake helpers -----------------------------
 
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.08/RAPIDS.cmake
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.10/RAPIDS.cmake
        ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 endif()
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,9 +1,9 @@
 {
   "packages" : {
     "Thrust" : {
-      "version" : "1.17.0.0",
+      "version" : "2.1.0.0",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "1.17.0"
+      "git_tag" : "2.1.0"
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",


### PR DESCRIPTION
This update will have impact on the CTK requirement. There is be a corresponding cunumeric PR to test the impact of the update on cunumeric: nv-legate/cunumeric#1006