### PR TITLE
Stop setting LD_LIBRARY_PATH in the launcher

### DIFF
--- a/legate/driver/driver.py
+++ b/legate/driver/driver.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..util.system import System
 from ..util.types import DataclassMixin
-from ..util.ui import kvtable, rule, section, value, warn
+from ..util.ui import kvtable, rule, section, value
 from .command import CMD_PARTS_CANONICAL, CMD_PARTS_LEGION
 from .config import ConfigProtocol
 from .launcher import Launcher, SimpleLauncher
@@ -33,15 +33,6 @@ if TYPE_CHECKING:
     from ..util.types import Command, EnvDict
 
 __all__ = ("LegateDriver", "CanonicalDriver", "format_verbose")
-
-_DARWIN_GDB_WARN = """\
-You must start the debugging session with the following command,
-as LLDB no longer forwards the environment to subprocesses for security
-reasons:
-
-(lldb) process launch -v LIB_PATH={libpath} -v PYTHONPATH={pythonpath}
-
-"""
 
 
 @dataclass(frozen=True)
@@ -106,8 +97,6 @@ class LegateDriver:
             msg = format_verbose(self.system, self)
             self.print_on_head_node(msg, flush=True)
 
-        self._darwin_gdb_warn()
-
         return self.config.other.dry_run
 
     def run(self) -> int:
@@ -150,15 +139,6 @@ class LegateDriver:
 
         if launcher.kind != "none" or launcher.detected_rank_id == "0":
             print(*args, **kw)
-
-    def _darwin_gdb_warn(self) -> None:
-        gdb = self.config.debugging.gdb
-
-        if gdb and self.system.os == "Darwin":
-            libpath = self.env[self.system.LIB_PATH]
-            pypath = self.env["PYTHONPATH"]
-            msg = _DARWIN_GDB_WARN.format(libpath=libpath, pythonpath=pypath)
-            self.print_on_head_node(warn(msg))
 
 
 class CanonicalDriver(LegateDriver):

--- a/legate/driver/launcher.py
+++ b/legate/driver/launcher.py
@@ -194,17 +194,6 @@ class Launcher:
                 / "realm_ucp_bootstrap_mpi.so"
             )
 
-        # Set some environment variables depending on our configuration that
-        # we will check in the Legate binary to ensure that it is properly.
-        # configured. Always make sure we include the Legion library
-        lpaths = [
-            str(system.legion_paths.legion_lib_path),
-            str(system.legate_paths.legate_lib_path),
-        ]
-        if system.LIB_PATH in system.env:
-            lpaths.append(system.env[system.LIB_PATH])
-        env[system.LIB_PATH] = os.pathsep.join(lpaths)
-
         if config.core.gpus > 0:
             assert "LEGATE_NEED_CUDA" not in system.env
             env["LEGATE_NEED_CUDA"] = "1"

--- a/legate/util/system.py
+++ b/legate/util/system.py
@@ -73,17 +73,6 @@ class System:
         return os
 
     @cached_property
-    def LIB_PATH(self) -> str:
-        """An ld library path environment variable name suitable for the OS
-
-        Returns
-        -------
-            str
-
-        """
-        return "LD_LIBRARY_PATH" if self.os == "Linux" else "DYLD_LIBRARY_PATH"
-
-    @cached_property
     def cpus(self) -> tuple[CPUInfo, ...]:
         """A list of CPUs on the system."""
 

--- a/tests/unit/legate/driver/test_driver.py
+++ b/tests/unit/legate/driver/test_driver.py
@@ -14,7 +14,6 @@
 #
 from __future__ import annotations
 
-import re
 from shlex import quote
 
 import pytest
@@ -34,14 +33,6 @@ from ...util import Capsys
 from .util import GenConfig
 
 SYSTEM = System()
-
-DARWIN_GDB_WARN_EXPECTED_PAT = """\
-WARNING: You must start the debugging session with the following command,
-as LLDB no longer forwards the environment to subprocesses for security
-reasons:
-
-[(]lldb[)] process launch -v LIB_PATH=(.*) -v PYTHONPATH=(.*)
-"""
 
 
 class TestDriver:
