### PR TITLE
Revert accidental changes to `conda build` files

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -1,11 +1,57 @@
-# Install legate_core C++ libs
-tar -C "$PREFIX" --exclude="*.a" --strip-components=1 -xf /tmp/out/legate_core-*-Linux.tar.gz;
-sed -E -i "s@/home/coder/\.conda/envs/legate@$PREFIX@g" "$PREFIX/share/Legion/cmake/LegionConfigCommon.cmake";
-sed -E -i "s@/home/coder/legate/build/_CPack_Packages/Linux/TGZ/legate_core-(.*)-Linux@$PREFIX@g" "$SP_DIR/legion_canonical_cffi.py";
+#!/bin/bash
 
-# Install legate_core Python wheel
-pip install --no-deps --root / --prefix "$PREFIX" /tmp/out/legate.core-*.whl;
+# Rewrite conda's -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY to
+#                 -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH
+CMAKE_ARGS="$(echo "$CMAKE_ARGS" | sed -r "s@_INCLUDE=ONLY@_INCLUDE=BOTH@g")"
 
-# Legion leaves .egg-info files, which confuses conda trying to pick up the information
-# Remove them so legate-core is the only egg-info file added.
-rm -rf "$SP_DIR"/legion*egg-info;
+# Add our options to conda's CMAKE_ARGS
+CMAKE_ARGS+="
+--log-level=VERBOSE
+-DBUILD_MARCH=haswell
+-DLegion_USE_OpenMP=ON
+-DLegion_USE_Python=ON
+-DLegion_Python_Version=$($PYTHON --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f3 --complement)"
+
+# We rely on an environment variable to determine if we need to build cpu-only bits
+if [ -z "$CPU_ONLY" ]; then
+  CMAKE_ARGS+="
+-DLegion_USE_CUDA=ON
+-DLegion_CUDA_ARCH:LIST=60-real;70-real;75-real;80-real;90
+"
+fi
+
+# Do not compile with NDEBUG until Legion handles it without warnings
+export CFLAGS="-UNDEBUG"
+export CXXFLAGS="-UNDEBUG"
+export CPPFLAGS="-UNDEBUG"
+export CUDAFLAGS="-UNDEBUG"
+export CMAKE_GENERATOR=Ninja
+export CUDAHOSTCXX=${CXX}
+export OPENSSL_DIR="$CONDA_PREFIX"
+
+echo "Build starting on $(date)"
+
+cmake -S . -B build ${CMAKE_ARGS}
+cmake --build build -j$CPU_COUNT
+cmake --install build --prefix "$PREFIX"
+
+CMAKE_ARGS="
+-DFIND_LEGATE_CORE_CPP=ON
+-Dlegate_core_ROOT=$PREFIX
+"
+
+SKBUILD_BUILD_OPTIONS=-j$CPU_COUNT \
+$PYTHON -m pip install             \
+  --root /                         \
+  --no-deps                        \
+  --prefix "$PREFIX"               \
+  --no-build-isolation             \
+  --cache-dir "$PIP_CACHE_DIR"     \
+  --disable-pip-version-check      \
+  . -vv
+
+echo "Build ending on $(date)"
+
+# Legion leaves an egg-info file which will confuse conda trying to pick up the information
+# Remove it so the legate-core is the only egg-info file added
+rm -rf $SP_DIR/legion*egg-info

--- a/conda/conda-build/conda_build_config.yaml
+++ b/conda/conda-build/conda_build_config.yaml
@@ -12,9 +12,3 @@ numpy_version:
 
 cmake_version:
   - ">=3.20.1,!=3.23.0"
-
-numpy:
-  - 1.22
-
-package_version:
-  - "23.09.00"


### PR DESCRIPTION
Reverts changes to the conda build files accidentally introduced in https://github.com/nv-legate/legate.core/pull/828.