### PR TITLE
Add support for custom wrappers

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -148,7 +148,7 @@ profiling.add_argument(
     dest="cprofile",
     action="store_true",
     required=False,
-    help="profile Python execution with the cprofile module, "
+    help="profile Python execution with the cprofile module "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -158,7 +158,7 @@ profiling.add_argument(
     dest="nvprof",
     action="store_true",
     required=False,
-    help="run Legate with nvprof, "
+    help="run Legate with nvprof "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -168,7 +168,7 @@ profiling.add_argument(
     dest="nsys",
     action="store_true",
     required=False,
-    help="run Legate with Nsight Systems, "
+    help="run Legate with Nsight Systems "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -178,7 +178,7 @@ profiling.add_argument(
     dest="nsys_targets",
     default="cublas,cuda,cudnn,nvtx,ucx",
     required=False,
-    help="Specify profiling targets for Nsight Systems, "
+    help="Specify profiling targets for Nsight Systems "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -191,7 +191,7 @@ profiling.add_argument(
     required=False,
     help="Specify extra flags for Nsight Systems (can appear more than once). "
     "Multiple arguments may be provided together in a quoted string "
-    "(arguments with spaces inside must be additionally quoted), "
+    "(arguments with spaces inside must be additionally quoted) "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -233,7 +233,7 @@ debugging.add_argument(
     dest="gdb",
     action="store_true",
     required=False,
-    help="run Legate inside gdb, "
+    help="run Legate inside gdb "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -243,7 +243,7 @@ debugging.add_argument(
     dest="cuda_gdb",
     action="store_true",
     required=False,
-    help="run Legate inside cuda-gdb, "
+    help="run Legate inside cuda-gdb "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -253,7 +253,7 @@ debugging.add_argument(
     dest="memcheck",
     action="store_true",
     required=False,
-    help="run Legate with cuda-memcheck, "
+    help="run Legate with cuda-memcheck "
     "[legate-only, not supported with standard Python invocation]",
 )
 debugging.add_argument(
@@ -261,7 +261,7 @@ debugging.add_argument(
     dest="valgrind",
     action="store_true",
     required=False,
-    help="run Legate with valgrind, "
+    help="run Legate with valgrind "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -356,20 +356,48 @@ info.add_argument(
     dest="bind_detail",
     action="store_true",
     required=False,
-    help="print out the final invocation run by bind.sh, "
+    help="print out the final invocation run by bind.sh "
     "[legate-only, not supported with standard Python invocation]",
 )
 
 
 other = parser.add_argument_group("Other options")
 
+other.add_argument(
+    "--wrapper",
+    dest="wrapper",
+    required=False,
+    action="append",
+    default=[],
+    help="Specify another executable (and any command-line arguments for that "
+    "executable) that will be responsible to indirectly invoke legate, "
+    "including any other wrappers. May contain the special string "
+    "%%%%LEGATE_GLOBAL_RANK%%%% that will be replaced with the rank of the "
+    "current process by bind.sh. If multiple --wrapper values are provided, "
+    "they will execute in the order given. "
+    "[legate-only, not supported with standard Python invocation]",
+)
+
+other.add_argument(
+    "--wrapper-inner",
+    dest="wrapper_inner",
+    required=False,
+    action="append",
+    default=[],
+    help="Specify another executable (and any command-line arguments for that "
+    "executable) that will be responsible to directly invoke legate. May "
+    "contain the special string %%%%LEGATE_GLOBAL_RANK%%%% that will be "
+    "replaced with the rank of the current process by bind.sh. If multiple "
+    "--wrapper-inner values are given, they will execute in the order given. "
+    "[legate-only, not supported with standard Python invocation]",
+)
 
 other.add_argument(
     "--module",
     dest="module",
     default=None,
     required=False,
-    help="Specify a Python module to load before running, "
+    help="Specify a Python module to load before running "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -388,7 +416,7 @@ other.add_argument(
     dest="rlwrap",
     action="store_true",
     required=False,
-    help="Whether to run with rlwrap to improve readline ability, "
+    help="Whether to run with rlwrap to improve readline ability "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -409,6 +437,6 @@ other.add_argument(
 other.add_argument(
     "--info",
     action=InfoAction,
-    help="Print information about the capabilities of this build of legate, "
+    help="Print information about the capabilities of this build of legate "
     "and immediately exit.",
 )

--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -370,11 +370,12 @@ other.add_argument(
     action="append",
     default=[],
     help="Specify another executable (and any command-line arguments for that "
-    "executable) that will be responsible to indirectly invoke legate, "
-    "including any other wrappers. May contain the special string "
-    "%%%%LEGATE_GLOBAL_RANK%%%% that will be replaced with the rank of the "
-    "current process by bind.sh. If multiple --wrapper values are provided, "
-    "they will execute in the order given. "
+    "executable) to wrap the Legate executable invocation. This wrapper will "
+    "come right after the launcher invocation, and will be passed the rest of "
+    "the Legate invocation (including any other wrappers) to execute. May "
+    "contain the special string %%%%LEGATE_GLOBAL_RANK%%%% that will be "
+    "replaced with the rank of the current process by bind.sh. If multiple "
+    "--wrapper values are provided, they will execute in the order given. "
     "[legate-only, not supported with standard Python invocation]",
 )
 
@@ -385,10 +386,13 @@ other.add_argument(
     action="append",
     default=[],
     help="Specify another executable (and any command-line arguments for that "
-    "executable) that will be responsible to directly invoke legate. May "
-    "contain the special string %%%%LEGATE_GLOBAL_RANK%%%% that will be "
-    "replaced with the rank of the current process by bind.sh. If multiple "
-    "--wrapper-inner values are given, they will execute in the order given. "
+    "executable) to wrap the Legate executable invocation. This wrapper will "
+    "come right before the legion_python invocation (after any other "
+    "wrappers) and will be passed the rest of the legion_python invocation to "
+    "execute. May contain the special string %%%%LEGATE_GLOBAL_RANK%%%% that "
+    "will be replaced with the rank of the current process by bind.sh. If "
+    "multiple --wrapper-inner values are given, they will execute in the "
+    "order given. "
     "[legate-only, not supported with standard Python invocation]",
 )
 

--- a/legate/driver/command.py
+++ b/legate/driver/command.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import argparse
+import shlex
 from typing import TYPE_CHECKING
 
 from .. import install_info
@@ -201,6 +202,34 @@ def cmd_rlwrap(
     config: ConfigProtocol, system: System, launcher: Launcher
 ) -> CommandPart:
     return ("rlwrap",) if config.other.rlwrap else ()
+
+
+def cmd_wrapper(
+    config: ConfigProtocol, system: System, launcher: Launcher
+) -> CommandPart:
+    if not config.other.wrapper:
+        return ()
+
+    parts = []
+
+    for wrapper in config.other.wrapper:
+        parts.extend(shlex.split(wrapper))
+
+    return tuple(parts)
+
+
+def cmd_wrapper_inner(
+    config: ConfigProtocol, system: System, launcher: Launcher
+) -> CommandPart:
+    if not config.other.wrapper_inner:
+        return ()
+
+    parts = []
+
+    for wrapper in config.other.wrapper_inner:
+        parts.extend(shlex.split(wrapper))
+
+    return tuple(parts)
 
 
 def cmd_legion(
@@ -455,6 +484,8 @@ _CMD_PARTS_SHARED = (
 CMD_PARTS_LEGION = (
     (
         cmd_bind,
+        # Add any user supplied (outer) wrappers
+        cmd_wrapper,
         cmd_rlwrap,
         cmd_gdb,
         cmd_cuda_gdb,
@@ -464,6 +495,8 @@ CMD_PARTS_LEGION = (
         cmd_memcheck,
         # Add valgrind right before the binary
         cmd_valgrind,
+        # Add any user supplied inner wrappers
+        cmd_wrapper_inner,
         # Now we're ready to build the actual command to run
         cmd_legion,
         # This has to go before script name

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -142,6 +142,8 @@ class Info(DataclassMixin):
 
 @dataclass(frozen=True)
 class Other(DataclassMixin):
+    wrapper: list[str]
+    wrapper_inner: list[str]
     module: str | None
     dry_run: bool
     rlwrap: bool

--- a/legate/jupyter/config.py
+++ b/legate/jupyter/config.py
@@ -98,4 +98,4 @@ class Config:
             False,
         )
         self.info = Info(False, False, self.verbose > 0, False)
-        self.other = Other(None, False, False)
+        self.other = Other([], [], None, False, False)

--- a/tests/unit/legate/driver/test_args.py
+++ b/tests/unit/legate/driver/test_args.py
@@ -170,6 +170,12 @@ class TestParserDefaults:
 
     # other
 
+    def test_wrapper(self) -> None:
+        assert m.parser.get_default("wrapper") == []
+
+    def test_wrapper_inner(self) -> None:
+        assert m.parser.get_default("wrapper_inner") == []
+
     def test_module(self) -> None:
         assert m.parser.get_default("module") is None
 

--- a/tests/unit/legate/driver/test_command.py
+++ b/tests/unit/legate/driver/test_command.py
@@ -44,6 +44,7 @@ def test_LEGATE_GLOBAL_RANK_SUBSTITUTION() -> None:
 def test_CMD_PARTS() -> None:
     assert m.CMD_PARTS_LEGION == (
         m.cmd_bind,
+        m.cmd_wrapper,
         m.cmd_rlwrap,
         m.cmd_gdb,
         m.cmd_cuda_gdb,
@@ -51,6 +52,7 @@ def test_CMD_PARTS() -> None:
         m.cmd_nsys,
         m.cmd_memcheck,
         m.cmd_valgrind,
+        m.cmd_wrapper_inner,
         m.cmd_legion,
         m.cmd_python_processor,
         m.cmd_module,
@@ -569,6 +571,60 @@ class Test_cmd_memcheck:
         result = m.cmd_memcheck(config, system, launcher)
 
         assert result == ("compute-sanitizer",)
+
+
+class Test_cmd_wrapper:
+    def test_default(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs([])
+
+        result = m.cmd_wrapper(config, system, launcher)
+
+        assert result == ()
+
+    def test_with_option(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(
+            ["--wrapper", "foo --bar 10 -s -baz=20"]
+        )
+
+        result = m.cmd_wrapper(config, system, launcher)
+
+        assert result == ("foo", "--bar", "10", "-s", "-baz=20")
+
+    def test_multi(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(
+            ["--wrapper", "foo --bar 10", "--wrapper", "baz -s"]
+        )
+
+        result = m.cmd_wrapper(config, system, launcher)
+
+        assert result == ("foo", "--bar", "10", "baz", "-s")
+
+
+class Test_cmd_wrapper_inner:
+    def test_default(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs([])
+
+        result = m.cmd_wrapper_inner(config, system, launcher)
+
+        assert result == ()
+
+    def test_with_option(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(
+            ["--wrapper-inner", "foo --bar 10 -s -baz=20"]
+        )
+
+        result = m.cmd_wrapper_inner(config, system, launcher)
+
+        assert result == ("foo", "--bar", "10", "-s", "-baz=20")
+
+    def test_multi(self, genobjs: GenObjs) -> None:
+        config, system, launcher = genobjs(
+            ["--wrapper-inner", "foo --bar 10", "--wrapper-inner", "baz -s"]
+        )
+
+        result = m.cmd_wrapper_inner(config, system, launcher)
+
+        assert result == ("foo", "--bar", "10", "baz", "-s")
 
 
 class Test_cmd_valgrind:

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -263,6 +263,8 @@ class TestInfo:
 class TestOther:
     def test_fields(self) -> None:
         assert set(m.Other.__dataclass_fields__) == {
+            "wrapper",
+            "wrapper_inner",
             "module",
             "dry_run",
             "rlwrap",
@@ -344,7 +346,13 @@ class TestConfig:
             progress=False, mem_usage=False, verbose=False, bind_detail=False
         )
 
-        assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
+        assert c.other == m.Other(
+            wrapper=[],
+            wrapper_inner=[],
+            module=None,
+            dry_run=False,
+            rlwrap=False,
+        )
 
     def test_color_arg(self) -> None:
         m.Config(["legate", "--color"])

--- a/tests/unit/legate/jupyter/test_config.py
+++ b/tests/unit/legate/jupyter/test_config.py
@@ -113,7 +113,13 @@ class TestConfig:
             progress=False, mem_usage=False, verbose=False, bind_detail=False
         )
 
-        assert c.other == m.Other(module=None, dry_run=False, rlwrap=False)
+        assert c.other == m.Other(
+            wrapper=[],
+            wrapper_inner=[],
+            module=None,
+            dry_run=False,
+            rlwrap=False,
+        )
 
     def test_color_arg(self) -> None:
         m.Config(["legate-jupyter", "--color"])


### PR DESCRIPTION
This PR adds two new command line options `--wrapper` and `--wrapper-inner` to allow users to insert their own custom wrapper executables int the legate invocation chain. 

Both wrappers come after `bind.sh` so that `%%LEGATE_GLOBAL_RANK%%` can be expanded in the invocation. 
