### PR TITLE
Enable CUDA 12.1 environment

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -75,11 +75,14 @@ class CUDAConfig(SectionConfig):
             deps += (
                 "cuda-cudart-dev",
                 "cuda-nvml-dev",
-                "cuda-nvtx-dev",
+                "cuda-nvtx",
                 "libcublas-dev",
                 "libcufft-dev",
                 "libcurand-dev",
                 "libcusolver-dev",
+                "libcusparse-dev",
+                # needed by cusparse starting with 12.1
+                "libnvjitlink"
             )
 
         if self.compilers:
@@ -288,7 +291,7 @@ CTK_VERSIONS = (
     "11.8",
     "12.0",
     # TODO: libcublas 12.1 not available on conda-forge as of 2023-06-12
-    # "12.1",
+    "12.1"
 )
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
@@ -297,8 +300,8 @@ OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
 ENV_TEMPLATE = """\
 name: legate-{use}
 channels:
-  - conda-forge
   - nvidia
+  - conda-forge
 dependencies:
 
   - python={python},!=3.9.7  # avoid https://bugs.python.org/issue45121

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -82,7 +82,7 @@ class CUDAConfig(SectionConfig):
                 "libcusolver-dev",
                 "libcusparse-dev",
                 # needed by cusparse starting with 12.1
-                "libnvjitlink"
+                "libnvjitlink",
             )
 
         if self.compilers:
@@ -291,7 +291,7 @@ CTK_VERSIONS = (
     "11.8",
     "12.0",
     # TODO: libcublas 12.1 not available on conda-forge as of 2023-06-12
-    "12.1"
+    "12.1",
 )
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")


### PR DESCRIPTION
This change builds environment suitable for building Legate stack with CUDA 12.1. 

Also added libcusparse and it's dependency for legate.sparse.