### PR TITLE
Remove extraneous PYTHONPATH entry

### DIFF
--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .. import install_info
@@ -173,9 +172,6 @@ class Launcher:
             extra_python_paths.append(
                 str(system.legion_paths.legion_jupyter_module)
             )
-
-        # Make sure the base directory for this file is in the python path
-        extra_python_paths.append(str(Path(__file__).parents[1]))
 
         env["PYTHONPATH"] = os.pathsep.join(extra_python_paths)
 


### PR DESCRIPTION
It doesn't seem like this is necessary. Removing it because on non-editable installations it ends up adding `<venv-root>/lib/pythonX.Y/site-packages/legate` to the `PYTHONPATH`, which causes sub-modules under legate to potentially clash with top-level modules of the same name.