### PR TITLE
Add cuda-cudart-static to generated conda environments

### DIFF
--- a/.github/workflows/ci-gh-build-release.yml
+++ b/.github/workflows/ci-gh-build-release.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       build-target: all
       repos-name: ${{ github.event.repository.name }}
-      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-32cpu' || 'ubuntu-latest' }}
+      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
       sha: ${{ github.sha }}
       build-type: release
       use-container: true

--- a/.github/workflows/ci-gh-build-release.yml
+++ b/.github/workflows/ci-gh-build-release.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       build-target: all
       repos-name: ${{ github.event.repository.name }}
-      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
+      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-arm64-cpu16' || 'ubuntu-latest' }}
       sha: ${{ github.sha }}
       build-type: release
       use-container: true

--- a/.github/workflows/ci-gh-build-release.yml
+++ b/.github/workflows/ci-gh-build-release.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       build-target: all
       repos-name: ${{ github.event.repository.name }}
-      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-cpu16	' || 'ubuntu-latest' }}
+      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
       sha: ${{ github.sha }}
       build-type: release
       use-container: true

--- a/.github/workflows/ci-gh-build-release.yml
+++ b/.github/workflows/ci-gh-build-release.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       build-target: all
       repos-name: ${{ github.event.repository.name }}
-      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-arm64-cpu16' || 'ubuntu-latest' }}
+      runs-on: ${{ github.repository_owner == 'nv-legate' && 'linux-amd64-cpu16	' || 'ubuntu-latest' }}
       sha: ${{ github.sha }}
       build-type: release
       use-container: true

--- a/.github/workflows/ci-gh-docs.yml
+++ b/.github/workflows/ci-gh-docs.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read  # This is required for actions/checkout
       packages: write # This is required to push docker image to ghcr.io
 
-    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-32cpu' || 'ubuntu-latest' }}
+    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/ci-gh-docs.yml
+++ b/.github/workflows/ci-gh-docs.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read  # This is required for actions/checkout
       packages: write # This is required to push docker image to ghcr.io
 
-    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-arm64-cpu16' || 'ubuntu-latest' }}
+    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/ci-gh-docs.yml
+++ b/.github/workflows/ci-gh-docs.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read  # This is required for actions/checkout
       packages: write # This is required to push docker image to ghcr.io
 
-    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
+    runs-on: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-arm64-cpu16' || 'ubuntu-latest' }}
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -24,6 +24,14 @@ jobs:
             build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
             platform: linux
 
+          - device: gpu
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
+            platform: linux
+
+          - device: cpu
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
+            platform: linux
+
           - device: cpu
             build-runner: macos-latest
             platform: osx

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           - device: gpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - device: gpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu
@@ -29,7 +29,7 @@ jobs:
             platform: linux
 
           - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -21,7 +21,7 @@ jobs:
             platform: linux
 
           - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu16' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
             platform: linux
 
           - device: gpu
@@ -29,7 +29,7 @@ jobs:
             platform: linux
 
           - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           - device: gpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-32cpu' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-32cpu' || 'ubuntu-latest' }}
+            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-128cpu-dl325-0201' || 'ubuntu-latest' }}
             platform: linux
 
           - device: cpu

--- a/.github/workflows/ci-gh.yml
+++ b/.github/workflows/ci-gh.yml
@@ -17,14 +17,6 @@ jobs:
       matrix:
         include:
           - device: gpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
-            platform: linux
-
-          - device: cpu
-            build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu4' || 'ubuntu-latest' }}
-            platform: linux
-
-          - device: gpu
             build-runner: ${{ contains(github.repository, 'nv-legate/legate.core') && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
             platform: linux
 

--- a/.github/workflows/gh-build-and-test.yml
+++ b/.github/workflows/gh-build-and-test.yml
@@ -45,13 +45,13 @@ jobs:
           - name: Pytest Unit Tests
             test-scope: unit
             runner: linux-amd64-gpu-v100-latest-1
-            enabled: ${{ inputs.platform == 'linux' }}
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'gpu' }}
             ucx-config: no_ucx
 
           - name: Pytest Unit Tests
             test-scope: unit
             runner: linux-amd64-gpu-v100-latest-1
