### PR TITLE
Remove incorrect argument to mamba

### DIFF
--- a/continuous_integration/scripts/conda-utils
+++ b/continuous_integration/scripts/conda-utils
@@ -1,5 +1,5 @@
 make_conda_env_from_yaml() {
-    mamba env create -n "${CONDA_ENV}" -f "${yaml_file}" --force;
+    mamba env create -n "${CONDA_ENV}" -f "${yaml_file}";
 }
 
 generate_yaml_file() {


### PR DESCRIPTION
The `--force` argument was deemed necessary in the past (for reasons currently unknown), but it is incorrect and causes mamba crashes.