### PR TITLE
Print driver output only on head nodes

### DIFF
--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from io import StringIO
 from shlex import quote
 from subprocess import run
 from textwrap import indent
@@ -31,7 +32,7 @@ from .launcher import Launcher, SimpleLauncher
 if TYPE_CHECKING:
     from ..util.types import Command, EnvDict
 
-__all__ = ("LegateDriver", "CanonicalDriver", "print_verbose")
+__all__ = ("LegateDriver", "CanonicalDriver", "format_verbose")
 
 _DARWIN_GDB_WARN = """\
 You must start the debugging session with the following command,
@@ -102,12 +103,8 @@ class LegateDriver:
 
         """
         if self.config.info.verbose:
-            # we only want to print verbose output on a "head" node
-            if (
-                self.launcher.kind != "none"
-                or self.launcher.detected_rank_id == "0"
-            ):
-                print_verbose(self.system, self)
+            msg = format_verbose(self.system, self)
+            self.print_on_head_node(msg, flush=True)
 
         self._darwin_gdb_warn()
 
@@ -125,42 +122,43 @@ class LegateDriver:
             return 0
 
         if self.config.other.timing:
-            print(f"Legate start: {datetime.now()}")
+            self.print_on_head_node(f"Legate start: {datetime.now()}")
 
         ret = run(self.cmd, env=self.env).returncode
 
         if self.config.other.timing:
-            print(f"Legate end: {datetime.now()}")
+            self.print_on_head_node(f"Legate end: {datetime.now()}")
 
         log_dir = self.config.logging.logdir
 
         if self.config.profiling.profile:
