### PR TITLE
Simple addition enabling the passing of scalar arguments to Reduce

### DIFF
--- a/legate/core/context.py
+++ b/legate/core/context.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 import numpy as np
 
+import legate.core.types as ty
+
 from . import Future, legion
 from ._legion.util import Logger
 from ._lib.context import (  # type: ignore[import-not-found]
@@ -370,7 +372,13 @@ class Context:
         """
         self._runtime.issue_execution_fence(block=block)
 
-    def tree_reduce(self, task_id: int, store: Store, radix: int = 4) -> Store:
+    def tree_reduce(
+        self,
+        task_id: int,
+        store: Store,
+        radix: int = 4,
+        scalar_args: list[tuple[Any, ty.Dtype]] = [],
+    ) -> Store:
         """
         Performs a user-defined reduction by building a tree of reduction
         tasks. At each step, the reducer task gets up to ``radix`` input stores
@@ -399,4 +407,6 @@ class Context:
         Store
             Store that contains reduction results
         """
-        return self._runtime.tree_reduce(self, task_id, store, radix)
+        return self._runtime.tree_reduce(
+            self, task_id, store, radix, scalar_args
+        )

--- a/legate/core/operation.py
+++ b/legate/core/operation.py
@@ -1494,6 +1494,7 @@ class Reduce(AutoOperation):
         )
         self._radix = radix
         self._task_id = task_id
+        self._scalar_args: list[tuple[Any, ty.Dtype]] = []
 
     def add_input(self, store: Store) -> None:
         self._check_store(store)
@@ -1507,6 +1508,9 @@ class Reduce(AutoOperation):
         self._unbound_outputs.append(len(self._outputs))
         self._outputs.append(store)
         self._output_parts.append(partition)
+
+    def add_scalar_arg(self, value: Any, dtype: ty.Dtype) -> None:
+        self._scalar_args.append((value, dtype))
 
     def launch(self, strategy: Strategy) -> None:
         assert len(self._inputs) == 1 and len(self._outputs) == 1
@@ -1536,6 +1540,9 @@ class Reduce(AutoOperation):
                 tag=tag,
                 provenance=self.provenance,
             )
+
+            for scalar, dtype in self._scalar_args:
+                launcher.add_scalar_arg(scalar, dtype)
 
             if num_tasks > 1:
                 for proj_fn in proj_fns:

--- a/legate/core/runtime.py
+++ b/legate/core/runtime.py
@@ -1731,7 +1731,12 @@ class Runtime:
         fill.execute()
 
     def tree_reduce(
-        self, context: Context, task_id: int, store: Store, radix: int = 4
+        self,
+        context: Context,
+        task_id: int,
+        store: Store,
+        radix: int = 4,
+        scalar_args: list[tuple[Any, ty.Dtype]] = [],
     ) -> Store:
         """
         Performs a user-defined reduction by building a tree of reduction
@@ -1780,6 +1785,8 @@ class Runtime:
         )
         task.add_input(store)
         task.add_output(result)
+        for scalar_arg in scalar_args:
+            task.add_scalar_arg(scalar_arg[0], scalar_arg[1])
         task.execute()
         return result
 


### PR DESCRIPTION
Ad hoc change for cunumeric np.unique(return_index=True) functionality. I made this separate from the more comprehensive  equivalent function in Task, but it might be worthwhile to move these functions up into some higher level shared ancestor. @magnatelee @rohany 

Signed-off-by: Joseph Guman <joeytg@stanford.edu>