### PR TITLE
SLURM_TASKS_PER_NODE is not always an integer

### DIFF
--- a/legate/driver/args.py
+++ b/legate/driver/args.py
@@ -105,24 +105,6 @@ def _get_slurm_config() -> tuple[int, int] | None:
 
     nprocs_env = getenv("SLURM_NPROCS")
     ntasks_env = getenv("SLURM_NTASKS")
-    tasks_per_node_env = getenv("SLURM_TASKS_PER_NODE")
-
-    # at least one of these needs to be set
-    if (nprocs_env, ntasks_env, tasks_per_node_env) == (None, None, None):
-        return None
-
-    # use SLURM_TASKS_PER_NODE if it is given
-    if tasks_per_node_env is not None:
-        try:
-            nodes, ranks_per_node = int(nodes_env), int(tasks_per_node_env)
-        except ValueError:
-            raise ValueError(
-                "Expected SLURM_JOB_NUM_NODES and SLURM_TASKS_PER_NODE to "
-                f"be integers, got SLURM_JOB_NUM_NODES={nodes_env} and "
-                f"SLURM_TASKS_PER_NODE={tasks_per_node_env}"
-            )
-
-        return nodes, ranks_per_node
 
     # prefer newer SLURM_NTASKS over SLURM_NPROCS
     if ntasks_env is not None:
@@ -164,7 +146,6 @@ def _get_slurm_config() -> tuple[int, int] | None:
 
         return nodes, ranks // nodes
 
-    # should be unreachable
     return None
 
 

--- a/tests/unit/legate/driver/test_args.py
+++ b/tests/unit/legate/driver/test_args.py
@@ -300,20 +300,6 @@ class TestMultiNodeDefaults:
         assert "MV2_COMM_WORLD_SIZE=5" in str(e.value)
         assert "MV2_COMM_WORLD_LOCAL_SIZE=3.2" in str(e.value)
 
-    def test_with_SLURM_with_tasks_per_node(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("SLURM_TASKS_PER_NODE", "3")
-        monkeypatch.setenv("SLURM_JOB_NUM_NODES", "2")
-
-        node_kw, ranks_per_node_kw = m.detect_multi_node_defaults()
-
-        assert node_kw["default"] == 2
-        assert "SLURM" in node_kw["help"]
-
-        assert ranks_per_node_kw["default"] == 3
-        assert "SLURM" in ranks_per_node_kw["help"]
-
     def test_with_SLURM_with_ntasks(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
We're seeing it reported e.g. as "1(x2)"