### PR TITLE
Make NCCL warm-up optional

### DIFF
--- a/src/core/runtime/runtime.cc
+++ b/src/core/runtime/runtime.cc
@@ -46,6 +46,8 @@ static const char* const core_library_name = "legate.core";
 
 /*static*/ bool Core::has_socket_mem = false;
 
+/*static*/ bool Core::warmup_nccl = false;
+
 /*static*/ void Core::parse_config(void)
 {
 #ifndef LEGATE_USE_CUDA
@@ -84,6 +86,7 @@ static const char* const core_library_name = "legate.core";
   parse_variable("LEGATE_EMPTY_TASK", use_empty_task);
   parse_variable("LEGATE_SYNC_STREAM_VIEW", synchronize_stream_view);
   parse_variable("LEGATE_LOG_MAPPING", log_mapping_decisions);
+  parse_variable("LEGATE_WARMUP_NCCL", warmup_nccl);
 }
 
 static void extract_scalar_task(

--- a/src/core/runtime/runtime.h
+++ b/src/core/runtime/runtime.h
@@ -76,6 +76,7 @@ struct Core {
   static bool synchronize_stream_view;
   static bool log_mapping_decisions;
   static bool has_socket_mem;
+  static bool warmup_nccl;
 };
 
 class Runtime {


### PR DESCRIPTION
The NCCL initialization task has been performing all-to-all and all-gather to warm up NCCL. This makes it impossible for users to disentangle how much of the task execution time is attributed to the communicator creation vs. the warm-up. This PR makes two changes to the task:

1) the warm-up NCCL calls are performed only when `LEGATE_WARMUP_NCCL` is set to 1;
2) the NCCL initialization task starts to report timings for communicator creation and warm-up at the `DEBUG` logging level (`--logging legate=1` is needed to see them).