### PR TITLE
Expose bloat factor config

### DIFF
--- a/legate/tester/__init__.py
+++ b/legate/tester/__init__.py
@@ -34,6 +34,9 @@ DEFAULT_CPUS_PER_NODE = 2
 #: Value to use if --gpus is not specified.
 DEFAULT_GPUS_PER_NODE = 1
 
+# Value to use if --bloat-factor is not specified
+DEFAULT_GPU_BLOAT_FACTOR = 1.5
+
 # Delay to introduce between GPU test invocations (ms)
 DEFAULT_GPU_DELAY = 2000
 

--- a/legate/tester/args.py
+++ b/legate/tester/args.py
@@ -25,6 +25,7 @@ from typing_extensions import TypeAlias
 from ..util.args import ExtendAction, MultipleChoices
 from . import (
     DEFAULT_CPUS_PER_NODE,
+    DEFAULT_GPU_BLOAT_FACTOR,
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
@@ -158,6 +159,15 @@ feature_opts.add_argument(
     type=int,
     default=DEFAULT_GPU_MEMORY_BUDGET,
     help="GPU framebuffer memory (MB)",
+)
+
+
+feature_opts.add_argument(
+    "--bloat-factor",
+    dest="bloat_factor",
+    type=int,
+    default=DEFAULT_GPU_BLOAT_FACTOR,
+    help="Fudge factor to adjust GPU memory reserved",
 )
 
 

--- a/legate/tester/config.py
+++ b/legate/tester/config.py
@@ -68,6 +68,7 @@ class Config:
         self.utility = args.utility
         self.cpu_pin = args.cpu_pin
         self.fbmem = args.fbmem
+        self.bloat_factor = args.bloat_factor
         self.gpu_delay = args.gpu_delay
         self.ompthreads = args.ompthreads
         self.numamem = args.numamem

--- a/legate/tester/stages/_linux/gpu.py
+++ b/legate/tester/stages/_linux/gpu.py
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
     from ...config import Config
     from ...test_system import TestSystem
 
-BLOAT_FACTOR = 1.5  # hard coded for now
-
 
 class GPU(TestStage):
     """A test stage for exercising GPU features.
@@ -76,7 +74,7 @@ class GPU(TestStage):
         degree = N // (config.gpus * config.ranks)
 
         fbsize = min(gpu.total for gpu in system.gpus) / (1 << 20)  # MB
-        oversub_factor = int(fbsize // (config.fbmem * BLOAT_FACTOR))
+        oversub_factor = int(fbsize // (config.fbmem * config.bloat_factor))
         workers = adjust_workers(
             degree * oversub_factor, config.requested_workers
         )

--- a/tests/unit/legate/tester/test___init__.py
+++ b/tests/unit/legate/tester/test___init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from legate.tester import (
     DEFAULT_CPUS_PER_NODE,
+    DEFAULT_GPU_BLOAT_FACTOR,
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
@@ -39,6 +40,9 @@ class TestConsts:
 
     def test_DEFAULT_GPUS_PER_NODE(self) -> None:
         assert DEFAULT_GPUS_PER_NODE == 1
+
+    def test_DEFAULT_GPU_BLOAT_FACTOR(self) -> None:
+        assert DEFAULT_GPU_BLOAT_FACTOR == 1.5
 
     def test_DEFAULT_GPU_DELAY(self) -> None:
         assert DEFAULT_GPU_DELAY == 2000

--- a/tests/unit/legate/tester/test_config.py
+++ b/tests/unit/legate/tester/test_config.py
@@ -25,6 +25,7 @@ from pytest_mock import MockerFixture
 
 from legate.tester import (
     DEFAULT_CPUS_PER_NODE,
+    DEFAULT_GPU_BLOAT_FACTOR,
     DEFAULT_GPU_DELAY,
     DEFAULT_GPU_MEMORY_BUDGET,
     DEFAULT_GPUS_PER_NODE,
@@ -58,6 +59,7 @@ class TestConfig:
         assert c.cpu_pin == "partial"
         assert c.gpu_delay == DEFAULT_GPU_DELAY
         assert c.fbmem == DEFAULT_GPU_MEMORY_BUDGET
+        assert c.bloat_factor == DEFAULT_GPU_BLOAT_FACTOR
         assert c.omps == DEFAULT_OMPS_PER_NODE
         assert c.ompthreads == DEFAULT_OMPTHREADS
 


### PR DESCRIPTION
This PR adds `--bloat-factor` to the tester  command line options, in order to tweak GPU memory allocations if needed. 