### PR TITLE
Update Base Mapper to Work with the Modified Legion Mapping Interface for Replicating Tasks

### DIFF
--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -447,11 +447,10 @@ void BaseMapper::map_task(const Legion::Mapping::MapperContext ctx,
   map_legate_stores(ctx, task, for_stores, task.target_proc, output_map);
 }
 
-void BaseMapper::map_replicate_task(const Legion::Mapping::MapperContext ctx,
-                                    const Legion::Task& task,
-                                    const MapTaskInput& input,
-                                    const MapTaskOutput& def_output,
-                                    MapReplicateTaskOutput& output)
+void BaseMapper::replicate_task(const Legion::Mapping::MapperContext ctx,
+                                const Legion::Task& task,
+                                const ReplicateTaskInput& input,
+                                ReplicateTaskOutput& output)
 {
   LEGATE_ABORT;
 }

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -78,11 +78,10 @@ class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface 
                         const Legion::Task& task,
                         const MapTaskInput& input,
                         MapTaskOutput& output) override;
-  virtual void map_replicate_task(const Legion::Mapping::MapperContext ctx,
-                                  const Legion::Task& task,
-                                  const MapTaskInput& input,
-                                  const MapTaskOutput& default_output,
-                                  MapReplicateTaskOutput& output) override;
+  virtual void replicate_task(const Legion::Mapping::MapperContext ctx,
+                              const Legion::Task& task,
+                              const ReplicateTaskInput& input,
+                              ReplicateTaskOutput& output) override;
   virtual void select_task_variant(const Legion::Mapping::MapperContext ctx,
                                    const Legion::Task& task,
                                    const SelectVariantInput& input,


### PR DESCRIPTION
This pull request updates the `BaseMapper` class so that it works with new interface for replicating tasks in Legion and removes the old replication function which no longer exists in the mapping interface. This request should only be merged after the `shardrefine` branch is merged into the `control_replication` branch of Legion or it will likely break things.