### PR TITLE
Remove unnecessary flags in Legion CMake build

### DIFF
--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -67,9 +67,6 @@ function(find_or_configure_legion)
 
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/cpm_helpers.cmake)
     get_cpm_git_args(legion_cpm_git_args REPOSITORY ${git_repo} BRANCH ${git_branch})
-    if(NOT DEFINED Legion_PYTHON_EXTRA_INSTALL_ARGS)
-      set(Legion_PYTHON_EXTRA_INSTALL_ARGS "--root / --prefix \"\${CMAKE_INSTALL_PREFIX}\"")
-    endif()
 
     # Support comma and semicolon delimited lists
     string(REPLACE "," " " Legion_PYTHON_EXTRA_INSTALL_ARGS "${Legion_PYTHON_EXTRA_INSTALL_ARGS}")

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "0cbee456b9ee80e494262f663bd4838666bdd0be"
+      "git_tag" : "d7803630bf9917e62e3674d598f194daa666785b"
     }
   }
 }

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -447,11 +447,10 @@ void BaseMapper::map_task(const Legion::Mapping::MapperContext ctx,
   map_legate_stores(ctx, task, for_stores, task.target_proc, output_map);
 }
 
-void BaseMapper::map_replicate_task(const Legion::Mapping::MapperContext ctx,
-                                    const Legion::Task& task,
-                                    const MapTaskInput& input,
-                                    const MapTaskOutput& def_output,
-                                    MapReplicateTaskOutput& output)
+void BaseMapper::replicate_task(const Legion::Mapping::MapperContext ctx,
+                                const Legion::Task& task,
+                                const ReplicateTaskInput& input,
+                                ReplicateTaskOutput& output)
 {
   LEGATE_ABORT;
 }

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -78,11 +78,10 @@ class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface 
                         const Legion::Task& task,
                         const MapTaskInput& input,
                         MapTaskOutput& output) override;
-  virtual void map_replicate_task(const Legion::Mapping::MapperContext ctx,
-                                  const Legion::Task& task,
-                                  const MapTaskInput& input,
-                                  const MapTaskOutput& default_output,
-                                  MapReplicateTaskOutput& output) override;
+  virtual void replicate_task(const Legion::Mapping::MapperContext ctx,
+                              const Legion::Task& task,
+                              const ReplicateTaskInput& input,
+                              ReplicateTaskOutput& output) override;
   virtual void select_task_variant(const Legion::Mapping::MapperContext ctx,
                                    const Legion::Task& task,
                                    const SelectVariantInput& input,


### PR DESCRIPTION
The flag `--root` here is a workaround for buggy behavior in `pip install` where pip would ignore the `--prefix` setting when `--global-option` was supplied. As it turns out, `--global-option` is deprecated anyway so we removed in Legion. As a result, this is no longer required; the prefix is already set in the upstream project and the need for `--root` goes away with the removal of `--global-option`.

See this Legion MR for details:

https://gitlab.com/StanfordLegion/legion/-/merge_requests/1072

I'm not sure which branch to send this patch to so if I'm set the wrong one, let me know and I'll update it.