### PR TITLE
Add legate-issue command for collecting issue info

### DIFF
--- a/legate/issue.py
+++ b/legate/issue.py
@@ -47,29 +47,32 @@ def main() -> None:
     print(f"Numba       :  {try_version('numba', '__version__')}")
 
     try:
-        out = check_output("conda list cuda-version --json".split())
-        info = json.loads(out.decode("utf-8"))[0]
-        print(f"CTK package : {info['dist_name']} ({info['channel']})")
-    except CalledProcessError:
-        print("CTK package : (failed to detect)")
+        if out := check_output("conda list cuda-version --json".split()):
+            info = json.loads(out.decode("utf-8"))[0]
+            print(f"CTK package :  {info['dist_name']} ({info['channel']})")
+        else:
+            print("CTK package :  (failed to detect)")
+    except (CalledProcessError, IndexError, KeyError):
+        print("CTK package :  (failed to detect)")
+    except FileNotFoundError:
+        print("CTK package :  (conda missing)")
 
     try:
         out = check_output(
             "nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0".split()  # noqa
         )
-        print(f"GPU Driver  : {out.decode('utf-8').strip()}")
+        print(f"GPU Driver  :  {out.decode('utf-8').strip()}")
     except CalledProcessError:
-        print("GPU Driver  : (failed to detect)")
+        print("GPU Driver  :  (failed to detect)")
+    except FileNotFoundError:
+        print("GPU Driver  :  (nvidia-smi missing)")
 
     try:
-        out = check_output("nvidia-smi -L", shell=True)
+        out = check_output("nvidia-smi -L".split())
         gpus = re.sub(r" \(UUID: .*\)", "", out.decode("utf-8").strip())
         print("GPU Devices :")
         print(indent(gpus, "  "))
     except CalledProcessError:
-        print("GPU Devices : (failed to detect)")
-
-
-# just helpful for testing
-if __name__ == "__main__":
-    main()
+        print("GPU Devices :  (failed to detect)")
+    except FileNotFoundError:
+        print("GPU Devices :  (nvidia-smi missing)")

--- a/legate/issue.py
+++ b/legate/issue.py
@@ -1,0 +1,75 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import json
+import platform
+import re
+import sys
+from importlib import import_module
+from subprocess import CalledProcessError, check_output
+from textwrap import indent
+
+NL = "\n"
+
+
+def try_version(module_name: str, attr: str) -> str:
+    try:
+        module = import_module(module_name)
+        return getattr(module, attr) if module else None
+    except ModuleNotFoundError:
+        return "(not installed)"
+    except ImportError as e:
+        err = re.sub(r" \(.*\)", "", str(e))  # remove any local path
+        return f"(ImportError: {err})"
+
+
+def main() -> None:
+    print(f"Python      :  {sys.version.split(NL)[0]}")
+    print(f"Platform    :  {platform.platform()}")
+    print(f"Legion      :  {try_version('legion_info', '__version__')}")
+    print(f"Legate      :  {try_version('legate', '__version__')}")
+    print(f"Cunumeric   :  {try_version('cunumeric', '__version__')}")
+    print(f"Numpy       :  {try_version('numpy', '__version__')}")
+    print(f"Scipy       :  {try_version('scipy', '__version__')}")
+    print(f"Numba       :  {try_version('numba', '__version__')}")
+
+    try:
+        out = check_output("conda list cuda-version --json".split())
+        info = json.loads(out.decode("utf-8"))[0]
+        print(f"CTK package : {info['dist_name']} ({info['channel']})")
+    except CalledProcessError:
+        print("CTK package : (failed to detect)")
+
+    try:
+        out = check_output(
+            "nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0".split()  # noqa
+        )
+        print(f"GPU Driver  : {out.decode('utf-8').strip()}")
+    except CalledProcessError:
+        print("GPU Driver  : (failed to detect)")
+
+    try:
+        out = check_output("nvidia-smi -L", shell=True)
+        gpus = re.sub(r" \(UUID: .*\)", "", out.decode("utf-8").strip())
+        print("GPU Devices :")
+        print(indent(gpus, "  "))
+    except CalledProcessError:
+        print("GPU Devices : (failed to detect)")
+
+
+# just helpful for testing
+if __name__ == "__main__":
+    main()

--- a/legate/issue.py
+++ b/legate/issue.py
@@ -18,6 +18,7 @@ import json
 import platform
 import re
 import sys
+from contextlib import redirect_stderr
 from importlib import import_module
 from subprocess import CalledProcessError, check_output
 from textwrap import indent
@@ -28,7 +29,9 @@ FAILED_TO_DETECT = "(failed to detect)"
 
 def try_version(module_name: str, attr: str) -> str:
     try:
-        module = import_module(module_name)
+        # some tools are chatty on stderr in a way thats not relevant here
+        with redirect_stderr(None):
+            module = import_module(module_name)
         return getattr(module, attr) if module else None
     except ModuleNotFoundError:
         return FAILED_TO_DETECT

--- a/legate/issue.py
+++ b/legate/issue.py
@@ -18,7 +18,6 @@ import json
 import platform
 import re
 import sys
-from contextlib import redirect_stderr
 from importlib import import_module
 from subprocess import CalledProcessError, check_output
 from textwrap import indent
@@ -29,9 +28,7 @@ FAILED_TO_DETECT = "(failed to detect)"
 
 def try_version(module_name: str, attr: str) -> str:
     try:
-        # some tools are chatty on stderr in a way thats not relevant here
-        with redirect_stderr(None):
-            module = import_module(module_name)
+        module = import_module(module_name)
         return getattr(module, attr) if module else None
     except ModuleNotFoundError:
         return FAILED_TO_DETECT

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
     entry_points={
         "console_scripts": [
             "legate = legate.driver:main",
+            "legate-issue = legate.issue:main",
             "legate-jupyter = legate.jupyter:main",
             "lgpatch = legate.lgpatch:main",
         ],


### PR DESCRIPTION
This PR adds a new entry point `legate-issue` that prints out information that is useful for GitHub issues. We can create a GH issue template to suggest (or require) including the output of this command up-front. 

Sample output on my system:
```
dev310 ❯ legate-issue 
Python      :  3.10.11 | packaged by conda-forge | (main, May 10 2023, 18:58:44) [GCC 11.3.0]
Platform    :  Linux-5.14.0-1042-oem-x86_64-with-glibc2.31
Legion      :  v23.11.00.dev-16-g2499f878
Legate      :  23.11.00.dev+17.gb7b50313
Cunumeric   :  (ImportError: cannot import name 'LogicalArray' from 'legate.core')
Numpy       :  1.24.4
Scipy       :  1.10.1
Numba       :  (not installed)
CTK package : cuda-version-11.8-h70ddcb2_2 (conda-forge)
GPU Driver  : 515.65.01
GPU Devices :
  GPU 0: Quadro RTX 8000
  GPU 1: Quadro RTX 8000
```

As it stands the code is fairly bare-bones. @manopapad if you'd like it to be more bulletproof I can continue to robustify it. We can also add more output now or in the future as new bits of important context arise. 