### PR TITLE
Pre-seeding random nuber generators

### DIFF
--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -131,8 +131,8 @@ _np.random.seed(1234)
 _random.seed(1234)
 
 
-def _warn_seed(func):
-    def wrapper(*args, **kw):
+def _warn_seed(func: AnyCallable)->AnyCallable:
+    def wrapper(*args:Any, **kw:Any)->Any:
         print(
             "WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks."
         )

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -124,11 +124,11 @@ from .types import (
 )
 from .io import CustomSplit, TiledSplit, ingest
 
+import warnings
 import numpy as _np
 import random as _random
 from typing import Any
 from .runtime import AnyCallable
-from ..util.ui import warn
 
 _np.random.seed(1234)
 _random.seed(1234)
@@ -136,13 +136,11 @@ _random.seed(1234)
 
 def _warn_seed(func: AnyCallable) -> AnyCallable:
     def wrapper(*args: Any, **kw: Any) -> Any:
-        print(
-            warn(
-                "Seeding the random number generator with a non-constant value "
-                "inside Legate can lead to undefined behavior and/or errors when "
-                "the program is executed with multiple ranks."
-            )
-        )
+        msg = """
+        Seeding the random number generator with a non-constant value 
+        inside Legate can lead to undefined behavior and/or errors when 
+        the program is executed with multiple ranks."""
+        warnings.warn(msg, Warning)
         return func(*args, **kw)
 
     return wrapper

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -123,3 +123,19 @@ from .types import (
     ReductionOp,
 )
 from .io import CustomSplit, TiledSplit, ingest
+
+import numpy as _np
+import random as _random
+
+_np.random.seed(1234)
+_random.seed(1234)
+
+def _warn_seed(func):
+    def wrapper(*args, **kw):
+        print("WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks.")
+        return func(*args, **kw)
+    return wrapper
+
+
+_np.random.seed = _warn_seed(_np.random.seed)
+_random.seed= _warn_seed(_random.seed)

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -136,7 +136,9 @@ _random.seed(1234)
 def _warn_seed(func: AnyCallable) -> AnyCallable:
     def wrapper(*args: Any, **kw: Any) -> Any:
         print(
-            "WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks."
+            "Seeding the random number generator with a non-constant value "
+            "inside Legate can lead to undefined behavior and/or errors when "
+            "the program is executed with multiple ranks."
         )
         return func(*args, **kw)
 

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -130,12 +130,16 @@ import random as _random
 _np.random.seed(1234)
 _random.seed(1234)
 
+
 def _warn_seed(func):
     def wrapper(*args, **kw):
-        print("WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks.")
+        print(
+            "WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks."
+        )
         return func(*args, **kw)
+
     return wrapper
 
 
 _np.random.seed = _warn_seed(_np.random.seed)
-_random.seed= _warn_seed(_random.seed)
+_random.seed = _warn_seed(_random.seed)

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -128,6 +128,7 @@ import numpy as _np
 import random as _random
 from typing import Any
 from .runtime import AnyCallable
+from ..util.ui import warn
 
 _np.random.seed(1234)
 _random.seed(1234)
@@ -136,9 +137,11 @@ _random.seed(1234)
 def _warn_seed(func: AnyCallable) -> AnyCallable:
     def wrapper(*args: Any, **kw: Any) -> Any:
         print(
-            "Seeding the random number generator with a non-constant value "
-            "inside Legate can lead to undefined behavior and/or errors when "
-            "the program is executed with multiple ranks."
+            warn(
+                "Seeding the random number generator with a non-constant value "
+                "inside Legate can lead to undefined behavior and/or errors when "
+                "the program is executed with multiple ranks."
+            )
         )
         return func(*args, **kw)
 

--- a/legate/core/__init__.py
+++ b/legate/core/__init__.py
@@ -126,13 +126,15 @@ from .io import CustomSplit, TiledSplit, ingest
 
 import numpy as _np
 import random as _random
+from typing import Any
+from .runtime import AnyCallable
 
 _np.random.seed(1234)
 _random.seed(1234)
 
 
-def _warn_seed(func: AnyCallable)->AnyCallable:
-    def wrapper(*args:Any, **kw:Any)->Any:
+def _warn_seed(func: AnyCallable) -> AnyCallable:
+    def wrapper(*args: Any, **kw: Any) -> Any:
         print(
             "WARNING: Seeding the random number generator inside the legate-based code can lead to undefined behavior and/or errors when the program is executed with multiple ranks."
         )


### PR DESCRIPTION
We want to seed `np.random` and `random` to avoid control-replication violations when running multi-rank.
We also want to warn users who tries to call `seed` inside of their code (python side)