-            enabled: ${{ inputs.platform == 'linux' }}
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'gpu' }}
             ucx-config: ucx
 
           - name: Pytest Unit Tests (OS X)
@@ -63,25 +63,37 @@ jobs:
           - name: Pytest Unit Tests
             test-scope: unit
             runner: linux-amd64-2gpu
-            enabled: ${{ inputs.platform == 'linux' }}
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'gpu' }}
             ucx-config: no_ucx
 
           - name: Pytest Unit Tests
             test-scope: unit
             runner: linux-amd64-2gpu
-            enabled: ${{ inputs.platform == 'linux' }}
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'gpu' }}
+            ucx-config: ucx
+
+          - name: Pytest Unit Tests
+            test-scope: unit
+            runner: linux-amd64-cpu4
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'cpu' }}
+            ucx-config: no_ucx
+
+          - name: Pytest Unit Tests
+            test-scope: unit
+            runner: linux-amd64-cpu4
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'cpu' }}
             ucx-config: ucx
 
           - name: mypy
             test-scope: mypy
-            runner: linux-amd64-gpu-v100-latest-1
-            enabled: ${{ inputs.platform == 'linux' }}
+            runner: linux-amd64-cpu4
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'cpu' }}
             ucx-config: no_ucx
 
           - name: mypy
             test-scope: mypy
-            runner: linux-amd64-gpu-v100-latest-1
-            enabled: ${{ inputs.platform == 'linux' }}
+            runner: linux-amd64-cpu4
+            enabled: ${{ inputs.platform == 'linux' && inputs.device == 'cpu' }}
             ucx-config: ucx
 
           - name: mypy (OS X)

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,8 +35,8 @@ environment file listing all the packages that are required to build, run and
 test Legate Core and all downstream libraries. For example:
 
 ```shell
-$ ./scripts/generate-conda-envs.py --python 3.10 --ctk 12.0 --os linux --ucx
---- generating: environment-test-linux-py310-cuda-12.0-ucx.yaml
+$ ./scripts/generate-conda-envs.py --python 3.10 --ctk 12.3.1 --os linux --ucx
+--- generating: environment-test-linux-py310-cuda-12.3.1-ucx.yaml
 ```
 
 Run this script with `-h` to see all available configuration options for the

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,8 +35,8 @@ environment file listing all the packages that are required to build, run and
 test Legate Core and all downstream libraries. For example:
 
 ```shell
-$ ./scripts/generate-conda-envs.py --python 3.10 --ctk 12.3.1 --os linux --ucx
---- generating: environment-test-linux-py310-cuda-12.3.1-ucx.yaml
+$ ./scripts/generate-conda-envs.py --python 3.10 --ctk 12.2.2 --os linux --ucx
+--- generating: environment-test-linux-py310-cuda-12.2.2-ucx.yaml
 ```
 
 Run this script with `-h` to see all available configuration options for the

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -121,7 +121,7 @@ function(find_or_configure_legion)
       set(Legion_BACKTRACE_USE_LIBDW OFF)
     endif()
 
