### PR TITLE
Revert "Remove unnecessary flags in Legion CMake build (#932)"

### DIFF
--- a/cmake/thirdparty/get_legion.cmake
+++ b/cmake/thirdparty/get_legion.cmake
@@ -67,6 +67,9 @@ function(find_or_configure_legion)
 
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/cpm_helpers.cmake)
     get_cpm_git_args(legion_cpm_git_args REPOSITORY ${git_repo} BRANCH ${git_branch})
+    if(NOT DEFINED Legion_PYTHON_EXTRA_INSTALL_ARGS)
+      set(Legion_PYTHON_EXTRA_INSTALL_ARGS "--root / --prefix \"\${CMAKE_INSTALL_PREFIX}\"")
+    endif()
 
     # Support comma and semicolon delimited lists
     string(REPLACE "," " " Legion_PYTHON_EXTRA_INSTALL_ARGS "${Legion_PYTHON_EXTRA_INSTALL_ARGS}")

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -7,7 +7,7 @@
     },
     "Legion": {
       "git_url" : "https://gitlab.com/StanfordLegion/legion.git",
-      "git_tag" : "d7803630bf9917e62e3674d598f194daa666785b"
+      "git_tag" : "0cbee456b9ee80e494262f663bd4838666bdd0be"
     }
   }
 }

--- a/src/core/mapping/base_mapper.cc
+++ b/src/core/mapping/base_mapper.cc
@@ -447,10 +447,11 @@ void BaseMapper::map_task(const Legion::Mapping::MapperContext ctx,
   map_legate_stores(ctx, task, for_stores, task.target_proc, output_map);
 }
 
-void BaseMapper::replicate_task(const Legion::Mapping::MapperContext ctx,
-                                const Legion::Task& task,
-                                const ReplicateTaskInput& input,
-                                ReplicateTaskOutput& output)
+void BaseMapper::map_replicate_task(const Legion::Mapping::MapperContext ctx,
+                                    const Legion::Task& task,
+                                    const MapTaskInput& input,
+                                    const MapTaskOutput& def_output,
+                                    MapReplicateTaskOutput& output)
 {
   LEGATE_ABORT;
 }

--- a/src/core/mapping/base_mapper.h
+++ b/src/core/mapping/base_mapper.h
@@ -78,10 +78,11 @@ class BaseMapper : public Legion::Mapping::Mapper, public MachineQueryInterface 
                         const Legion::Task& task,
                         const MapTaskInput& input,
                         MapTaskOutput& output) override;
-  virtual void replicate_task(const Legion::Mapping::MapperContext ctx,
-                              const Legion::Task& task,
-                              const ReplicateTaskInput& input,
-                              ReplicateTaskOutput& output) override;
+  virtual void map_replicate_task(const Legion::Mapping::MapperContext ctx,
+                                  const Legion::Task& task,
+                                  const MapTaskInput& input,
+                                  const MapTaskOutput& default_output,
+                                  MapReplicateTaskOutput& output) override;
   virtual void select_task_variant(const Legion::Mapping::MapperContext ctx,
                                    const Legion::Task& task,
                                    const SelectVariantInput& input,


### PR DESCRIPTION
This reverts commit 5d74fdc115f6a4b06baa3f145d2a837c24126974.

CI had not actually fully succeeded on #932, rather the bot was waiting for us to tell it "\ok to test" again, and there is no indication that this was required on the test results.

So reverting this, and will reopen it to try and fix the errors.