### PR TITLE
Build with oldest supported numpy.

### DIFF
--- a/conda/conda-build/conda_build_config.yaml
+++ b/conda/conda-build/conda_build_config.yaml
@@ -7,7 +7,10 @@ python:
   - 3.10
   - 3.11
 
-numpy_version:
+numpy_build_version:
+  - "=1.22"
+
+numpy_run_version:
   - ">=1.22"
 
 cmake_version:

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -104,7 +104,7 @@ requirements:
     - cython
     - llvm-openmp
     - scikit-build
-    - numpy {{ numpy_version }}
+    - numpy {{ numpy_build_version }}
     - elfutils # [linux]
     - libdwarf # [linux]
 {% if gpu_enabled_bool %}
@@ -120,7 +120,7 @@ requirements:
   run:
     - cffi
     - llvm-openmp
-    - numpy {{ numpy_version }}
+    - numpy {{ numpy_run_version }}
     - typing_extensions
     - elfutils # [linux]
     - libdwarf # [linux]

--- a/continuous_integration/home/coder/.local/bin/build-legate-conda
+++ b/continuous_integration/home/coder/.local/bin/build-legate-conda
@@ -43,7 +43,9 @@ numpy:
   - 1.22
 python:
   - "${python_version}"
-numpy_version:
+numpy_build_version:
+  - "=1.22"
+numpy_run_version:
   - ">=1.22"
 use_local_path:
   - "true"


### PR DESCRIPTION
It looks like legate.core is allowing newer numpy versions like 1.25 at build time, via `numpy>=1.22`. This breaks compatibility with older numpy versions because the build time version must be older than the runtime version. The rule here is to always build with the oldest supported numpy version, if using the numpy C API or Cython API **(if you're not using one of these APIs, such as via `cimport numpy`, then numpy isn't a build requirement and should just be a runtime requirement)**.

If you depend on numpy at build time, [this run_exports](https://github.com/conda-forge/numpy-feedstock/blob/e12fb4fad5aecf2618844a60f9dcb493bce574da/recipe/meta.yaml#L30) means that you'll require at least that version at run time. Since the numpy_version is set to [>=1.22](https://github.com/nv-legate/legate.core/blob/40295b0f2d686cc7fbabb9f17da385bdee202afe/conda/conda-build/conda_build_config.yaml#L11), builds are going to pull the latest version (probably 1.25 or maybe 1.26 at the time of writing) and thus set the dependency requirements to >=1.25. The way this is solved is by pinning the oldest supported numpy [in the host section here](https://github.com/nv-legate/legate.core/blob/40295b0f2d686cc7fbabb9f17da385bdee202afe/conda/conda-build/meta.yaml#L107). conda-forge currently uses [a pinning of 1.22 for numpy build/host pinnings ](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/b7295d0d79c41e3f768a0042f2d885a948f67995/recipe/conda_build_config.yaml#L600-L602)unless otherwise specified. This is also the reason why packages like https://pypi.org/project/oldest-supported-numpy/ exist.

cc: @m3vaz @csadorf