### PR TITLE
Use labels from the nvidia channel to restrict CTK versions

### DIFF
--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from argparse import Action, ArgumentParser
 from dataclasses import dataclass
 from textwrap import indent
-from typing import Literal, Tuple
+from typing import Literal, Tuple, Union
 
 # --- Types -------------------------------------------------------------------
 
@@ -53,7 +53,7 @@ class SectionConfig:
 
 @dataclass(frozen=True)
 class CUDAConfig(SectionConfig):
-    ctk_version: str
+    ctk_version: Union[str, None]
     compilers: bool
     os: OSType
 
@@ -61,7 +61,7 @@ class CUDAConfig(SectionConfig):
 
     @property
     def conda(self) -> Reqs:
-        if self.ctk_version == "none":
+        if not self.ctk_version:
             return ()
 
         deps = (
@@ -137,7 +137,7 @@ class CUDAConfig(SectionConfig):
         return deps
 
     def __str__(self) -> str:
-        if self.ctk_version == "none":
+        if not self.ctk_version:
             return ""
 
         return f"-cuda{self.ctk_version}"
@@ -263,7 +263,7 @@ class EnvConfig:
     use: str
     python: str
     os: OSType
-    ctk: str
+    ctk_version: Union[str, None]
     compilers: bool
     openmpi: bool
     ucx: bool
@@ -280,7 +280,7 @@ class EnvConfig:
 
     @property
     def cuda(self) -> CUDAConfig:
-        return CUDAConfig(self.ctk, self.compilers, self.os)
+        return CUDAConfig(self.ctk_version, self.compilers, self.os)
 
     @property
     def build(self) -> BuildConfig:
@@ -306,18 +306,6 @@ class EnvConfig:
 # --- Setup -------------------------------------------------------------------
 
 PYTHON_VERSIONS = ("3.9", "3.10", "3.11")
-
-CTK_VERSIONS = (
-    "none",
-    "11.4",
-    "11.5",
-    "11.6",
-    "11.7",
-    "11.8",
-    "12.0",
-    "12.1",
-    "12.2",
-)
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
 
@@ -402,8 +390,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--ctk",
-        choices=CTK_VERSIONS,
-        default="none",
         dest="ctk_version",
         help="CTK version to generate for",
     )

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -80,7 +80,7 @@ class CUDAConfig(SectionConfig):
             "pynvml",  # tests
         )
 
-        if V(self.ctk_version) < V("12.0.0"):
+        if V(self.ctk_version) < (12, 0, 0):
             deps += (f"cudatoolkit={self.ctk_version}",)
         else:
             deps += (
@@ -99,13 +99,13 @@ class CUDAConfig(SectionConfig):
 
         if self.compilers:
             if self.os == "linux":
-                if V(self.ctk_version) < V("12.0.0"):
+                if V(self.ctk_version) < (12, 0, 0):
                     deps += (f"nvcc_linux-64={self.ctk_version}",)
                 else:
                     deps += ("cuda-nvcc",)
 
                 # gcc 11.3 is incompatible with nvcc < 11.6.
-                if V(self.ctk_version) < V("11.6.0"):
+                if V(self.ctk_version) < (11, 6, 0):
                     deps += (
                         "gcc_linux-64<=11.2",
                         "gxx_linux-64<=11.2",
@@ -253,7 +253,7 @@ class EnvConfig:
     @property
     def channels(self) -> str:
         channels = ("conda-forge",)
-        if self.ctk_version and V(self.ctk_version) >= V("12.0.0"):
+        if self.ctk_version and V(self.ctk_version) >= (12, 0, 0):
             channels += (f"nvidia/label/cuda-{self.ctk_version}",)
         return "- " + "\n- ".join(channels)
 
@@ -419,7 +419,7 @@ if __name__ == "__main__":
     args = parser.parse_args(sys.argv[1:])
 
     if args.ctk_version:
-        if V(args.ctk_version) < V("12.0.0"):
+        if V(args.ctk_version) < (12, 0, 0):
             if len(args.ctk_version.split(".")) != 2:
                 raise ValueError("CTK 11 versions must be in the form 11.X")
         else:

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -256,9 +256,10 @@ class EnvConfig:
 
     @property
     def channels(self) -> str:
-        channels = ("conda-forge",)
+        channels = []
         if self.ctk_version and V(self.ctk_version) >= (12, 0, 0):
-            channels += (f"nvidia/label/cuda-{self.ctk_version}",)
+            channels.append(f"nvidia/label/cuda-{self.ctk_version}")
+        channels.append("conda-forge")
         return "- " + "\n- ".join(channels)
 
     @property


### PR DESCRIPTION
Package versions on the nvidia channel don't always correspond to CTK version (e.g. cusparse 12.2 can be part of CTK 12.3). The only robust way to ensure that all selected nvidia conda channel packages are coming from a compatible CTK collection is to restrict based on label.