### PR TITLE
Specify min conda version

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ specific cluster is not covered, you may be able to adapt an existing workflow.
 The primary method of retrieving dependencies for Legate Core and downstream
 libraries is through [conda](https://docs.conda.io/en/latest/). You will need
 an installation of conda to follow the instructions below. We suggest using
-the [mamba](https://github.com/mamba-org/mamba) implementation of the conda
+the [conda](https://github.com/conda/conda) implementation of the conda
 package manager.
 
 Please use the `scripts/generate-conda-envs.py` script to create a conda
@@ -47,13 +47,13 @@ Once you have this environment file, you can install the required packages by
 creating a new conda environment:
 
 ```shell
-mamba env create -n legate -f <env-file>.yaml
+conda env create -n legate -f <env-file>.yaml
 ```
 
 or by updating an existing environment:
 
 ```shell
-mamba env update -f <env-file>.yaml
+conda env update -f <env-file>.yaml
 ```
 
 ## Building through install.py

--- a/BUILD.md
+++ b/BUILD.md
@@ -26,9 +26,7 @@ specific cluster is not covered, you may be able to adapt an existing workflow.
 
 The primary method of retrieving dependencies for Legate Core and downstream
 libraries is through [conda](https://docs.conda.io/en/latest/). You will need
-an installation of conda to follow the instructions below. We suggest using
-the [conda](https://github.com/conda/conda) implementation of the conda
-package manager.
+an installation of conda to follow the instructions below.
 
 Please use the `scripts/generate-conda-envs.py` script to create a conda
 environment file listing all the packages that are required to build, run and

--- a/README.md
+++ b/README.md
@@ -215,8 +215,10 @@ as though they are running on a single processor.
 
 ## How Do I Install Legate?
 
-Legate Core is available [on conda](https://anaconda.org/legate/legate-core).
-Create a new environment containing Legate Core:
+Legate Core is available from [conda](https://docs.conda.io/projects/conda/en/latest/index.html)
+on the [legate-core channel](https://anaconda.org/legate/legate-core).
+Please make sure you have at least conda version 24.1 installed, then create
+a new environment containing Legate Core:
 
 ```
 mamba create -n myenv -c nvidia -c conda-forge -c legate legate-core

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ as though they are running on a single processor.
 ## How Do I Install Legate?
 
 Legate Core is available from [conda](https://docs.conda.io/projects/conda/en/latest/index.html)
-on the [legate-core channel](https://anaconda.org/legate/legate-core).
+on the [legate channel](https://anaconda.org/legate/legate-core).
 Please make sure you have at least conda version 24.1 installed, then create
 a new environment containing Legate Core:
 

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Please make sure you have at least conda version 24.1 installed, then create
 a new environment containing Legate Core:
 
 ```
-mamba create -n myenv -c nvidia -c conda-forge -c legate legate-core
+conda create -n myenv -c nvidia -c conda-forge -c legate legate-core
 ```
 
 or install it into an existing environment:
 
 ```
-mamba install -c nvidia -c conda-forge -c legate legate-core
+conda install -c nvidia -c conda-forge -c legate legate-core
 ```
 
 Only linux-64 packages are available at the moment.
@@ -239,7 +239,7 @@ installing on a machine without GPUs. You can force installation of a CPU-only
 package by requesting it as follows:
 
 ```
-mamba ... legate-core=*=*_cpu
+conda ... legate-core=*=*_cpu
 ```
 
 See [BUILD.md](BUILD.md) for instructions on building Legate Core from source.


### PR DESCRIPTION
This PR adds a link to the conda docs and also specifies a min conda version to use to ensure that the latest legate versions are properly picked up. 