### PR TITLE
Add simple --timing flag to driver

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -364,6 +364,15 @@ info.add_argument(
 other = parser.add_argument_group("Other options")
 
 other.add_argument(
+    "--timing",
+    dest="timing",
+    action="store_true",
+    required=False,
+    help="Print overall process start and end timestamps to stdout "
+    "[legate-only, not supported with standard Python invocation]",
+)
+
+other.add_argument(
     "--wrapper",
     dest="wrapper",
     required=False,

--- a/legate/driver/config.py
+++ b/legate/driver/config.py
@@ -142,6 +142,7 @@ class Info(DataclassMixin):
 
 @dataclass(frozen=True)
 class Other(DataclassMixin):
+    timing: bool
     wrapper: list[str]
     wrapper_inner: list[str]
     module: str | None

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from shlex import quote
 from subprocess import run
 from textwrap import indent
@@ -125,7 +126,15 @@ class LegateDriver:
             return 0
 
         with process_logs(self.config, self.system, self.launcher):
-            return run(self.cmd, env=self.env).returncode
+            if self.config.other.timing:
+                print(f"Legate start: {datetime.now()}")
+
+            ret = run(self.cmd, env=self.env).returncode
+
+            if self.config.other.timing:
+                print(f"Legate end: {datetime.now()}")
+
+            return ret
 
     def _darwin_gdb_warn(self) -> None:
         gdb = self.config.debugging.gdb

--- a/legate/jupyter/config.py
+++ b/legate/jupyter/config.py
@@ -98,4 +98,4 @@ class Config:
             False,
         )
         self.info = Info(False, False, self.verbose > 0, False)
-        self.other = Other([], [], None, False, False)
+        self.other = Other(False, [], [], None, False, False)

--- a/tests/unit/legate/driver/test_args.py
+++ b/tests/unit/legate/driver/test_args.py
@@ -170,6 +170,9 @@ class TestParserDefaults:
 
     # other
 
+    def test_timing(self) -> None:
+        assert m.parser.get_default("timing") is False
+
     def test_wrapper(self) -> None:
         assert m.parser.get_default("wrapper") == []
 

--- a/tests/unit/legate/driver/test_config.py
+++ b/tests/unit/legate/driver/test_config.py
@@ -263,6 +263,7 @@ class TestInfo:
 class TestOther:
     def test_fields(self) -> None:
         assert set(m.Other.__dataclass_fields__) == {
+            "timing",
             "wrapper",
             "wrapper_inner",
             "module",
@@ -347,6 +348,7 @@ class TestConfig:
         )
 
         assert c.other == m.Other(
+            timing=False,
             wrapper=[],
             wrapper_inner=[],
             module=None,

--- a/tests/unit/legate/jupyter/test_config.py
+++ b/tests/unit/legate/jupyter/test_config.py
@@ -114,6 +114,7 @@ class TestConfig:
         )
 
         assert c.other == m.Other(
+            timing=False,
             wrapper=[],
             wrapper_inner=[],
             module=None,


### PR DESCRIPTION
This PR addds a basic `--timing` option to the driver, that, when enabled, prints "Legate start" and "Legate end" timestamps to stdout. Currently the timestamps are inclusive of Python's `subprocess.run` overhead.

Run on a single file, it looks like:
```
dev310 ❯ LEGATE_TEST=1 legate --timing /home/bryan/work/cunumeric/tests/integration/test_binary_op_complex.py  -v  
Legate start: 2023-08-10 14:26:27.029508
====================================================================================================== test session starts =======================================================================================================
platform linux -- Python 3.10.11, pytest-7.4.0, pluggy-1.0.0 -- /home/bryan/anaconda3/envs/dev310/bin/python3
cachedir: .pytest_cache
rootdir: /home/bryan/work/cunumeric
configfile: pyproject.toml
plugins: mock-3.11.1, cov-4.1.0, lazy-fixture-0.6.3
collected 5 items                                                                                                                                                                                                                

tests/integration/test_binary_op_complex.py::test_add PASSED                                                                                                                                                               [ 20%]
tests/integration/test_binary_op_complex.py::test_sub PASSED                                                                                                                                                               [ 40%]
tests/integration/test_binary_op_complex.py::test_div PASSED                                                                                                                                                               [ 60%]
tests/integration/test_binary_op_complex.py::test_mul PASSED                                                                                                                                                               [ 80%]
tests/integration/test_binary_op_complex.py::test_pow PASSED                                                                                                                                                               [100%]

======================================================================================================= 5 passed in 0.22s ========================================================================================================
Legate end: 2023-08-10 14:26:28.617350
```

To use this immediately on tests runs, utilize `LEGATE_CONFIG` with `-v`:
```
LEGATE_CONFIG="--timing" ./test.py --use=cuda --gpus 1 --debug --color --cpu-pin=none -v            
```
Further work could teach `legate.test` how to understand and report on this data without needing to enable verbose output. 