### PR TITLE
Remove numpy from conda build dependencies.

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -104,7 +104,6 @@ requirements:
     - cython
     - llvm-openmp
     - scikit-build
-    - numpy {{ numpy_version }}
     - elfutils # [linux]
     - libdwarf # [linux]
 {% if gpu_enabled_bool %}


### PR DESCRIPTION
I saw an issue discussed offline by @csadorf and @m3vaz. The core problem was that legate.core had a high constraint on `numpy>=1.26` despite the build scripts requesting `numpy >=1.22`. I filed #854 to solve this by pinning the build dependency on numpy but then realized that it seems to be only a runtime dependency. I couldn't find any reliance on numpy in the build scripts, nor use of the Cython API like `cimport numpy` or C API, so I think this is safe to remove. Removing this from the `host:` section of the conda recipe will resolve this problem.

The screenshot below shows two numpy dependencies being added to this package. The constraint `numpy >=1.22` is coming from the `run:` pinning, while the `numpy >=1.26.0,<2.0a0` is coming from a run_exports on the `numpy >=1.22` being installed in the `host:` list, which resolves to `numpy 1.26` at build time.

![image](https://github.com/nv-legate/legate.core/assets/3943761/a15b4f2b-064d-4c79-9311-520fef5465ec)
https://anaconda.org/legate/legate-core/files
