### PR TITLE
make _lib a proper module

### DIFF
--- a/legate/core/_lib/__init__.py
+++ b/legate/core/_lib/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
This clears the `pip install` warning about "Package would be ignored" described in #862

All `cunumeric` tests pass when built against an wheel install with this change. Since we do intend there to be `legate.core._lib` package, this seems like the correct action, or at the very least, a harmless resolution. 