### PR TITLE
Add pynvml as a test dependency in generate_conda_envs.py.

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -172,6 +172,7 @@ class TestsConfig(SectionConfig):
             "pytest-mock",
             "pytest",
             "types-docutils",
+            "pynvml"
         )
 
     @property

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -172,7 +172,7 @@ class TestsConfig(SectionConfig):
             "pytest-mock",
             "pytest",
             "types-docutils",
-            "pynvml"
+            "pynvml",
         )
 
     @property


### PR DESCRIPTION
`Pynvml` is a test dependency for `cunumeric` so it needs to be present in the tests section even if it is already present in the cuda section. Because generating an env def file with the `--sections tests` flag will otherwise produce an incomplete environment.