### PR TITLE
Enable CUDA 12.1 environment

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -76,11 +76,14 @@ class CUDAConfig(SectionConfig):
             deps += (
                 "cuda-cudart-dev",
                 "cuda-nvml-dev",
-                "cuda-nvtx-dev",
+                "cuda-nvtx",
                 "libcublas-dev",
                 "libcufft-dev",
                 "libcurand-dev",
                 "libcusolver-dev",
+                "libcusparse-dev",
+                # needed by cusparse starting with 12.1
+                "libnvjitlink",
             )
 
         if self.compilers:
@@ -284,7 +287,7 @@ CTK_VERSIONS = (
     "11.8",
     "12.0",
     # TODO: libcublas 12.1 not available on conda-forge as of 2023-06-12
-    # "12.1",
+    "12.1",
 )
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
@@ -293,8 +296,8 @@ OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
 ENV_TEMPLATE = """\
 name: legate-{use}
 channels:
-  - conda-forge
   - nvidia
+  - conda-forge
 dependencies:
 
   - python={python},!=3.9.7  # avoid https://bugs.python.org/issue45121


### PR DESCRIPTION
Continuing https://github.com/nv-legate/legate.core/pull/883 from a new repo.

Changes allow building CUDA 12.1 conda environment that is usable for legate.core, cunumeric and legate.sparse