### PR TITLE
Satisfy new flake8 type check rules

### DIFF
--- a/legate/core/_legion/future.py
+++ b/legate/core/_legion/future.py
@@ -49,7 +49,7 @@ class Future:
     # change during the lifetime of a Future object, and thus so would the
     # object's hash. So we just leave the default `f1 == f2 <==> f1 is f2`.
     def same_handle(self, other: Future) -> bool:
-        return type(self) == type(other) and self.handle == other.handle
+        return isinstance(other, type(self)) and self.handle == other.handle
 
     def __str__(self) -> str:
         if self.handle:

--- a/legate/core/_legion/future.py
+++ b/legate/core/_legion/future.py
@@ -49,7 +49,9 @@ class Future:
     # change during the lifetime of a Future object, and thus so would the
     # object's hash. So we just leave the default `f1 == f2 <==> f1 is f2`.
     def same_handle(self, other: Future) -> bool:
-        return isinstance(other, type(self)) and self.handle == other.handle
+        return (
+            type(self) == type(other) and self.handle == other.handle
+        )  # noqa
 
     def __str__(self) -> str:
         if self.handle:

--- a/legate/core/_legion/region.py
+++ b/legate/core/_legion/region.py
@@ -100,7 +100,7 @@ class Region:
 
     def same_handle(self, other: Region) -> bool:
         return (
-            type(self) == type(other)
+            isinstance(other, type(self))
             and self.handle.tree_id == other.handle.tree_id
             and self.handle.index_space.id == other.handle.index_space.id
             and self.handle.field_space.id == other.handle.field_space.id

--- a/legate/core/_legion/region.py
+++ b/legate/core/_legion/region.py
@@ -100,7 +100,7 @@ class Region:
 
     def same_handle(self, other: Region) -> bool:
         return (
-            isinstance(other, type(self))
+            type(self) == type(other)  # noqa
             and self.handle.tree_id == other.handle.tree_id
             and self.handle.index_space.id == other.handle.index_space.id
             and self.handle.field_space.id == other.handle.field_space.id

--- a/legate/core/cycle_detector.py
+++ b/legate/core/cycle_detector.py
@@ -53,18 +53,14 @@ def _find_cycles(root: Any, all_ids: Set[int]) -> bool:
 
 
 def _find_field(src: Any, dst: Any) -> Union[str, None]:
-    if type(src) == dict:
+    if isinstance(src, dict):
         for k, v in src.items():
             if v is dst and isinstance(k, str):
                 return f'["{k}"]'
-    if type(src) == tuple:
+    if isinstance(src, (tuple, list)):
         for k, v in enumerate(src):
             if v is dst:
                 return f"[{k}]"
-    if type(src) == list:
-        for i, v in enumerate(src):
-            if v is dst:
-                return f"[{i}]"
     try:
         for fld in dir(src):
             try:

--- a/legate/core/launcher.py
+++ b/legate/core/launcher.py
@@ -721,7 +721,7 @@ class TaskLauncher:
         side_effect: bool = False,
         provenance: Optional[str] = None,
     ) -> None:
-        assert type(tag) != bool
+        assert not isinstance(tag, bool)
         self._context = context
         self._mapper_id = context.mapper_id
         self._task_id = task_id
@@ -1016,7 +1016,7 @@ class CopyLauncher:
         tag: int = 0,
         provenance: Optional[str] = None,
     ) -> None:
-        assert type(tag) != bool
+        assert not isinstance(tag, bool)
         self._context = context
         self._mapper_id = context.mapper_id
         self._inputs: list[LauncherArg] = []

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -83,7 +83,9 @@ class Field:
         self.detach_future: Optional[Future] = None
 
     def same_handle(self, other: Field) -> bool:
-        return type(self) == type(other) and self.field_id == other.field_id
+        return (
+            isinstance(other, type(self)) and self.field_id == other.field_id
+        )
 
     def add_detach_future(self, future: Future) -> None:
         self.detach_future = future
@@ -139,7 +141,7 @@ class RegionField:
         return RegionField(region, field, shape)
 
     def same_handle(self, other: RegionField) -> bool:
-        return type(self) == type(other) and self.field.same_handle(
+        return isinstance(other, type(self)) and self.field.same_handle(
             other.field
         )
 

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -84,8 +84,8 @@ class Field:
 
     def same_handle(self, other: Field) -> bool:
         return (
-            isinstance(other, type(self)) and self.field_id == other.field_id
-        )
+            type(self) == type(other) and self.field_id == other.field_id
+        )  # noqa
 
     def add_detach_future(self, future: Future) -> None:
         self.detach_future = future
@@ -141,7 +141,7 @@ class RegionField:
         return RegionField(region, field, shape)
 
     def same_handle(self, other: RegionField) -> bool:
-        return isinstance(other, type(self)) and self.field.same_handle(
+        return type(self) == type(other) and self.field.same_handle(  # noqa
             other.field
         )
 


### PR DESCRIPTION
This PR resolves this class of new `flake8` errors:
> legate/core/_legion/future.py:52:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

All `legate.core` and `cunumeric` tests were checked locally to pass. Still it's unclear if some of the instances really do intend strict type equality. If so those can be changed back with a `# noqa` added. 