### PR TITLE
adding a workaround  for NumPy's conversion from unit64 to float

### DIFF
--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -1233,14 +1233,7 @@ class Store:
             If ``dim`` is not a valid dimension name or ``index`` is
             out of bounds
         """
-        # This is a workaround for NumPy's expected behavior when adding
-        # an integer to np.uint64, resulting in float64.
-        if type(index) is not int:
-            import numpy as np
-
-            assert np.issubdtype(type(index), np.integer)
-            index = int(index)
-
+        index = int(index)
         dim = dim + self.ndim if dim < 0 else dim
         if dim < 0 or dim >= self.ndim:
             raise ValueError(

--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -1233,6 +1233,14 @@ class Store:
             If ``dim`` is not a valid dimension name or ``index`` is
             out of bounds
         """
+        # This is a workaround for NumPy's expected behavior when adding
+        # an integer to np.uint64, resulting in float64.
+        if type(index) is not int:
+            import numpy as np
+
+            assert np.issubdtype(type(index), np.integer)
+            index = int(index)
+
         dim = dim + self.ndim if dim < 0 else dim
         if dim < 0 or dim >= self.ndim:
             raise ValueError(


### PR DESCRIPTION
adding a workaround  for NumPy's expected behavior when adding an integer to np.uint64, resulting in float64
see https://github.com/numpy/numpy/issues/5745