@@ -158,28 +149,6 @@ class TestDriver:
         pv_out = scrub(m.format_verbose(driver.system, driver)).strip()
 
         assert pv_out not in run_out
-
-    @pytest.mark.parametrize("launch", LAUNCHERS)
-    def test_darwin_gdb_warning(
-        self,
-        mocker: MockerFixture,
-        capsys: Capsys,
-        genconfig: GenConfig,
-        launch: str,
-    ) -> None:
-        mocker.patch("platform.system", return_value="Darwin")
-
-        system = m.System()
-
-        # set --dry-run to avoid needing to mock anything
-        config = genconfig(["--launcher", launch, "--gdb", "--dry-run"])
-        driver = m.LegateDriver(config, system)
-
-        driver.run()
-
-        out, _ = capsys.readouterr()
-
-        assert re.search(DARWIN_GDB_WARN_EXPECTED_PAT, scrub(out))
 
 
 class Test_format_verbose:

--- a/tests/unit/legate/driver/test_launcher.py
+++ b/tests/unit/legate/driver/test_launcher.py
@@ -174,49 +174,6 @@ class TestLauncherEnv:
 
         assert env["GASNET_MPI_THREAD"] == "MPI_THREAD_MULTIPLE"
 
-    def test_libpath_no_system(
-        self,
-        genconfig: GenConfig,
-        monkeypatch: pytest.MonkeyPatch,
-        launch: LauncherType,
-    ) -> None:
-        # need to create a new System after env update, we will assume
-        # that SYSTEM.LIB_PATH and later system.LIB_PATH are the same
-        monkeypatch.delenv(SYSTEM.LIB_PATH, raising=False)
-        system = System()
-        config = genconfig(["--launcher", launch])
-
-        env = m.Launcher.create(config, system).env
-
-        assert env[system.LIB_PATH] == os.pathsep.join(
-            [
-                str(system.legion_paths.legion_lib_path),
-                str(system.legate_paths.legate_lib_path),
-            ]
-        )
-
-    def test_libpath_with_system(
-        self,
-        genconfig: GenConfig,
-        monkeypatch: pytest.MonkeyPatch,
-        launch: LauncherType,
-    ) -> None:
-        # need to create a new System after env update, we will assume
-        # that SYSTEM.LIB_PATH and later system.LIB_PATH are the same
-        monkeypatch.setenv(SYSTEM.LIB_PATH, "TEST/LIB/PATH")
-        system = System()
-        config = genconfig(["--launcher", launch])
-
-        env = m.Launcher.create(config, system).env
-
-        assert env[system.LIB_PATH] == os.pathsep.join(
-            [
-                str(system.legion_paths.legion_lib_path),
-                str(system.legate_paths.legate_lib_path),
-                "TEST/LIB/PATH",
-            ]
-        )
-
     def test_need_cuda_false(
         self, genconfig: GenConfig, launch: LauncherType
     ) -> None:

--- a/tests/unit/legate/util/test_system.py
+++ b/tests/unit/legate/util/test_system.py
@@ -56,20 +56,6 @@ class TestSystem:
         with pytest.raises(RuntimeError, match=msg):
             s.os
 
-    def test_LIBPATH_Linux(self, mocker: MockerFixture) -> None:
-        mocker.patch("platform.system", return_value="Linux")
-
-        s = m.System()
-
-        assert s.LIB_PATH == "LD_LIBRARY_PATH"
-
-    def test_LIBPATH_Darwin(self, mocker: MockerFixture) -> None:
-        mocker.patch("platform.system", return_value="Darwin")
-
-        s = m.System()
-
-        assert s.LIB_PATH == "DYLD_LIBRARY_PATH"
-
     # These properties delegate to util functions, just verify plumbing
 
     def test_legate_paths(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
There is no reason anymore to mess with `LD_LIBRARY_PATH` and friends. Our binaries and libraries nowadays have `RPATH` set appropriately, and the python interpreter should be able to locate cython extensions even under editable installation by looking through `PYTHONPATH`.  Our canonical python support works by accident due to https://github.com/StanfordLegion/legion/issues/1443, which is not ideal, but the plan is to get rid of this path soon, so I'm not worried about that.