-            print(
+            self.print_on_head_node(
                 f"Profiles have been generated under {log_dir}, run "
                 f"legion_prof --view {log_dir}/legate_*.prof to view them"
             )
 
         if self.config.debugging.spy:
-            print(
+            self.print_on_head_node(
                 f"Legion Spy logs have been generated under {log_dir}, run "
                 f"legion_spy.py {log_dir}/legate_*.log to process them"
             )
 
         return ret
 
+    def print_on_head_node(self, *args, **kw) -> None:
+        launcher = self.launcher
+
+        if launcher.kind != "none" or launcher.detected_rank_id == "0":
+            print(*args, **kw)
+
     def _darwin_gdb_warn(self) -> None:
         gdb = self.config.debugging.gdb
 
         if gdb and self.system.os == "Darwin":
             libpath = self.env[self.system.LIB_PATH]
-            pythonpath = self.env["PYTHONPATH"]
-            print(
-                warn(
-                    _DARWIN_GDB_WARN.format(
-                        libpath=libpath, pythonpath=pythonpath
-                    )
-                )
-            )
+            pypath = self.env["PYTHONPATH"]
+            msg = _DARWIN_GDB_WARN.format(libpath=libpath, pythonpath=pypath)
+            self.print_on_head_node(warn(msg))
 
 
 class CanonicalDriver(LegateDriver):
@@ -209,10 +207,10 @@ def get_versions() -> LegateVersions:
     return LegateVersions(legate_version=lg_version)
 
 
-def print_verbose(
+def format_verbose(
     system: System,
     driver: LegateDriver | None = None,
-) -> None:
+) -> str:
     """Print system and driver configuration values.
 
     Parameters
@@ -226,35 +224,36 @@ def print_verbose(
 
     Returns
     -------
-        None
+        str
 
     """
+    out = StringIO()
 
-    print(f"\n{rule('Legion Python Configuration')}")
+    out.write(f"\n{rule('Legion Python Configuration')}")
 
-    print(section("\nLegate paths:"))
-    print(indent(str(system.legate_paths), prefix="  "))
+    out.write(section("\nLegate paths:"))
+    out.write(indent(str(system.legate_paths), prefix="  "))
 
-    print(section("\nLegion paths:"))
-    print(indent(str(system.legion_paths), prefix="  "))
+    out.write(section("\nLegion paths:"))
+    out.write(indent(str(system.legion_paths), prefix="  "))
 
-    print(section("\nVersions:"))
-    print(indent(str(get_versions()), prefix="  "))
+    out.write(section("\nVersions:"))
+    out.write(indent(str(get_versions()), prefix="  "))
 
     if driver:
-        print(section("\nCommand:"))
+        out.write(section("\nCommand:"))
         cmd = " ".join(quote(t) for t in driver.cmd)
-        print(f"  {value(cmd)}")
+        out.write(f"  {value(cmd)}")
 
         if keys := sorted(driver.custom_env_vars):
-            print(section("\nCustomized Environment:"))
-            print(
+            out.write(section("\nCustomized Environment:"))
+            out.write(
                 indent(
                     kvtable(driver.env, delim="=", align=False, keys=keys),
                     prefix="  ",
                 )
             )
 
-    print(f"\n{rule()}")
+    out.write(f"\n{rule()}")
 
-    print(flush=True)
+    return out.getvalue()

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -20,7 +20,7 @@ from io import StringIO
 from shlex import quote
 from subprocess import run
 from textwrap import indent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..util.system import System
 from ..util.types import DataclassMixin
@@ -145,7 +145,7 @@ class LegateDriver:
 
         return ret
 
-    def print_on_head_node(self, *args, **kw) -> None:
+    def print_on_head_node(self, *args: Any, **kw: Any) -> None:
         launcher = self.launcher
 
         if launcher.kind != "none" or launcher.detected_rank_id == "0":

--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -229,24 +229,24 @@ def format_verbose(
     """
     out = StringIO()
 
-    out.write(f"\n{rule('Legion Python Configuration')}")
+    out.write(f"\n{rule('Legion Python Configuration')}\n")
 
-    out.write(section("\nLegate paths:"))
+    out.write(section("\nLegate paths:\n"))
     out.write(indent(str(system.legate_paths), prefix="  "))
 
-    out.write(section("\nLegion paths:"))
+    out.write(section("\n\nLegion paths:\n"))
     out.write(indent(str(system.legion_paths), prefix="  "))
 
-    out.write(section("\nVersions:"))
+    out.write(section("\n\nVersions:\n"))
     out.write(indent(str(get_versions()), prefix="  "))
 
     if driver:
-        out.write(section("\nCommand:"))
+        out.write(section("\n\nCommand:\n"))
         cmd = " ".join(quote(t) for t in driver.cmd)
         out.write(f"  {value(cmd)}")
 
         if keys := sorted(driver.custom_env_vars):
-            out.write(section("\nCustomized Environment:"))
+            out.write(section("\n\nCustomized Environment:\n"))
             out.write(
                 indent(
                     kvtable(driver.env, delim="=", align=False, keys=keys),
@@ -254,6 +254,6 @@ def format_verbose(
                 )
             )
 
-    out.write(f"\n{rule()}")
+    out.write(f"\n\n{rule()}\n")
 
     return out.getvalue()

--- a/legate/driver/main.py
+++ b/legate/driver/main.py
@@ -31,7 +31,7 @@ def prepare_driver(
     from ..util.system import System
     from ..util.ui import error
     from . import Config
-    from .driver import print_verbose
+    from .driver import format_verbose
 
     try:
         config = Config(argv)
@@ -50,7 +50,7 @@ def prepare_driver(
     except Exception as e:
         msg = "Could not initialize driver, path config and exception follow:"  # noqa
         print(error(msg))
-        print_verbose(system)
+        print(format_verbose(system), flush=True)
         raise e
 
     return driver

--- a/tests/unit/legate/driver/test_driver.py
+++ b/tests/unit/legate/driver/test_driver.py
@@ -113,7 +113,7 @@ class TestDriver:
         mock_run.assert_called_once_with(driver.cmd, env=driver.env)
 
     @pytest.mark.parametrize("launch", LAUNCHERS)
-    def test_verbose(
+    def test_format_verbose(
         self,
         capsys: Capsys,
         genconfig: GenConfig,
@@ -127,9 +127,7 @@ class TestDriver:
 
         run_out = scrub(capsys.readouterr()[0]).strip()
 
-        m.print_verbose(driver.system, driver)
-
-        pv_out = scrub(capsys.readouterr()[0]).strip()
+        pv_out = scrub(m.format_verbose(driver.system, driver)).strip()
 
         assert pv_out in run_out
 
@@ -157,9 +155,7 @@ class TestDriver:
 
         run_out = scrub(capsys.readouterr()[0]).strip()
 
-        m.print_verbose(driver.system, driver)
-
-        pv_out = scrub(capsys.readouterr()[0]).strip()
+        pv_out = scrub(m.format_verbose(driver.system, driver)).strip()
 
         assert pv_out not in run_out
 
@@ -186,13 +182,11 @@ class TestDriver:
         assert re.search(DARWIN_GDB_WARN_EXPECTED_PAT, scrub(out))
 
 
-class Test_print_verbose:
-    def test_system_only(self, capsys: Capsys) -> None:
+class Test_format_verbose:
+    def test_system_only(self) -> None:
         system = System()
 
-        m.print_verbose(system)
-
-        out = scrub(capsys.readouterr()[0]).strip()
+        out = scrub(m.format_verbose(system)).strip()
 
         assert out.startswith(f"{'--- Legion Python Configuration ':-<80}")
         assert "Legate paths:" in out
@@ -208,9 +202,7 @@ class Test_print_verbose:
         system = System()
         driver = m.LegateDriver(config, system)
 
-        m.print_verbose(system, driver)
-
-        out = scrub(capsys.readouterr()[0]).strip()
+        out = scrub(m.format_verbose(system, driver)).strip()
 
         assert out.startswith(f"{'--- Legion Python Configuration ':-<80}")
         assert "Legate paths:" in out


### PR DESCRIPTION
This PR prevents informational messages, e.g. profiling output locations, from being printed on every node in a multi-node scenario. 