-    set(Legion_BUILD_RUST_PROFILER OFF CACHE STRING)
+    set(Legion_BUILD_RUST_PROFILER OFF CACHE BOOL "Whether to build the Legion profiler" FORCE)
 
     rapids_cpm_find(Legion ${version} ${FIND_PKG_ARGS}
         CPM_ARGS

--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -121,6 +121,8 @@ function(find_or_configure_legion)
       set(Legion_BACKTRACE_USE_LIBDW OFF)
     endif()
 
+    set(Legion_BUILD_RUST_PROFILER OFF CACHE STRING)
+
     rapids_cpm_find(Legion ${version} ${FIND_PKG_ARGS}
         CPM_ARGS
           ${legion_cpm_git_args}
@@ -132,7 +134,6 @@ function(find_or_configure_legion)
                                  "Legion_BUILD_BINDINGS ON"
                                  "Legion_REDOP_HALF ON"
                                  "Legion_REDOP_COMPLEX ON"
-                                 "Legion_BUILD_RUST_PROFILER ON"
                                  "Legion_UCX_DYNAMIC_LOAD ON"
     )
   endif()

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -39,7 +39,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version='.'.join(environ.get('CUDA', '12.0').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -39,7 +39,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2')) %}
+{% set cuda_version=environ.get('CUDA', '12.2.2') %}
 {% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -39,7 +39,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2')) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 
@@ -183,7 +183,7 @@ requirements:
     - __glibc >=2.17  # [linux]
     - python != 3.9.7
 {% if gpu_enabled_bool %}
-    - __cuda >={{ cuda_major }}
+    - __cuda >={{ cuda_version }}
 {% endif %}
 
 test:

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -160,6 +160,7 @@ requirements:
 {% endif %}
 {% if ucx_configured_bool %}
     - ucx >=1.14
+    - openmpi
 {% endif %}
 
   # Runtime python dependencies
@@ -177,6 +178,7 @@ requirements:
 {% endif %}
 {% if ucx_configured_bool %}
     - ucx >=1.14
+    - openmpi
 {% endif %}
 
   run_constrained:

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -160,6 +160,7 @@ requirements:
 {% endif %}
 {% if ucx_configured_bool %}
     - ucx >=1.14
+    - openmpi
 {% endif %}
 
   # Runtime python dependencies

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -160,7 +160,6 @@ requirements:
 {% endif %}
 {% if ucx_configured_bool %}
     - ucx >=1.14
-    - openmpi
 {% endif %}
 
   # Runtime python dependencies

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -39,7 +39,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version=environ.get('CUDA', '12.2.2') %}
+{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2')) %}
 {% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -39,7 +39,7 @@
 {% else %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', default_env_var).lstrip('v') %}
 {% endif %}
-{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '12.2.2')) %}
 {% set cuda_major=cuda_version.split('.')[0]|int %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 
@@ -183,7 +183,7 @@ requirements:
     - __glibc >=2.17  # [linux]
     - python != 3.9.7
 {% if gpu_enabled_bool %}
-    - __cuda >={{ cuda_version }}
+    - __cuda >={{ cuda_major }}
 {% endif %}
 
 test:

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -183,7 +183,7 @@ requirements:
     - __glibc >=2.17  # [linux]
     - python != 3.9.7
 {% if gpu_enabled_bool %}
-    - __cuda >={{ cuda_version }}
+    - __cuda
 {% endif %}
 
 test:

--- a/continuous_integration/scripts/build-legate
+++ b/continuous_integration/scripts/build-legate
@@ -24,7 +24,7 @@ build_legate_ci() {
 build_legate_release() {
     mkdir -p /tmp/env_yaml /tmp/conda-build
 
-    conda mambabuild --output-folder /tmp/conda-build -c nvidia -c conda-forge --no-include-recipe conda/conda-build
+    conda mambabuild --output-folder /tmp/conda-build -c nvidia/label/cuda-${CUDA_VERSION} -c conda-forge --no-include-recipe conda/conda-build
 }
 
 copy_release_artifacts() {

--- a/continuous_integration/scripts/build-legate-conda
+++ b/continuous_integration/scripts/build-legate-conda
@@ -17,7 +17,7 @@ build_legate_conda_package() {
     local conda_build_args=();
     conda_build_args+=(--override-channels);
     conda_build_args+=(-c conda-forge);
-    conda_build_args+=(-c nvidia);
+    conda_build_args+=(-c nvidia/label/cuda${CUDA_VERSION});
     conda_build_args+=(--croot /tmp/conda-croot/legate_core);
     conda_build_args+=(--numpy 1.22);
     conda_build_args+=(--python ${python_version});

--- a/continuous_integration/scripts/build-legate-conda
+++ b/continuous_integration/scripts/build-legate-conda
@@ -17,7 +17,7 @@ build_legate_conda_package() {
     local conda_build_args=();
     conda_build_args+=(--override-channels);
     conda_build_args+=(-c conda-forge);
-    conda_build_args+=(-c nvidia/label/cuda${CUDA_VERSION});
+    conda_build_args+=(-c nvidia/label/cuda-${CUDA_VERSION});
     conda_build_args+=(--croot /tmp/conda-croot/legate_core);
     conda_build_args+=(--numpy 1.22);
     conda_build_args+=(--python ${python_version});

--- a/continuous_integration/scripts/build-legate-cpp
+++ b/continuous_integration/scripts/build-legate-cpp
@@ -28,6 +28,7 @@ build_legate_cpp() {
     cmake_args+=(-DLegion_USE_HDF5=${USE_HDF5:-OFF});
     cmake_args+=(-DLegion_USE_LLVM=${USE_LLVM:-OFF});
     cmake_args+=(-DLegion_USE_OpenMP=${USE_OPENMP:-OFF});
+    cmake_args+=(-DLegion_BUILD_RUST_PROFILER=OFF)
     cmake_args+=(-Dlegate_core_BUILD_DOCS=ON);
     cmake_args+=(-DCMAKE_BUILD_PARALLEL_LEVEL=${JOBS:-$(nproc --ignore=1)});
     cmake_args+=(${@:-});

--- a/continuous_integration/scripts/build-legate-wheel
+++ b/continuous_integration/scripts/build-legate-wheel
@@ -21,7 +21,7 @@ build_legate_wheel() {
 
     local cmake_args=(${CMAKE_ARGS:-});
     cmake_args+=("-DFIND_LEGATE_CORE_CPP=ON");
-    cmake_args+=("-Dlegate_core_ROOT=$REPO_DIR/legate.core/build");
+    cmake_args+=("-Dlegate_core_ROOT=$REPO_DIR/build");
     cmake_args+=("-DLegion_USE_CUDA=${USE_CUDA:-OFF}");
     cmake_args+=("-DLegion_USE_OpenMP=${USE_OPENMP:-OFF}");
 

--- a/continuous_integration/scripts/build-legate-wheel
+++ b/continuous_integration/scripts/build-legate-wheel
@@ -21,7 +21,7 @@ build_legate_wheel() {
 
     local cmake_args=(${CMAKE_ARGS:-});
     cmake_args+=("-DFIND_LEGATE_CORE_CPP=ON");
-    cmake_args+=("-Dlegate_core_ROOT=$REPO_DIR/legate/build");
+    cmake_args+=("-Dlegate_core_ROOT=$REPO_DIR/legate.core/build");
     cmake_args+=("-DLegion_USE_CUDA=${USE_CUDA:-OFF}");
     cmake_args+=("-DLegion_USE_OpenMP=${USE_OPENMP:-OFF}");
 

--- a/continuous_integration/scripts/conda-utils
+++ b/continuous_integration/scripts/conda-utils
@@ -24,7 +24,6 @@ generate_yaml_file() {
         )"
     else
         local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}}";
-        cuda_version="$(echo "${cuda_version}" | cut -d'.' -f3 --complement)";
         yaml_file="$(\
             $REPO_DIR/scripts/generate-conda-envs.py \
                 --os "$OS_SHORT_NAME" \

--- a/continuous_integration/scripts/conda-utils
+++ b/continuous_integration/scripts/conda-utils
@@ -76,7 +76,7 @@ install_legate_core_with_war() {
     # See github issue: https://github.com/nv-legate/legate.core/issues/812
     mamba uninstall -y -n "${CONDA_ENV}" numpy;
 
-    mamba install -y -n "${CONDA_ENV}" -c nvidia -c conda-forge -c "${ARTIFACTS_DIR}/conda-build/legate_core" legate-core;
+    mamba install -y -n "${CONDA_ENV}" -c nvidia/label/cuda-${CUDA_VERSION} -c conda-forge -c "${ARTIFACTS_DIR}/conda-build/legate_core" legate-core;
 }
 
 activate_conda_env() {

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            pytest
+            REALM_BACKTRACE=1 pytest
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 legate --verbose --module pytest .
+            pytest
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 pytest
+            REALM_BACKTRACE=1 legate --module pytest .
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 legate --verbose --sysmem 2000 --module pytest .
+            REALM_BACKTRACE=1 legate --verbose --module pytest .
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 legate --module pytest .
+            REALM_BACKTRACE=1 legate --verbose -ll:networks none --module pytest .
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 legate --verbose -ll:networks none --module pytest .
+            REALM_BACKTRACE=1 legate --verbose --module pytest .
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/run-test-or-analysis
+++ b/continuous_integration/scripts/run-test-or-analysis
@@ -41,7 +41,7 @@ run_test_or_analysis() {
             [ "${UCX_ENABLED:-}" = "ON" ] && ucx_libs=ucx\ openmpi
             mamba install -y -n "${CONDA_ENV}" -c conda-forge pytest pytest-mock ipython jupyter_client $ucx_libs
             cd $REPO_DIR/tests/unit
-            REALM_BACKTRACE=1 legate --verbose --module pytest .
+            REALM_BACKTRACE=1 legate --verbose --sysmem 2000 --module pytest .
             ;;
         "mypy")
           echo "Executing mypy..."

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -155,7 +155,7 @@ set_base_defs() {
 
     export BUILD_MARCH=$(uname -m | tr '_' '-')
 
-    export CUDA_VERSION=12.3.1
+    export CUDA_VERSION=12.2.2
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -159,7 +159,7 @@ set_base_defs() {
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 
-    export PYTHON_VERSION=3.12
+    export PYTHON_VERSION=3.11
 
     export USE_OPENMP=ON
 }

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -159,7 +159,7 @@ set_base_defs() {
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 
-    export PYTHON_VERSION=3.11
+    export PYTHON_VERSION=3.10
 
     export USE_OPENMP=ON
 }

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -155,7 +155,7 @@ set_base_defs() {
 
     export BUILD_MARCH=$(uname -m | tr '_' '-')
 
-    export CUDA_VERSION=12.0
+    export CUDA_VERSION=12.3.1
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -159,7 +159,7 @@ set_base_defs() {
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 
-    export PYTHON_VERSION=3.9
+    export PYTHON_VERSION=3.11
 
     export USE_OPENMP=ON
 }

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -159,7 +159,7 @@ set_base_defs() {
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 
-    export PYTHON_VERSION=3.11
+    export PYTHON_VERSION=3.12
 
     export USE_OPENMP=ON
 }

--- a/continuous_integration/scripts/setup-utils
+++ b/continuous_integration/scripts/setup-utils
@@ -159,7 +159,7 @@ set_base_defs() {
     export CUDA_VERSION_MAJOR=12
     export CUDA_VERSION_MINOR=0
 
-    export PYTHON_VERSION=3.10
+    export PYTHON_VERSION=3.9
 
     export USE_OPENMP=ON
 }

--- a/scripts/conda-build.sh
+++ b/scripts/conda-build.sh
@@ -14,7 +14,7 @@ conda mambabuild \
     --numpy 1.22 \
     --python $PYTHON_VERSION \
     --override-channels \
-    -c conda-forge -c nvidia \
+    -c conda-forge -c nvidia/label/cuda-${CUDA_VERSION} \
     --croot /tmp/conda-build/legate_core \
     --no-test \
     --no-verify \

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -69,7 +69,6 @@ class CUDAConfig(SectionConfig):
             return ()
 
         deps = (
-            f"cuda-version={drop_patch(self.ctk_version)}",  # runtime
             # cuTensor package notes:
             # - We are pinning to 1.X major version.
             #   See https://github.com/nv-legate/cunumeric/issues/1092.

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -300,7 +300,7 @@ class EnvConfig:
 
 # --- Setup -------------------------------------------------------------------
 
-PYTHON_VERSIONS = ("3.9", "3.10", "3.11")
+PYTHON_VERSIONS = ("3.9", "3.10", "3.11", "3.12")
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
 

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -79,6 +79,7 @@ class CUDAConfig(SectionConfig):
         if V(self.ctk_version) >= V("12.0"):
             deps += (
                 "cuda-cudart-dev",
+                "cuda-cudart-static",
                 "cuda-nvml-dev",
                 "cuda-nvtx",
                 "libcublas-dev",

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -69,6 +69,7 @@ class CUDAConfig(SectionConfig):
             return ()
 
         deps = (
+            f"cuda-version={drop_patch(self.ctk_version)}",  # runtime
             # cuTensor package notes:
             # - We are pinning to 1.X major version.
             #   See https://github.com/nv-legate/cunumeric/issues/1092.

--- a/scripts/generate-conda-envs.py
+++ b/scripts/generate-conda-envs.py
@@ -300,7 +300,7 @@ class EnvConfig:
 
 # --- Setup -------------------------------------------------------------------
 
-PYTHON_VERSIONS = ("3.9", "3.10", "3.11", "3.12")
+PYTHON_VERSIONS = ("3.9", "3.10", "3.11")
 
 OS_NAMES: Tuple[OSType, ...] = ("linux", "osx")
 

--- a/tests/unit/legate/tester/stages/test_test_stage.py
+++ b/tests/unit/legate/tester/stages/test_test_stage.py
@@ -29,8 +29,6 @@ from legate.util.types import ArgList, EnvDict
 
 from . import FakeSystem
 
-s = FakeSystem()
-
 
 class MockTestStage(m.TestStage):
     kind: FeatureType = "eager"
@@ -56,17 +54,17 @@ class MockTestStage(m.TestStage):
 class TestTestStage:
     def test_name(self) -> None:
         c = Config([])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.name == "mock"
 
     def test_intro(self) -> None:
         c = Config([])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert "Entering stage: mock" in stage.intro
 
     def test_outro(self) -> None:
         c = Config([])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         stage.result = StageResult(
             [ProcessResult("invoke", Path("test/file"))],
             timedelta(seconds=2.123),
@@ -78,25 +76,25 @@ class TestTestStage:
 
     def test_file_args_default(self) -> None:
         c = Config([])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.file_args(Path("integration/foo"), c) == []
         assert stage.file_args(Path("unit/foo"), c) == []
 
     def test_file_args_v(self) -> None:
         c = Config(["test.py", "-v"])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.file_args(Path("integration/foo"), c) == ["-v"]
         assert stage.file_args(Path("unit/foo"), c) == []
 
     def test_file_args_vv(self) -> None:
         c = Config(["test.py", "-vv"])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.file_args(Path("integration/foo"), c) == ["-v", "-s"]
         assert stage.file_args(Path("unit/foo"), c) == []
 
     def test_cov_args_without_cov_bin(self) -> None:
         c = m.Config(["test.py", "--cov-args", "run -a"])
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.cov_args(c) == []
 
     def test_cov_args_with_cov_bin(self) -> None:
@@ -104,7 +102,7 @@ class TestTestStage:
         args = ["--cov-bin", cov_bin]
         c = m.Config(["test.py"] + args)
         expected_result = [cov_bin] + c.cov_args.split()
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.cov_args(c) == expected_result
 
     def test_cov_args_with_cov_bin_args_and_src_path(self) -> None:
@@ -120,5 +118,5 @@ class TestTestStage:
         expected_result = (
             [cov_bin] + cov_args.split() + ["--source", cov_src_path]
         )
-        stage = MockTestStage(c, s)
+        stage = MockTestStage(c, FakeSystem())
         assert stage.cov_args(c) == expected_result


### PR DESCRIPTION
Adding this package should resolve the build issues that have cropped up recently.

Issues that came up in the process:

- Fixed the runner that does not exist anymore
- Update cuda version to a format introduced in another PR
- Update the documentation
- Change to using labels for the nvidia channel
- Fix a test issue that was crashing the tests on OS X
- Do not use GPU runners for CPU tests
- Provide an option for not building the profiler and turn it off in the CI builds (provides a good speedup)
- Switch to using cuda 12.2.2
- Require that cuda is installed (__cuda requirement) in the meta.yaml, but do not request any specific version
- Add openmpi to requirements if we build with UCX